### PR TITLE
Return default access token when aad auth is not enabled

### DIFF
--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/AuthTokenProvider.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/AuthTokenProvider.cs
@@ -29,12 +29,12 @@ internal class AuthTokenProvider(
 
     public async Task<AccessToken> GetTokenAsync(CancellationToken cancellationToken)
     {
-        TokenCredential? tokenCredential = _serviceProfilerOptions.Credential;
-        if (tokenCredential is null)
+        if(!IsAADAuthenticateEnabled)
         {
-            throw new InvalidOperationException($"Credential is not provided. How does it pass the check of {nameof(IsAADAuthenticateEnabled)}?");
+            return default;
         }
 
+        TokenCredential? tokenCredential = _serviceProfilerOptions.Credential ?? throw new InvalidOperationException($"Credential is not provided. How does it pass the check of {nameof(IsAADAuthenticateEnabled)}?");
         string scope = GetScope();
 
         TokenRequestContext tokenRequestContext = new(scopes: [scope]);


### PR DESCRIPTION
There is a small bug when the TokenCredential was not set that the code would still try to create access token, causing unhandled exception. This will fix the error.

