### PR TITLE
Add `IServiceCollection.AddAzureMonitorProfiler()` for App Insights 3.x support

### DIFF
--- a/.github/skills/build-private-package/SKILL.md
+++ b/.github/skills/build-private-package/SKILL.md
@@ -4,44 +4,68 @@ description: >
   Build a private NuGet package for the Application Insights Profiler ASP.NET Core SDK.
   Use this skill when asked to build, pack, or create a private or test NuGet package
   for the profiler. Handles restore, build, uploader packing, and NuGet packaging.
-compatibility: Windows. Requires .NET SDK and cmd.exe.
+compatibility: Windows. Requires .NET SDK, cmd.exe, and PowerShell 7+ (for OTel).
 ---
 
 # Build Private Application Insights Profiler NuGet Package
 
 ## Overview
 
-This skill builds private NuGet packages for the Application Insights Profiler SDK
-using the packaging script at `src/ServiceProfiler.EventPipe/tools/PackNugetPackage.cmd`.
+This skill builds private NuGet packages for the Application Insights Profiler SDK.
+Two package flavors are available:
 
-Two packages are produced:
-- `Microsoft.ApplicationInsights.Profiler.Core` (core library)
-- `Microsoft.ApplicationInsights.Profiler.AspNetCore` (ASP.NET Core integration)
+| Flavor | Package(s) | Script |
+|--------|-----------|--------|
+| **Classic** (ASP.NET Core / App Insights SDK) | `Microsoft.ApplicationInsights.Profiler.Core`, `Microsoft.ApplicationInsights.Profiler.AspNetCore` | `src/ServiceProfiler.EventPipe/tools/PackNugetPackage.cmd` |
+| **OTel** (OpenTelemetry / Azure Monitor distro) | `Azure.Monitor.OpenTelemetry.Profiler` | `src/ServiceProfiler.EventPipe.Otel/tools/PackSolution.ps1` |
 
 ## Steps
 
-1. Ask the user which configuration to use if not specified. Default to `Debug`.
-2. Run the build script:
-   ```powershell
-   cmd /c "C:\AIR\fork-otel-profiler\src\ServiceProfiler.EventPipe\tools\PackNugetPackage.cmd <Config>"
-   ```
-   - First arg (required): `Debug` or `Release`
-   - Second arg (optional): package type suffix, defaults to `private`
-   - Third arg (optional): rebuild, `TRUE` (default) or `FALSE`
-3. Check output for `Package succeeded :-)` to confirm success.
-4. List the generated `.nupkg` files from the output directories and report full paths.
+1. **Ask the user which package to build** if not specified:
+   - Classic (Application Insights Profiler ASP.NET Core)
+   - OTel (Azure Monitor OpenTelemetry Profiler)
+2. Ask the user which configuration to use if not specified. Default to `Debug`.
+3. Run the appropriate build script (see below).
+4. Check output for `Package succeeded :-)` to confirm success.
+5. List the generated `.nupkg` files from the output directories and report full paths.
+
+### Classic Package
+
+Run the build script:
+```powershell
+cmd /c "C:\AIR\fork-otel-profiler\src\ServiceProfiler.EventPipe\tools\PackNugetPackage.cmd <Config>"
+```
+- First arg (required): `Debug` or `Release`
+- Second arg (optional): package type suffix, defaults to `private`
+- Third arg (optional): rebuild, `TRUE` (default) or `FALSE`
+
+### OTel Package
+
+Run the build script (requires PowerShell 7+):
+```powershell
+& "C:\AIR\fork-otel-profiler\src\ServiceProfiler.EventPipe.Otel\tools\PackSolution.ps1" -Configuration <Config>
+```
+- `-Configuration`: `Debug` or `Release` (default: `Release`)
+- `-PackageType`: package type suffix (default: `private`)
+- `-Rebuild`: switch to force a rebuild
+- `-VersionSuffix`: optional custom version suffix
 
 ## Output Locations
 
+### Classic
 - With symbols: `src/ServiceProfiler.EventPipe/Out/Nuget/`
 - Without symbols: `src/ServiceProfiler.EventPipe/Out/NugetNoSymbols/`
 
+### OTel
+- NuGet packages: `Out/NuGets/`
+
 ## Version Format
 
-`99.YYYY.MMDD.HHmm-<packageType>-YYYYMMDDHHMM`
+`99.YYYY.MMDD.HHmm-<packageType>YYMMDDHHMM`
 
 ## Troubleshooting
 
-- If `PackUploader.cmd` fails, check that the uploader projects build successfully.
+- If `PackUploader.cmd` fails (Classic), check that the uploader projects build successfully.
 - If NuGet pack fails with missing properties, verify `NuspecProperties` in the csproj
   include all variables referenced in the `.nuspec` files.
+- OTel pack requires PowerShell 7+. Run `pwsh --version` to verify.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The profiler supports both **random sampling** (periodic snapshots) and **trigge
 - **Application Insights Resource**: Follow [this guide](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource) to create a new Application Insights resource.
 - **Azure Monitor OpenTelemetry**: This profiler works with the [Azure Monitor OpenTelemetry distro](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore).
 
-> **Note:** If you are using the classic `Microsoft.ApplicationInsights.AspNetCore` SDK instead of OpenTelemetry, see [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead.
+> **Note:** If you are using the classic `Microsoft.ApplicationInsights.AspNetCore` 2.x SDK, see [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead.
+> For `Microsoft.ApplicationInsights.AspNetCore` 3.x (which is an OpenTelemetry wrapper), see [Experimental: App Insights 3.x support](#experimental-app-insights-3x-support) below.
 
 ### Walkthrough
 
@@ -105,6 +106,24 @@ Assuming you are building an **ASP.NET Core application**:
 As an alternative to the manual walkthrough above, you can use Copilot to enable the profiler automatically:
 
 - [Enable Profiler using Copilot](./docs/AddAzureMonitorProfilerWithCoPilot.md)
+
+## Experimental: App Insights 3.x Support
+
+`Microsoft.ApplicationInsights.AspNetCore` 3.x is an OpenTelemetry-based wrapper. Since it already configures OpenTelemetry internally, you can enable the profiler directly on `IServiceCollection` without calling `AddOpenTelemetry()`:
+
+```csharp
+using Azure.Monitor.OpenTelemetry.Profiler;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddApplicationInsightsTelemetry();
+builder.Services.AddAzureMonitorProfiler();   // Enable profiler directly
+
+var app = builder.Build();
+app.Run();
+```
+
+> ⚠️ **Experimental** — This integration is under active development. Please [report any issues](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net/issues/new) you encounter.
 
 ## Next
 

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/Azure.Monitor.OpenTelemetry.Profiler.csproj
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/Azure.Monitor.OpenTelemetry.Profiler.csproj
@@ -17,4 +17,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Azure.Monitor.OpenTelemetry.Profiler.Core\Azure.Monitor.OpenTelemetry.Profiler.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Azure.Monitor.OpenTelemetry.Profiler.Tests" Key="$(TestPublicKey)" />
+  </ItemGroup>
 </Project>

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/OpenTelemetryBuilderExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/OpenTelemetryBuilderExtensions.cs
@@ -1,15 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Monitor.OpenTelemetry.Profiler.Core;
-using Microsoft.ApplicationInsights.Profiler.Shared;
-using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
-using Microsoft.ApplicationInsights.Profiler.Shared.Services;
-using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OpenTelemetry;
 
 namespace Azure.Monitor.OpenTelemetry.Profiler;
@@ -23,103 +16,8 @@ public static class OpenTelemetryBuilderExtensions
     /// <param name="configureServiceProfiler">An action to customize the behavior of the profiler.</param>
     public static IOpenTelemetryBuilder AddAzureMonitorProfiler(this IOpenTelemetryBuilder builder, Action<ServiceProfilerOptions>? configureServiceProfiler = null)
     {
-        if (!PreCheck(builder.Services))
-        {
-            // Did not pass the registering check but okay to let the application keep running.
-            return builder;
-        }
-
-        builder.Services.AddSingleton<IAgentStringProvider, AgentStringProvider>();
-        // Passed the registering check, keep registering classes into the 
-        ConfigureServices(builder.Services, configureServiceProfiler);
+        builder.Services.AddAzureMonitorProfiler(configureServiceProfiler);
         return builder;
-    }
-
-    /// <summary>
-    /// Verify if the register needs to be run.
-    /// There are 2 responsibilities:
-    /// 1. to avoid double registering when called in multiple places.
-    /// 2. to verify that dependency services are there.
-    /// </summary>
-    /// <param name="services"></param>
-    /// <returns>Returns true when register should continue. Otherwise, false.</returns>
-    /// <exception cref="InvalidOperationException">The application should be interrupted for invalid configurations. Check out the reasons by the message.</exception>
-    private static bool PreCheck(IServiceCollection services)
-    {
-        bool isRegistered = IsRegistered(services);
-        if(isRegistered)
-        {
-            // Fail the pre-check.
-            return false;
-        }
-
-        // TODO: Looking into better ways to check dependencies
-        // It is not very clear what to do today.
-        return true;
-    }
-
-    // The services are treated as registered before when the bootstrap service is registered.
-    // In the future, when we need more complex check, consider injecting the logic than simply update this
-    // implementation.
-    private static bool IsRegistered(IServiceCollection services) =>
-        services.Any(descriptor => descriptor.ServiceType == typeof(IServiceProfilerAgentBootstrap));
-
-    private static void ConfigureServices(IServiceCollection services, Action<ServiceProfilerOptions>? configureServiceProfiler)
-    {
-        services.AddLogging();
-        services.AddOptions();
-
-        services.AddOptions<ServiceProfilerOptions>().Configure<IConfiguration, IOptions<AzureMonitorExporterOptions>>((opt, configuration, azureMonitorOptions) =>
-        {
-            configuration.GetSection("ServiceProfiler").Bind(opt);
-
-            AzureMonitorExporterOptions? monitorOptions = azureMonitorOptions.Value;
-
-            // Inherit connection string from the Azure Monitor Options unless
-            // the value is already there.
-            string? azureMonitorConnectionString = monitorOptions.ConnectionString;
-            if (string.IsNullOrWhiteSpace(opt.ConnectionString))
-            {
-                opt.ConnectionString = azureMonitorConnectionString;
-            }
-
-            // Inherit the credential object from the Azure Monitor Options unless
-            // the value is already there.
-            opt.Credential ??= monitorOptions.Credential;
-            configureServiceProfiler?.Invoke(opt);
-
-            // Last effort to capture the connection string when all above failed
-            if (string.IsNullOrEmpty(opt.ConnectionString))
-            {
-                opt.ConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
-            }
-        });
-
-        services.AddSingleton<IOptions<UserConfigurationBase>>(p =>
-        {
-            ServiceProfilerOptions profilerOptions = GetRequiredOptions<ServiceProfilerOptions>(p);
-            return Options.Create(profilerOptions);
-        });
-
-        services.AddServiceProfilerCore();
-
-        services.AddSingleton<BootstrapState>();
-        services.AddSingleton<IServiceProfilerAgentBootstrap>(p =>
-        {
-            ServiceProfilerOptions userConfiguration = GetRequiredOptions<ServiceProfilerOptions>(p);
-            // Choose one by configurations to register.
-            return userConfiguration.IsDisabled ?
-                ActivatorUtilities.CreateInstance<DisabledAgentBootstrap>(p) :
-                ActivatorUtilities.CreateInstance<ServiceProfilerAgentBootstrap>(p);
-        });
-
-        services.AddHostedService<ProfilerBackgroundService>();
-    }
-
-    private static T GetRequiredOptions<T>(IServiceProvider p)
-        where T : class
-    {
-        return p.GetRequiredService<IOptions<T>>().Value ?? throw new InvalidOperationException($"Option {typeof(T).FullName} is required.");
     }
 }
 

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/PublicAPI.Unshipped.txt
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
-
+Azure.Monitor.OpenTelemetry.Profiler.ServiceCollectionExtensions
+static Azure.Monitor.OpenTelemetry.Profiler.ServiceCollectionExtensions.AddAzureMonitorProfiler(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Azure.Monitor.OpenTelemetry.Profiler.Core.ServiceProfilerOptions!>? configureServiceProfiler = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/ServiceCollectionExtensions.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Azure.Monitor.OpenTelemetry.Exporter;
+using Azure.Monitor.OpenTelemetry.Profiler.Core;
+using Microsoft.ApplicationInsights.Profiler.Shared;
+using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler;
+
+/// <summary>
+/// Extension methods for <see cref="IServiceCollection"/> to register Azure Monitor Profiler services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register the services needed to enable Azure Monitor Profiler.
+    /// Use this when the telemetry pipeline is already configured (e.g., via AddApplicationInsightsTelemetry()).
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureServiceProfiler">An action to customize the behavior of the profiler.</param>
+    public static IServiceCollection AddAzureMonitorProfiler(this IServiceCollection services, Action<ServiceProfilerOptions>? configureServiceProfiler = null)
+    {
+        if (!PreCheck(services))
+        {
+            return services;
+        }
+
+        services.AddSingleton<IAgentStringProvider, AgentStringProvider>();
+        ConfigureServices(services, configureServiceProfiler);
+        return services;
+    }
+
+    /// <summary>
+    /// Verify if the register needs to be run.
+    /// There are 2 responsibilities:
+    /// 1. to avoid double registering when called in multiple places.
+    /// 2. to verify that dependency services are there.
+    /// </summary>
+    /// <returns>Returns true when register should continue. Otherwise, false.</returns>
+    internal static bool PreCheck(IServiceCollection services)
+    {
+        bool isRegistered = IsRegistered(services);
+        if (isRegistered)
+        {
+            return false;
+        }
+
+        // TODO: Looking into better ways to check dependencies
+        // It is not very clear what to do today.
+        return true;
+    }
+
+    // The services are treated as registered before when the bootstrap service is registered.
+    // In the future, when we need more complex check, consider injecting the logic than simply update this
+    // implementation.
+    internal static bool IsRegistered(IServiceCollection services) =>
+        services.Any(descriptor => descriptor.ServiceType == typeof(IServiceProfilerAgentBootstrap));
+
+    internal static void ConfigureServices(IServiceCollection services, Action<ServiceProfilerOptions>? configureServiceProfiler)
+    {
+        services.AddLogging();
+        services.AddOptions();
+
+        services.AddOptions<ServiceProfilerOptions>().Configure<IConfiguration, IOptions<AzureMonitorExporterOptions>>((opt, configuration, azureMonitorOptions) =>
+        {
+            configuration.GetSection("ServiceProfiler").Bind(opt);
+
+            AzureMonitorExporterOptions? monitorOptions = azureMonitorOptions.Value;
+
+            // Inherit connection string from the Azure Monitor Options unless
+            // the value is already there.
+            string? azureMonitorConnectionString = monitorOptions.ConnectionString;
+            if (string.IsNullOrWhiteSpace(opt.ConnectionString))
+            {
+                opt.ConnectionString = azureMonitorConnectionString;
+            }
+
+            // Inherit the credential object from the Azure Monitor Options unless
+            // the value is already there.
+            opt.Credential ??= monitorOptions.Credential;
+            configureServiceProfiler?.Invoke(opt);
+
+            // Last effort to capture the connection string when all above failed
+            if (string.IsNullOrEmpty(opt.ConnectionString))
+            {
+                opt.ConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+            }
+        });
+
+        services.AddSingleton<IOptions<UserConfigurationBase>>(p =>
+        {
+            ServiceProfilerOptions profilerOptions = GetRequiredOptions<ServiceProfilerOptions>(p);
+            return Options.Create(profilerOptions);
+        });
+
+        services.AddServiceProfilerCore();
+
+        services.AddSingleton<BootstrapState>();
+        services.AddSingleton<IServiceProfilerAgentBootstrap>(p =>
+        {
+            ServiceProfilerOptions userConfiguration = GetRequiredOptions<ServiceProfilerOptions>(p);
+            // Choose one by configurations to register.
+            return userConfiguration.IsDisabled ?
+                ActivatorUtilities.CreateInstance<DisabledAgentBootstrap>(p) :
+                ActivatorUtilities.CreateInstance<ServiceProfilerAgentBootstrap>(p);
+        });
+
+        services.AddHostedService<ProfilerBackgroundService>();
+    }
+
+    internal static T GetRequiredOptions<T>(IServiceProvider p)
+        where T : class
+    {
+        return p.GetRequiredService<IOptions<T>>().Value ?? throw new InvalidOperationException($"Option {typeof(T).FullName} is required.");
+    }
+}

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/Azure.Monitor.OpenTelemetry.Profiler.Tests.csproj
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/Azure.Monitor.OpenTelemetry.Profiler.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ServiceProfiler.EventPipe.Otel\Azure.Monitor.OpenTelemetry.Profiler\Azure.Monitor.OpenTelemetry.Profiler.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Azure.Monitor.OpenTelemetry.Profiler;
+using Azure.Monitor.OpenTelemetry.Profiler.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddAzureMonitorProfiler_RegistersHostedService()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddAzureMonitorProfiler();
+
+        Assert.Contains(services, d => d.ServiceType == typeof(IHostedService));
+    }
+
+    [Fact]
+    public void AddAzureMonitorProfiler_ReturnsServiceCollection()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        IServiceCollection result = services.AddAzureMonitorProfiler();
+
+        Assert.Same(services, result);
+    }
+
+    [Fact]
+    public void AddAzureMonitorProfiler_PreventsDoubleRegistration()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddAzureMonitorProfiler();
+        int countAfterFirst = services.Count;
+
+        services.AddAzureMonitorProfiler();
+        int countAfterSecond = services.Count;
+
+        Assert.Equal(countAfterFirst, countAfterSecond);
+    }
+
+    [Fact]
+    public void AddAzureMonitorProfiler_AcceptsConfigureAction()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Should not throw when a configure action is provided
+        services.AddAzureMonitorProfiler(opt => { });
+
+        Assert.Contains(services, d => d.ServiceType == typeof(IHostedService));
+    }
+
+    [Fact]
+    public void AddAzureMonitorProfiler_RegistersServicesWithoutOpenTelemetryBuilder()
+    {
+        // Key scenario: user calls AddAzureMonitorProfiler directly on IServiceCollection
+        // without calling AddOpenTelemetry() first (e.g., App Insights 3.x scenario)
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // This should succeed without requiring IOpenTelemetryBuilder
+        IServiceCollection result = services.AddAzureMonitorProfiler();
+
+        Assert.Same(services, result);
+        Assert.Contains(services, d => d.ServiceType == typeof(IHostedService));
+    }
+}


### PR DESCRIPTION
Closes #120

## Summary

Adds a new `IServiceCollection.AddAzureMonitorProfiler()` extension method so that Application Insights SDK 3.x users can enable the profiler without the redundant `AddOpenTelemetry()` call.

### Before (awkward)

```csharp
builder.Services.AddApplicationInsightsTelemetry();
builder.Services.AddOpenTelemetry().AddAzureMonitorProfiler(); // why AddOpenTelemetry()?
```

### After (clean)

```csharp
builder.Services.AddApplicationInsightsTelemetry();
builder.Services.AddAzureMonitorProfiler();
```

The existing `IOpenTelemetryBuilder.AddAzureMonitorProfiler()` continues to work unchanged for Azure Monitor OTel distro users.

## Changes

| File | Change |
|---|---|
| `ServiceCollectionExtensions.cs` | **New** — public `IServiceCollection.AddAzureMonitorProfiler()` with all registration logic |
| `OpenTelemetryBuilderExtensions.cs` | Simplified to a thin delegate to the new `IServiceCollection` extension |
| `PublicAPI.Unshipped.txt` | Declares the new public API surface |
| `Azure.Monitor.OpenTelemetry.Profiler.csproj` | Added `InternalsVisibleTo` for test project |
| `Azure.Monitor.OpenTelemetry.Profiler.Tests/` | **New** — 5 unit tests covering registration, double-registration guard, and no-OTel-builder scenarios |
| `SKILL.md` | Updated `build-private-package` skill to support OTel package builds |

## Design Decisions

- **Backward-compatible**: The `IOpenTelemetryBuilder` overload now delegates to the `IServiceCollection` overload. No behavior change for existing callers.
- **Shared double-registration guard**: `PreCheck` uses the same `IServiceProfilerAgentBootstrap` sentinel check, preventing duplicate registration regardless of which entry point is used.
- **Graceful degradation**: When called without any telemetry SDK, `IOptions<AzureMonitorExporterOptions>` resolves to a default instance (standard .NET Options behavior). The connection string fallback chain runs, and if nothing is found, the profiler logs a warning and doesn't start — no crash.

## Testing

- 5 new unit tests — all passing
- Full solution build verified with 0 errors
- Private OTel NuGet package built successfully via `PackSolution.ps1`