### PR TITLE
Telemetry adapter should only listen to `Microsoft.AspNetCore.Hosting.HttpRequestIn`

### DIFF
--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -175,12 +175,14 @@ internal class TraceSessionListener : EventListener
             if (isDebugLoggingEnabled)
             {
                 _logger.LogDebug("Drop uninterested request by name: {requestName}", requestName);
-                return;
             }
+
+            // Do not relay this event since it is not interested.
+            return;
         }
 
         // Interested request
-        _startedActivityIds.Add(id);
+        _startedActivityIds.Add(id);    // Note to the _startedActivityIds bag, so that when stop happens, it knows to match.
         AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStart(
             name: requestName,
             id: id,
@@ -198,11 +200,12 @@ internal class TraceSessionListener : EventListener
 
         if (!_startedActivityIds.TryTake(out _))
         {
-            // No interesting start activity captured.
             if (isDebugLoggingEnabled)
             {
                 _logger.LogDebug("No start activity found for this stop activity. Request name: {requestName}, id: {id}", requestName, id);
             }
+
+            // No interesting start activity captured, it then doesn't make sense to just capture the stop.
             return;
         }
 

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -175,6 +175,7 @@ internal class TraceSessionListener : EventListener
             if (isDebugLoggingEnabled)
             {
                 _logger.LogDebug("Drop uninterested request by name: {requestName}", requestName);
+                return;
             }
         }
 
@@ -202,6 +203,7 @@ internal class TraceSessionListener : EventListener
             {
                 _logger.LogDebug("No start activity found for this stop activity. Request name: {requestName}, id: {id}", requestName, id);
             }
+            return;
         }
 
         if (isDebugLoggingEnabled)

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -174,7 +174,7 @@ internal class TraceSessionListener : EventListener
         {
             if (isDebugLoggingEnabled)
             {
-                _logger.LogDebug("Drop uninterested request by name: {requestName}", requestName);
+                _logger.LogDebug("Drop uninterested request by name: {requestName}, id: {id}", requestName, id);
             }
 
             // Do not relay this event since it is not interested.

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -182,11 +182,18 @@ internal class TraceSessionListener : EventListener
         }
 
         // Interested request
+
+        if (isDebugLoggingEnabled)
+        {
+            _logger.LogDebug("Interested start activity, name: {name}, id: {id}", requestName, id);
+        }
+
         // Note to the _startedActivityIds bag, so that when stop happens, it knows to match.
         if (!_startedActivityIds.TryAdd(id, id))
         {
-            _logger.LogWarning("Activity by id {id} already exists. Please report a bug", id);
+            _logger.LogWarning("Failed to add started activity. Activity by id {id} already exists? Please report a bug.", id);
         }
+
         AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStart(
             name: requestName,
             id: id,

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -174,18 +174,18 @@ internal class TraceSessionListener : EventListener
         {
             if (isDebugLoggingEnabled)
             {
-                _logger.LogDebug("Drop uninterested request by name: {requestName}, id: {id}", requestName, id);
+                _logger.LogDebug("Drop uninteresting request by name: {requestName}, id: {id}", requestName, id);
             }
 
-            // Do not relay this event since it is not interested.
+            // Do not relay this event since it is not interesting.
             return;
         }
 
-        // Interested request
+        // Interesting request
 
         if (isDebugLoggingEnabled)
         {
-            _logger.LogDebug("Interested start activity, name: {name}, id: {id}", requestName, id);
+            _logger.LogDebug("Interesting start activity, name: {name}, id: {id}", requestName, id);
         }
 
         // Note to the _startedActivityIds bag, so that when stop happens, it knows to match.
@@ -222,9 +222,9 @@ internal class TraceSessionListener : EventListener
 
         if (isDebugLoggingEnabled)
         {
-            _logger.LogDebug("Interested activity found. Name: {name}, id: {id}", requestName, id);
+            _logger.LogDebug("Interesting activity found. Name: {name}, id: {id}", requestName, id);
         }
-        // Interested start activity was captured, relay this stop activity.
+        // Interesting start activity was captured, relay this stop activity.
         AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStop(
             name: requestName, id: id, requestId: requestId, operationId: operationId);
 

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -27,7 +27,7 @@ internal class TraceSessionListener : EventListener
 
     public SampleActivityContainer? SampleActivities => _sampleCollector?.SampleActivities;
 
-    private readonly ConcurrentDictionary<string, string> _startedActivityIds = new();
+    private readonly ConcurrentDictionary<string, byte> _startedActivityIds = new();
 
     public TraceSessionListener(
         ISerializationProvider serializer,
@@ -189,7 +189,7 @@ internal class TraceSessionListener : EventListener
         }
 
         // Note to the _startedActivityIds bag, so that when stop happens, it knows to match.
-        if (!_startedActivityIds.TryAdd(id, id))
+        if (!_startedActivityIds.TryAdd(id, default))
         {
             _logger.LogWarning("Failed to add started activity. Activity by id {id} already exists? Please report a bug.", id);
         }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -154,7 +154,7 @@ internal class TraceSessionListener : EventListener
         }
     }
 
-    private bool IsInterestedRequest(string requestName)
+    private bool IsInterestingRequest(string requestName)
     {
         // We only are interested capturing Http In requests.
         // Http request out, for example, from HttpClient will be excluded.
@@ -170,7 +170,7 @@ internal class TraceSessionListener : EventListener
             _logger.LogDebug("Request started: Activity Id: {activityId}", currentActivityId);
         }
 
-        if (!IsInterestedRequest(requestName))
+        if (!IsInterestingRequest(requestName))
         {
             if (isDebugLoggingEnabled)
             {

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -204,6 +204,10 @@ internal class TraceSessionListener : EventListener
             }
         }
 
+        if (isDebugLoggingEnabled)
+        {
+            _logger.LogDebug("Interested activity found. Name: {name}, id: {id}", requestName, id);
+        }
         // Interested start activity was captured, relay this stop activity.
         AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStop(
             name: requestName, id: id, requestId: requestId, operationId: operationId);


### PR DESCRIPTION
The adapter is passing along too many events while the only interested one at this moment is `Microsoft.AspNetCore.Hosting.HttpRequestIn`.

The problem was that when the user initiated an activity, for example, using httpclient, like described in #58, it leads to unexpected events being relayed to the event source adapter.

I would guess the same issue also exists for other code that triggers an activity as well, like for a sql command execution.