### PR TITLE
Push down dependency to `Azure.Monitor.OpenTelemetry,Exporter` from `Azure.Monitor.OpenTelemetry.AspNetCore`

### DIFF
--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore.csproj
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
   </ItemGroup>

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore.nuspec
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore.nuspec
@@ -17,10 +17,11 @@
 
     <dependencies>
       <group targetFramework="$targetFramework$">
-        <!-- Auzre Monitor Open Telemetry SDK for application insights -->
-        <dependency id="Azure.Monitor.OpenTelemetry.Profiler.Core" version="$version$" exclude="Build,Analyzers" />
+        <!-- Azure Monitor Open Telemetry SDK for application insights -->
+        <dependency id="Azure.Monitor.OpenTelemetry.Exporter" version="$AzureMonitorOpenTelemetryExporterVersion$" exclude="Build,Analyzers" />
+        
         <!-- Core package for profiler -->
-        <dependency id="Azure.Monitor.OpenTelemetry.AspNetCore" version="$AzureMonitorOpenTelemetryAspNetCoreVersion$" exclude="Build,Analyzers" />
+        <dependency id="Azure.Monitor.OpenTelemetry.Profiler.Core" version="$version$" exclude="Build,Analyzers" />
 
         <!-- Other packages -->
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="$MicrosoftExtensionsConfigurationAbstractionsVersion$" exclude="Build,Analyzers" />

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/DisabledAgentBootstrap.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/DisabledAgentBootstrap.cs
@@ -4,7 +4,7 @@
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
 using Microsoft.Extensions.Logging;
 
-namespace Azure.Monitor.OpenTelemetry.AspNetCore;
+namespace Azure.Monitor.OpenTelemetry.Profiler.AspNetCore;
 
 internal class DisabledAgentBootstrap(ILogger<DisabledAgentBootstrap> logger) : IServiceProfilerAgentBootstrap
 {

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/OpenTelemetryBuilderExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/OpenTelemetryBuilderExtensions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Azure.Monitor.OpenTelemetry.AspNetCore;
+using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Monitor.OpenTelemetry.Profiler.Core;
 using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
@@ -24,11 +24,11 @@ public static class OpenTelemetryBuilderExtensions
         builder.Services.AddLogging();
         builder.Services.AddOptions();
 
-        builder.Services.AddOptions<ServiceProfilerOptions>().Configure<IConfiguration, IOptions<AzureMonitorOptions>>((opt, configuration, azureMonitorOptions) =>
+        builder.Services.AddOptions<ServiceProfilerOptions>().Configure<IConfiguration, IOptions<AzureMonitorExporterOptions>>((opt, configuration, azureMonitorOptions) =>
         {
             configuration.GetSection("ServiceProfiler").Bind(opt);
 
-            AzureMonitorOptions? monitorOptions = azureMonitorOptions.Value;
+            AzureMonitorExporterOptions? monitorOptions = azureMonitorOptions.Value;
 
             // Inherit connection string from the Azure Monitor Options unless
             // the value is already there.

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/OpenTelemetryBuilderExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.AspNetCore/OpenTelemetryBuilderExtensions.cs
@@ -59,6 +59,12 @@ public static class OpenTelemetryBuilderExtensions
             opt.Credential ??= monitorOptions.Credential;
             configureServiceProfiler?.Invoke(opt);
 
+            // Last effort to capture the connection string when all above failed
+            if (string.IsNullOrEmpty(opt.ConnectionString))
+            {
+                opt.ConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+            }
+
             // Fast fail when the connection string is not set.
             // This should never happen, or the profiler is not going to work.
             if (string.IsNullOrEmpty(opt.ConnectionString))

--- a/src/ServiceProfiler.EventPipe.Otel/Directory.Packages.props
+++ b/src/ServiceProfiler.EventPipe.Otel/Directory.Packages.props
@@ -7,7 +7,7 @@
     <!-- These versions is specific for EventPipe OTel Agent, and will be shared between the build project
      and the nuget spec as tokens through the property of `NuspecProperties`. -->
     <AzureCoreVersion>1.44.1</AzureCoreVersion>
-    <AzureMonitorOpenTelemetryAspNetCoreVersion>1.3.0-beta.2</AzureMonitorOpenTelemetryAspNetCoreVersion>
+    <AzureMonitorOpenTelemetryExporterVersion>1.4.0-beta.2</AzureMonitorOpenTelemetryExporterVersion>
     <CommandLineParserVersion>2.9.1</CommandLineParserVersion>
     <MicrosoftDiagnosticsNETCoreClientVersion>0.2.532401</MicrosoftDiagnosticsNETCoreClientVersion>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>9.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
@@ -20,10 +20,9 @@
     <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <NuspecProperties>
-  <![CDATA[
+    <NuspecProperties><![CDATA[
 AzureCoreVersion=$(AzureCoreVersion);
-AzureMonitorOpenTelemetryAspNetCoreVersion=$(AzureMonitorOpenTelemetryAspNetCoreVersion);
+AzureMonitorOpenTelemetryExporterVersion=$(AzureMonitorOpenTelemetryExporterVersion);
 CommandlineParserVersion=$(CommandLineParserVersion);
 MicrosoftDiagnosticsNETCoreClientVersion=$(MicrosoftDiagnosticsNETCoreClientVersion);
 MicrosoftExtensionsConfigurationAbstractionsVersion=$(MicrosoftExtensionsConfigurationAbstractionsVersion); 
@@ -38,7 +37,7 @@ $(NuspecProperties)]]></NuspecProperties>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Core" Version="$(AzureCoreVersion)" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="$(AzureMonitorOpenTelemetryAspNetCoreVersion)" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="$(AzureMonitorOpenTelemetryExporterVersion)" />
     <PackageVersion Include="CommandLineParser" Version="$(CommandLineParserVersion)" />
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="$(MicrosoftDiagnosticsNETCoreClientVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsVersion)" />


### PR DESCRIPTION
This reduces the size of the dependency graph. There are several benefits:
1. The user will depend on less packages and more flexible to pick which package to carry.
2. It is easier to integrate with `Azure.Monitor.OpenTelemetry.AspNetCore`.
  1. When that need to happen, there's no circular dependency.

I also provided 1 more extension method for the user to light up Profiler with the `TracerProviderBuilder`.