### PR TITLE
Simplify the nuspec authoring

### DIFF
--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/Azure.Monitor.OpenTelemetry.Profiler.nuspec
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/Azure.Monitor.OpenTelemetry.Profiler.nuspec
@@ -39,34 +39,9 @@
     </contentFiles>
   </metadata>
   <files>
-    <file src="bin\$configuration$\$targetFramework$\Azure.Monitor.OpenTelemetry.Profiler.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Azure.Monitor.OpenTelemetry.Profiler.pdb" target="lib/$targetFramework$"></file>
-
-    <!-- Project to project references -->
-    <file src="bin\$configuration$\$targetFramework$\Azure.Monitor.OpenTelemetry.Profiler.Core.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Azure.Monitor.OpenTelemetry.Profiler.Core.pdb" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ApplicationInsights.Profiler.Shared.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ApplicationInsights.Profiler.Shared.pdb" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Agent.Exceptions.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Agent.Exceptions.pdb" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Agent.FrontendClient.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Agent.FrontendClient.pdb" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Agent.FrontendClient.Profiler.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Agent.FrontendClient.Profiler.pdb" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Common.Utilities.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Common.Utilities.pdb" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Contract.Agent.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Contract.Agent.pdb" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Contract.Agent.Profiler.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Contract.Agent.Profiler.pdb" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.HttpPipeline.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.HttpPipeline.pdb" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Orchestration.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Orchestration.pdb" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.ProcessMonitor.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.ProcessMonitor.pdb" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Utilities.dll" target="lib/$targetFramework$"></file>
-    <file src="bin\$configuration$\$targetFramework$\Microsoft.ServiceProfiler.Utilities.pdb" target="lib/$targetFramework$"></file>
+    <!-- All files and symbols -->
+    <file src="bin\$configuration$\$targetFramework$\*.dll" target="lib/$targetFramework$"></file>
+    <file src="bin\$configuration$\$targetFramework$\*.pdb" target="lib/$targetFramework$"></file>
 
     <!-- Uploader -->
     <file src="obj\$configuration$\Uploader\Uploader.zip" target="contentFiles\any\net6.0\ServiceProfiler\TraceUpload.zip"></file>


### PR DESCRIPTION
Using wildcard to gather all assemblies and the symbols. Linking to #67 