### PR TITLE
Dev/saars/bug unhandled uploader exception

### DIFF
--- a/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Orchestrations/OrchestratorEventPipe.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Orchestrations/OrchestratorEventPipe.cs
@@ -169,6 +169,17 @@ internal abstract class OrchestratorEventPipe : Orchestrator
                             result = false;
                         }
                     }
+                    catch
+                    {
+                        // Stop profiling can fail for various reasons. Check the current status to decide 
+                        // wether to give back the current profiling handler.
+                        if (_currentProfilingPolicy == policy && !_profilerProvider.IsProfilerRunning)
+                        {
+                            _currentProfilingPolicy = null;
+                        }
+                        
+                        throw;
+                    }
                     finally
                     {
                         _policyChangeHandler.Release();

--- a/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Orchestrations/Scheduling/OneTimeSchedulingPolicy.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Orchestrations/Scheduling/OneTimeSchedulingPolicy.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.ServiceProfiler.Orchestration;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.ApplicationInsights.Profiler.Shared.Orchestrations;
@@ -37,11 +36,13 @@ internal class OneTimeSchedulingPolicy : EventPipeSchedulingPolicy
     public override string Source { get; } = nameof(OneTimeSchedulingPolicy);
     public override Task<IEnumerable<(TimeSpan duration, ProfilerAction action)>> GetScheduleAsync()
     {
-        return Task.FromResult(new List<(TimeSpan, ProfilerAction)>()
-            {
-                (ProfilingDuration, ProfilerAction.StartProfilingSession),
-                (ProfilingDuration, ProfilerAction.Standby), // The duration will be overwritten by the expiration policy.
-            }.AsEnumerable());
+        return Task.FromResult(CreateSchedule(ProfilingDuration));
+    }
+
+    private IEnumerable<(TimeSpan duration, ProfilerAction action)> CreateSchedule(TimeSpan profilingDuration)
+    {
+        yield return (profilingDuration, ProfilerAction.StartProfilingSession);
+        yield return (profilingDuration, ProfilerAction.Standby);
     }
 
     protected override bool PolicyNeedsRefresh() => false;

--- a/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IServiceProfilerProvider.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IServiceProfilerProvider.cs
@@ -6,7 +6,23 @@ namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
 
 internal interface IServiceProfilerProvider
 {
+    /// <summary>
+    /// Starts the service profiler for the given source.
+    /// </summary>
+    /// <returns>Returns true when the profiler started succeeded. Otherwise, false.</returns>
     Task<bool> StartServiceProfilerAsync(IProfilerSource source, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Stops the service profiler for the given source.
+    /// </summary>
+    /// <returns>Returns true when the profiler is stopped. Otherwise, false.</returns>
+    /// <remarks>
+    /// The return value indicates whether the profiler was successfully stopped.
+    /// <remarks>
     Task<bool> StopServiceProfilerAsync(IProfilerSource source, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets if the profiler is currently running.
+    /// </summary>
+    public bool IsProfilerRunning { get; }
 }


### PR DESCRIPTION
Address #88.

The problem was:
1. Stop profiling throws exception, but the _currentProfilingScheduler was not cleared (the session stopped already)
2. Next time, when start profiling being filed again, we would check if there's already a scheduler doing the profiler and it would think the last scheduler was still in effective and skip the start.
3. And no start, no stop; the status never got cleared and get into the dead loop.

The fix:
1. Expose the semaphore that represents the current profiling session in the ProfilerProvider;
2. Upon handling the exception, if the semaphore had been released already, clear the current scheduler from the orchestrator.

Piggyback:
1. Bump up refers to the ServcieProfiler project.
2. Clean up some code implementations.