### PR TITLE
Fix initialization bugs

### DIFF
--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/Azure.Monitor.OpenTelemetry.Profiler.Core.nuspec
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/Azure.Monitor.OpenTelemetry.Profiler.Core.nuspec
@@ -50,6 +50,8 @@
     <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Contract.Agent.pdb" target="lib/$targetFramework$"></file>
     <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Contract.Agent.Profiler.dll" target="lib/$targetFramework$"></file>
     <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Contract.Agent.Profiler.pdb" target="lib/$targetFramework$"></file>
+    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.HttpPipeline.dll" target="lib/$targetFramework$"></file>
+    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.HttpPipeline.pdb" target="lib/$targetFramework$"></file>
     <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Logging.dll" target="lib/$targetFramework$"></file>
     <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Logging.pdb" target="lib/$targetFramework$"></file>
     <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Orchestration.dll" target="lib/$targetFramework$"></file>

--- a/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerFrontendClientFactory.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerFrontendClientFactory.cs
@@ -53,7 +53,6 @@ internal class ProfilerFrontendClientFactory
             "1.0.0",
             FormattableString.Invariant($"ServiceProfilerEventPipeAgent/{EnvironmentUtilities.ExecutingAssemblyInformationalVersion}"),
             credential,
-            _userConfiguration.SkipEndpointCertificateValidation,
-            false);
+            _userConfiguration.SkipEndpointCertificateValidation);
     }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerFrontendClientFactory.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerFrontendClientFactory.cs
@@ -46,13 +46,12 @@ internal class ProfilerFrontendClientFactory
         TokenCredential? credential = authTokenProvider.IsAADAuthenticateEnabled ?
             ActivatorUtilities.CreateInstance<AADAuthTokenCredential>(_serviceProvider) :
             null;
-        
-        _logger.LogDebug("Is Credential null? {result}.", credential is null);
-        // TokenCredential? credential = ActivatorUtilities.CreateInstance<AADAuthTokenCredential>(_serviceProvider);
 
-        return ActivatorUtilities.CreateInstance<ProfilerFrontendClient>(
-            _serviceProvider,
-            _serviceProfilerContext.StampFrontendEndpointUrl,
+        // ActivatorUtilities is not used for creating ProfilerFrontendClient due to its limitation in handling nuk=llable parameters.
+        // For example, when credential is null, it will throw InvalidOperationException:
+        // A suitable constructor for type 'Microsoft.ServiceProfiler.Agent.FrontendClient.ProfilerFrontendClient' could not be located.
+        // Because CreateProfilerFrontendClient method is only called in ServiceCollectionExtensions, it will be disposed by the service provider.
+        return new ProfilerFrontendClient(_serviceProfilerContext.StampFrontendEndpointUrl,
             _serviceProfilerContext.AppInsightsInstrumentationKey,
             _serviceProfilerContext.MachineName,
             "1.0.0",

--- a/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerFrontendClientFactory.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerFrontendClientFactory.cs
@@ -43,7 +43,7 @@ internal class ProfilerFrontendClientFactory
             ActivatorUtilities.CreateInstance<AADAuthTokenCredential>(_serviceProvider) :
             null;
 
-        // ActivatorUtilities is not used for creating ProfilerFrontendClient due to its limitation in handling nuk=llable parameters.
+        // ActivatorUtilities is not used for creating ProfilerFrontendClient due to its limitation in handling nullable parameters.
         // For example, when credential is null, it will throw InvalidOperationException:
         // A suitable constructor for type 'Microsoft.ServiceProfiler.Agent.FrontendClient.ProfilerFrontendClient' could not be located.
         // Because CreateProfilerFrontendClient method is only called in ServiceCollectionExtensions, it will be disposed by the service provider.

--- a/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerFrontendClientFactory.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerFrontendClientFactory.cs
@@ -8,7 +8,6 @@ using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions.Auth;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Auth;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.ServiceProfiler.Agent.FrontendClient;
 using Microsoft.ServiceProfiler.Utilities;
@@ -24,16 +23,13 @@ internal class ProfilerFrontendClientFactory
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly IServiceProfilerContext _serviceProfilerContext;
-    private readonly ILogger _logger;
     private readonly UserConfigurationBase _userConfiguration;
 
     public ProfilerFrontendClientFactory(
         IServiceProvider serviceProvider,
         IServiceProfilerContext serviceProfilerContext,
-        IOptions<UserConfigurationBase> userConfiguration,
-        ILogger<ProfilerFrontendClientFactory> logger)
+        IOptions<UserConfigurationBase> userConfiguration)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         _serviceProfilerContext = serviceProfilerContext ?? throw new ArgumentNullException(nameof(serviceProfilerContext));
         _userConfiguration = userConfiguration?.Value ?? throw new ArgumentNullException(nameof(userConfiguration));


### PR DESCRIPTION
Fix bug in `ProfilerFrontendClientFactory` -- when credential is null, ActivatorUtilities would throw an error
Added missing assembly reference