### PR TITLE
Enforce the connection string

### DIFF
--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/OpenTelemetryBuilderExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/OpenTelemetryBuilderExtensions.cs
@@ -30,19 +30,25 @@ public static class OpenTelemetryBuilderExtensions
 
             AzureMonitorOptions? monitorOptions = azureMonitorOptions.Value;
 
+            // Inherit connection string from the Azure Monitor Options unless
+            // the value is already there.
             string? azureMonitorConnectionString = monitorOptions.ConnectionString;
-            if (string.IsNullOrEmpty(opt.ConnectionString))
+            if (string.IsNullOrWhiteSpace(opt.ConnectionString))
             {
                 opt.ConnectionString = azureMonitorConnectionString;
             }
 
-            if (opt.Credential is null)
-            {
-                opt.Credential = monitorOptions.Credential;
-                // Notice: the credential could still be null because monitorOptions is nullable, and its Credential object could be null.
-            }
-
+            // Inherit the credential object from the Azure Monitor Options unless
+            // the value is already there.
+            opt.Credential ??= monitorOptions.Credential;
             configureServiceProfiler?.Invoke(opt);
+
+            // Fast fail when the connection string is not set.
+            // This should never happen, or the profiler is not going to work.
+            if(string.IsNullOrEmpty(opt.ConnectionString))
+            {
+                throw new InvalidOperationException("Connection string is fetched. Please follow the instructions to setup connection string properly.");
+            }
         });
 
         builder.Services.AddSingleton<IOptions<UserConfigurationBase>>(p =>

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/OpenTelemetryBuilderExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/OpenTelemetryBuilderExtensions.cs
@@ -47,7 +47,7 @@ public static class OpenTelemetryBuilderExtensions
             // This should never happen, or the profiler is not going to work.
             if(string.IsNullOrEmpty(opt.ConnectionString))
             {
-                throw new InvalidOperationException("Connection string is fetched. Please follow the instructions to setup connection string properly.");
+                throw new InvalidOperationException("Connection string can't be fetched. Please follow the instructions to setup connection string properly.");
             }
         });
 

--- a/src/ServiceProfiler.EventPipe.Otel/Directory.Packages.props
+++ b/src/ServiceProfiler.EventPipe.Otel/Directory.Packages.props
@@ -7,7 +7,7 @@
     <!-- These versions is specific for EventPipe OTel Agent, and will be shared between the build project
      and the nuget spec as tokens through the property of `NuspecProperties`. -->
     <AzureCoreVersion>1.44.1</AzureCoreVersion>
-    <AzureMonitorOpenTelemetryAspNetCoreVersion>1.2.0</AzureMonitorOpenTelemetryAspNetCoreVersion>
+    <AzureMonitorOpenTelemetryAspNetCoreVersion>1.3.0-beta.2</AzureMonitorOpenTelemetryAspNetCoreVersion>
     <CommandLineParserVersion>2.9.1</CommandLineParserVersion>
     <MicrosoftDiagnosticsNETCoreClientVersion>0.2.532401</MicrosoftDiagnosticsNETCoreClientVersion>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>9.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>

--- a/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services/ConnectionStringParserFactory.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services/ConnectionStringParserFactory.cs
@@ -10,6 +10,11 @@ internal class ConnectionStringParserFactory(IServiceProvider serviceProvider) :
 
     public IConnectionStringParser Create(string connectionString)
     {
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            throw new InvalidOperationException("Can't create a connection string parser without a connection string. Please make sure the connection string is properly set.");
+        }
+
         return ActivatorUtilities.CreateInstance<ConnectionStringParser>(provider: _serviceProvider, connectionString);
     }
 }


### PR DESCRIPTION
* Bump up the version of dependency of Azure Monitor OpenTelemetry distro to `1.3.0-beta2` to overcome an issue that connection string set by env variable is not pass on to the Profiler - see #13.
* Add logic to enforce the existence of connection string for fail faster.
