### PR TITLE
docs: Add two-path Get Started for App Insights 3.x profiler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # dotenv files
 .env
+pr.draft.md
 
 # User-specific files
 *.rsuser

--- a/README.md
+++ b/README.md
@@ -16,16 +16,27 @@ The profiler supports both **random sampling** (periodic snapshots) and **trigge
 
 ## Get Started
 
-### Prerequisites
+### Which Application Insights SDK are you using?
+
+Choose the path that matches your project:
+
+| SDK | Path |
+|-----|------|
+| **Azure Monitor OpenTelemetry distro** (`Azure.Monitor.OpenTelemetry.AspNetCore`) | [Option A](#option-a-azure-monitor-opentelemetry-distro) |
+| **Application Insights ASP.NET Core 3.x** (`Microsoft.ApplicationInsights.AspNetCore` 3.x) | [Option B](#option-b-application-insights-aspnet-core-3x-experimental) |
+| **Application Insights ASP.NET Core 2.x** (classic SDK) | Use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead |
+
+---
+
+### Option A: Azure Monitor OpenTelemetry Distro
+
+#### Prerequisites
 
 - **.NET 8.0 or later**: Install the latest .NET SDK from [here](https://dotnet.microsoft.com/download/dotnet).
 - **Application Insights Resource**: Follow [this guide](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource) to create a new Application Insights resource.
 - **Azure Monitor OpenTelemetry**: This profiler works with the [Azure Monitor OpenTelemetry distro](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore).
 
-> **Note:** If you are using the classic `Microsoft.ApplicationInsights.AspNetCore` 2.x SDK, see [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead.
-> For `Microsoft.ApplicationInsights.AspNetCore` 3.x (which is an OpenTelemetry wrapper), see [Experimental: App Insights 3.x support](#experimental-app-insights-3x-support) below.
-
-### Walkthrough
+#### Walkthrough
 
 Assuming you are building an **ASP.NET Core application**:
 
@@ -71,7 +82,7 @@ Assuming you are building an **ASP.NET Core application**:
     ...
     ```
 
-- Run Your Application
+5. **Run Your Application**
 
     Run your application and verify the profiler starts. Look for this in the log output:
 
@@ -95,35 +106,109 @@ Assuming you are building an **ASP.NET Core application**:
     ...
     ```
 
-- View Profiler Data
+6. **View Profiler Data**
 
     After a few minutes, profiler traces will appear in Application Insights. Follow [these instructions](https://learn.microsoft.com/azure/azure-monitor/profiler/profiler-data) to view them.
 
     ![sample trace](./images/sample-trace.png)
 
-### Let Copilot enable the Profiler for you
+📖 **Full example:** [aspnetcore-webapi](./examples/aspnetcore-webapi)
 
-As an alternative to the manual walkthrough above, you can use Copilot to enable the profiler automatically:
+---
 
-- [Enable Profiler using Copilot](./docs/AddAzureMonitorProfilerWithCoPilot.md)
-
-## Experimental: App Insights 3.x Support
-
-`Microsoft.ApplicationInsights.AspNetCore` 3.x is an OpenTelemetry-based wrapper. Since it already configures OpenTelemetry internally, you can enable the profiler directly on `IServiceCollection` without calling `AddOpenTelemetry()`:
-
-```csharp
-using Azure.Monitor.OpenTelemetry.Profiler;
-
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddApplicationInsightsTelemetry();
-builder.Services.AddAzureMonitorProfiler();   // Enable profiler directly
-
-var app = builder.Build();
-app.Run();
-```
+### Option B: Application Insights ASP.NET Core 3.x (Experimental)
 
 > ⚠️ **Experimental** — This integration is under active development. Please [report any issues](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net/issues/new) you encounter.
+
+`Microsoft.ApplicationInsights.AspNetCore` 3.x is an OpenTelemetry-based wrapper. Since it already configures OpenTelemetry internally, you can enable the profiler **without** adding `Azure.Monitor.OpenTelemetry.AspNetCore` or calling `UseAzureMonitor()`.
+
+#### Prerequisites
+
+- **.NET 8.0 or later**: Install the latest .NET SDK from [here](https://dotnet.microsoft.com/download/dotnet).
+- **Application Insights Resource**: Follow [this guide](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource) to create a new Application Insights resource.
+- **Application Insights ASP.NET Core 3.x**: Your project must reference [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) version **3.x or later**.
+
+#### Walkthrough
+
+1. **Add NuGet Packages**
+
+    ```sh
+    dotnet add package Microsoft.ApplicationInsights.AspNetCore --version "3.*-*"
+    dotnet add package Azure.Monitor.OpenTelemetry.Profiler --prerelease
+    ```
+
+    Or in your `.csproj`:
+
+    ```xml
+    <ItemGroup>
+        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="[3.*-*, 4.0.0)" />
+        <PackageReference Include="Azure.Monitor.OpenTelemetry.Profiler" Version="[1.*-*, 2.0.0)" />
+    </ItemGroup>
+    ```
+
+2. **Enable the Profiler**
+
+    The code differs slightly depending on which version of `Azure.Monitor.OpenTelemetry.Profiler` you are using:
+
+    **`Azure.Monitor.OpenTelemetry.Profiler` 1.0.0-beta10 and later** — a single fluent chain:
+
+    ```csharp
+    using Azure.Monitor.OpenTelemetry.Profiler;
+
+    var builder = WebApplication.CreateBuilder(args);
+
+    builder.Services.AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();
+
+    var app = builder.Build();
+    app.Run();
+    ```
+
+    **`Azure.Monitor.OpenTelemetry.Profiler` 1.0.0-beta9 and earlier** — separate calls:
+
+    ```csharp
+    using Azure.Monitor.OpenTelemetry.Profiler;
+
+    var builder = WebApplication.CreateBuilder(args);
+
+    builder.Services.AddApplicationInsightsTelemetry();
+    builder.Services.AddOpenTelemetry().AddAzureMonitorProfiler();
+
+    var app = builder.Build();
+    app.Run();
+    ```
+
+3. **Set up the connection string**
+
+    Refer to the [connection string section](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore#paste-the-connection-string-in-your-environment) for all options. For local testing in PowerShell:
+
+    ```powershell
+    $env:APPLICATIONINSIGHTS_CONNECTION_STRING="InstrumentationKey=5d..."
+    ```
+
+4. **Run & Verify**
+
+    ```sh
+    dotnet run
+    ```
+
+    Look for profiler startup log messages like:
+
+    ```
+    info: Azure.Monitor.OpenTelemetry.Profiler.ServiceProfilerAgentBootstrap[0]
+        Starting application insights profiler with connection string: InstrumentationKey=5d…
+    ```
+
+    After a few minutes, traces will appear in Application Insights — see [how to view profiler data](https://learn.microsoft.com/azure/azure-monitor/profiler/profiler-data).
+
+📖 **Full example:** [aspnetcore-aisdk3](./examples/aspnetcore-aisdk3)
+
+---
+
+### Let Copilot enable the Profiler for you
+
+As an alternative to the manual walkthrough above, you can use Copilot to enable the profiler automatically (works for both Option A and Option B):
+
+- [Enable Profiler using Copilot](./docs/AddAzureMonitorProfilerWithCoPilot.md)
 
 ## Next
 
@@ -158,7 +243,8 @@ If you're still experiencing issues, please [open an issue](https://github.com/A
 
 Learn more by following the examples:
 
-- [Enable Azure Monitor OpenTelemetry Profiler in an ASP.NET Core WebAPI](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net/tree/main/examples/aspnetcore-webapi)
+- [Azure Monitor OpenTelemetry Distro + Profiler (ASP.NET Core WebAPI)](./examples/aspnetcore-webapi) — for [Option A](#option-a-azure-monitor-opentelemetry-distro)
+- [Application Insights ASP.NET Core 3.x + Profiler](./examples/aspnetcore-aisdk3) — for [Option B](#option-b-application-insights-aspnet-core-3x-experimental)
 
 ## Contributing
 

--- a/docs/ProfilerAgentSelectionGuide.md
+++ b/docs/ProfilerAgentSelectionGuide.md
@@ -34,9 +34,11 @@ If you are planning to host your applications in Linux, or run your application 
 
 There are 2 flavors of the **EventPipe profilers**, it depends on the Application Insights SDKs you pick.
 
-- If you are using [Azure Monitor OpenTelemetry distribution](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore), follow the instructions to use **[Azure Monitor OpenTelemetry Profiler](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net)**.
+- If you are using [Azure Monitor OpenTelemetry distribution](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore), follow the instructions to use **[Azure Monitor OpenTelemetry Profiler](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net)** — see [Option A in the README](../README.md#option-a-azure-monitor-opentelemetry-distro).
 
-- If you are using the traditional [Application Insights for ASP.NET Core applications](https://learn.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core), follow the instructions to use [Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore)
+- If you are using [Application Insights for ASP.NET Core](https://learn.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core) **3.x** (`Microsoft.ApplicationInsights.AspNetCore` 3.x, which is OpenTelemetry-based), you can use the same **[Azure Monitor OpenTelemetry Profiler](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net)** package — see [Option B in the README](../README.md#option-b-application-insights-aspnet-core-3x-experimental). ⚠️ _Experimental._
+
+- If you are using the traditional [Application Insights for ASP.NET Core applications](https://learn.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core) **2.x**, follow the instructions to use [Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore)
 
 You will need to add reference to NuGet packages and redeploy your application for those Profiler Agents to work. These profiler agents runs in-proc with your application, and are lightweight.
 

--- a/docs/SetupCloudRoleName.md
+++ b/docs/SetupCloudRoleName.md
@@ -20,10 +20,23 @@ Setting up a proper role name helps organize profiling sessions effectively. For
       OTEL_SERVICE_NAME="simple-otel-profiler"
       ```
 
-    * **Using code**:  
+    * **Using code (Azure Monitor OpenTelemetry distro)**:  
+
+      If you are using `Azure.Monitor.OpenTelemetry.AspNetCore` ([Option A](../README.md#option-a-azure-monitor-opentelemetry-distro)):
 
       ```csharp
       builder.Services.AddOpenTelemetry().UseAzureMonitor();
+      builder.Services.ConfigureOpenTelemetryTracerProvider((_, b) => 
+          b.ConfigureResource(resourceBuilder => resourceBuilder.AddService("service-name"))  // Set service.name to `service-name`
+      );
+      ```
+
+    * **Using code (Application Insights 3.x)**:  
+
+      If you are using `Microsoft.ApplicationInsights.AspNetCore` 3.x ([Option B](../README.md#option-b-application-insights-aspnet-core-3x-experimental)):
+
+      ```csharp
+      builder.Services.AddApplicationInsightsTelemetry();
       builder.Services.ConfigureOpenTelemetryTracerProvider((_, b) => 
           b.ConfigureResource(resourceBuilder => resourceBuilder.AddService("service-name"))  // Set service.name to `service-name`
       );

--- a/examples/Examples.slnx
+++ b/examples/Examples.slnx
@@ -2,4 +2,7 @@
   <Folder Name="/aspnetcore-webapi/">
     <Project Path="aspnetcore-webapi/SimpleApp.csproj" />
   </Folder>
+  <Folder Name="/aspnetcore-aisdk3/">
+    <Project Path="aspnetcore-aisdk3/AISDK3App.csproj" />
+  </Folder>
 </Solution>

--- a/examples/aspnetcore-aisdk3/AISDK3App.csproj
+++ b/examples/aspnetcore-aisdk3/AISDK3App.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="[3.*-*, 4.0.0)" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Profiler" Version="[1.*-*, 2.0.0)" />
+  </ItemGroup>
+
+</Project>

--- a/examples/aspnetcore-aisdk3/Program.cs
+++ b/examples/aspnetcore-aisdk3/Program.cs
@@ -1,0 +1,30 @@
+using Azure.Monitor.OpenTelemetry.Profiler;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// ------------------------------------------------------------------
+// Application Insights ASP.NET Core 3.x + Azure Monitor Profiler
+// ------------------------------------------------------------------
+// AI SDK 3.x is an OpenTelemetry-based wrapper, so the profiler
+// can be enabled without adding Azure.Monitor.OpenTelemetry.AspNetCore.
+//
+// Choose ONE of the patterns below based on your profiler package version.
+
+// --- Option 1: Azure.Monitor.OpenTelemetry.Profiler 1.0.0-beta10 and later ---
+// A single fluent chain:
+// builder.Services.AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();
+
+// --- Option 2: Azure.Monitor.OpenTelemetry.Profiler 1.0.0-beta9 and earlier ---
+// Separate calls:
+builder.Services.AddApplicationInsightsTelemetry();
+builder.Services.AddOpenTelemetry().AddAzureMonitorProfiler();
+
+var app = builder.Build();
+
+app.MapGet("/", async () =>
+{
+    await Task.Delay(2000); // 2 seconds delay
+    return "Hello World!";
+});
+
+app.Run();

--- a/examples/aspnetcore-aisdk3/Readme.md
+++ b/examples/aspnetcore-aisdk3/Readme.md
@@ -1,0 +1,99 @@
+# Enable Azure Monitor Profiler with Application Insights ASP.NET Core 3.x
+
+> ⚠️ **Experimental** — This integration is under active development. Please [report any issues](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net/issues/new) you encounter.
+
+This example shows how to enable Azure Monitor Profiler in an ASP.NET Core application that uses [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) **3.x** (the OpenTelemetry-based wrapper).
+
+> **Using Azure Monitor OpenTelemetry distro instead?** See the [aspnetcore-webapi](../aspnetcore-webapi/) example.
+
+## Create an application
+
+Run this command to create a web api application:
+
+```shell
+dotnet new web -n AISDK3App -o . -f net8.0
+```
+
+## Add NuGet packages
+
+Add the following 2 packages — see [AISDK3App.csproj](./AISDK3App.csproj) for details:
+
+```xml
+<ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="[3.*-*, 4.0.0)" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Profiler" Version="[1.*-*, 2.0.0)" />
+</ItemGroup>
+```
+
+Restore the packages:
+
+```shell
+dotnet restore AISDK3App.csproj
+```
+
+## Update the code to enable the profiler
+
+Application Insights ASP.NET Core 3.x already configures OpenTelemetry internally, so you do **not** need `Azure.Monitor.OpenTelemetry.AspNetCore` or `UseAzureMonitor()`. Just call `AddApplicationInsightsTelemetry()` and then enable the profiler.
+
+The API differs slightly depending on which version of `Azure.Monitor.OpenTelemetry.Profiler` you are using:
+
+### Azure.Monitor.OpenTelemetry.Profiler **1.0.0-beta10 and later**
+
+A single fluent chain:
+
+```csharp
+using Azure.Monitor.OpenTelemetry.Profiler;
+
+builder.Services.AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();
+```
+
+### Azure.Monitor.OpenTelemetry.Profiler **1.0.0-beta9 and earlier**
+
+Separate calls:
+
+```csharp
+using Azure.Monitor.OpenTelemetry.Profiler;
+
+builder.Services.AddApplicationInsightsTelemetry();
+builder.Services.AddOpenTelemetry().AddAzureMonitorProfiler();
+```
+
+See [Program.cs](./Program.cs) for the full example.
+
+## Set up the connection string
+
+Refer to the [connection string section](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore#paste-the-connection-string-in-your-environment) for all options.
+
+Quick way for local testing using an environment variable in PowerShell:
+
+```powershell
+$env:APPLICATIONINSIGHTS_CONNECTION_STRING="InstrumentationKey=5d..."
+```
+
+_Tip: Copy the connection string from the **Overview** blade of your Application Insights resource._
+
+## Add a delay to your endpoint (for testing)
+
+```csharp
+app.MapGet("/", async () =>
+{
+    await Task.Delay(2000); // 2 seconds delay
+    return "Hello World!";
+});
+```
+
+⚠️ Trace analysis might fail if the operation completes too quickly (e.g., within 10 milliseconds).
+
+## Run your application
+
+```shell
+dotnet run
+```
+
+Generate some traffic for the profiler to capture:
+
+```shell
+curl http://localhost:5082
+```
+
+After a few minutes, profiler traces will appear in Application Insights. Follow [these instructions](https://learn.microsoft.com/azure/azure-monitor/profiler/profiler-data) to view them.

--- a/examples/aspnetcore-aisdk3/appsettings.Development.json
+++ b/examples/aspnetcore-aisdk3/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/examples/aspnetcore-aisdk3/appsettings.json
+++ b/examples/aspnetcore-aisdk3/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/examples/aspnetcore-webapi/Readme.md
+++ b/examples/aspnetcore-webapi/Readme.md
@@ -2,6 +2,8 @@
 
 This is an example app to enable Azure Monitor Profiler in ASP.NET Core WebAPI with [Azure Monitor OpenTelemetry distro](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore).
 
+> **Using Application Insights ASP.NET Core 3.x instead?** See the [aspnetcore-aisdk3](../aspnetcore-aisdk3/) example.
+
 Here are the steps to build this example step to step.
 
 ## Create an application

--- a/prompts/enable-profiler.prompt.md
+++ b/prompts/enable-profiler.prompt.md
@@ -16,22 +16,46 @@ Ask for the necessary information to complete the integration, such as:
 Here are the steps you need to follow:
 
 1. **Identify the Project**: Determine which ASP.NET Core project you need to integrate the OpenTelemetry Profiler into. If there are multiple projects, ask for the specific one.
-2. **Add the latest required NuGet packages**, including the prerelease versions if necessary:
-   - Azure.Monitor.OpenTelemetry.AspNetCore
-   - Azure.Monitor.OpenTelemetry.Profiler
-   Do not install any other packages or change existing ones.
 
-3. Append the call to AddAzureMonitorProfiler() in the code. For example
+2. **Detect which Application Insights SDK is in use** by inspecting the project's `.csproj` file and `Program.cs` / `Startup.cs`:
+   - If the project references `Azure.Monitor.OpenTelemetry.AspNetCore` or calls `UseAzureMonitor()`, follow **Path A** (Azure Monitor OpenTelemetry distro).
+   - If the project references `Microsoft.ApplicationInsights.AspNetCore` version 3.x or later, or calls `AddApplicationInsightsTelemetry()`, follow **Path B** (Application Insights 3.x).
+   - If neither SDK is present, ask the user which SDK they want to use.
 
-  ```csharp
-  using Azure.Monitor.OpenTelemetry.AspNetCore;
-  // Import the Azure.Monitor.OpenTelemetry.Profiler namespace.
-  using Azure.Monitor.OpenTelemetry.Profiler;
+3. **Path A — Azure Monitor OpenTelemetry Distro**:
+   - **Add the latest required NuGet packages**, including the prerelease versions if necessary:
+     - Azure.Monitor.OpenTelemetry.AspNetCore
+     - Azure.Monitor.OpenTelemetry.Profiler
+   - Do not install any other packages or change existing ones.
+   - Append the call to `AddAzureMonitorProfiler()` in the code. For example:
 
-  // ...
-  builder.Services.AddOpenTelemetry()
-        .UseAzureMonitor()
-        .AddAzureMonitorProfiler();  // Add Azure Monitor Profiler
-  ```
+     ```csharp
+     using Azure.Monitor.OpenTelemetry.AspNetCore;
+     // Import the Azure.Monitor.OpenTelemetry.Profiler namespace.
+     using Azure.Monitor.OpenTelemetry.Profiler;
 
-4. Show user the instructions about how to setup the connection string for Azure Monitor OpenTelemetry distro, so that the profiler can send data to Azure Monitor.
+     // ...
+     builder.Services.AddOpenTelemetry()
+           .UseAzureMonitor()
+           .AddAzureMonitorProfiler();  // Add Azure Monitor Profiler
+     ```
+
+4. **Path B — Application Insights ASP.NET Core 3.x**:
+   - **Add the required NuGet package** (the project should already have `Microsoft.ApplicationInsights.AspNetCore` 3.x):
+     - Azure.Monitor.OpenTelemetry.Profiler
+   - Do not install any other packages or change existing ones. Do **not** add `Azure.Monitor.OpenTelemetry.AspNetCore`.
+   - Enable the profiler in the code. For example:
+
+     ```csharp
+     using Azure.Monitor.OpenTelemetry.Profiler;
+
+     // ...
+     // If using Azure.Monitor.OpenTelemetry.Profiler 1.0.0-beta10 or later:
+     builder.Services.AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();
+
+     // If using Azure.Monitor.OpenTelemetry.Profiler 1.0.0-beta9 or earlier:
+     // builder.Services.AddApplicationInsightsTelemetry();
+     // builder.Services.AddOpenTelemetry().AddAzureMonitorProfiler();
+     ```
+
+5. Show user the instructions about how to setup the connection string for Azure Monitor OpenTelemetry distro, so that the profiler can send data to Azure Monitor.

--- a/tag-and-push.ps1
+++ b/tag-and-push.ps1
@@ -1,0 +1,57 @@
+# Tags a specific commit and pushes the tag to remotes.
+# Usage: .\tag-and-push.ps1 -TagName <version> -CommitHash <sha> [-Remote <remote>]
+# Examples:
+#   .\tag-and-push.ps1 -TagName 1.0.0-beta3 -CommitHash abc1234
+#   .\tag-and-push.ps1 -TagName 1.0.0 -CommitHash abc1234 -Remote internal
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$TagName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$CommitHash,
+
+    [ValidateSet("origin", "internal")]
+    [string]$Remote = "origin"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Validate version-like tag name
+if ($TagName -notmatch '^\d+\.\d+\.\d+') {
+    Write-Error "TagName '$TagName' does not look like a version (expected format: 1.0.0, 1.0.0-beta3, etc.)"
+    exit 1
+}
+
+# Validate the commit exists
+$resolved = git rev-parse --verify "$CommitHash^{commit}" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Commit '$CommitHash' not found in the repository."
+    exit 1
+}
+
+Write-Host "Commit : $resolved ($(git log --oneline -1 $resolved))"
+Write-Host "Tag    : $TagName"
+Write-Host "Remote : $Remote"
+
+# Check if tag already exists locally
+$existing = git rev-parse $TagName 2>$null
+if ($LASTEXITCODE -eq 0) {
+    if ($existing -eq $resolved) {
+        Write-Host "Tag '$TagName' already exists on the correct commit. Skipping creation."
+    } else {
+        Write-Error "Tag '$TagName' already exists but points to a different commit ($existing). Delete it first if you want to re-tag."
+        exit 1
+    }
+} else {
+    git tag $TagName $resolved
+    Write-Host "Tag '$TagName' created on commit $resolved."
+}
+
+# Push to the specified remote
+git push $Remote $TagName
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to push tag '$TagName' to '$Remote'."
+    exit 1
+}
+Write-Host "Tag '$TagName' pushed to '$Remote'."


### PR DESCRIPTION
Restructures the documentation so users can clearly choose between two SDK paths to enable the profiler — without one path's instructions interfering with the other:

- **Option A**: Azure Monitor OpenTelemetry Distro (`Azure.Monitor.OpenTelemetry.AspNetCore`)
- **Option B**: Application Insights ASP.NET Core 3.x (`Microsoft.ApplicationInsights.AspNetCore` 3.x) — ⚠️ Experimental

Each option has its own self-contained prerequisites, NuGet packages, code snippets, and example project. A decision table at the top of "Get Started" routes users to the right path.

## Changes

| File | Change |
|---|---|
| `README.md` | Restructured "Get Started" into Option A / Option B with decision table; each path fully self-contained; relative links for examples |
| `examples/aspnetcore-aisdk3/` | **New** — complete example project for AI SDK 3.x (Program.cs, .csproj, Readme.md, appsettings) |
| `examples/aspnetcore-webapi/Readme.md` | Added cross-link to AI SDK 3.x example for discoverability |
| `examples/Examples.slnx` | Added new project to solution |
| `docs/ProfilerAgentSelectionGuide.md` | Added AI SDK 3.x as third EventPipe profiler option |
| `docs/SetupCloudRoleName.md` | Added role name code example for AI SDK 3.x users |
| `prompts/enable-profiler.prompt.md` | Added SDK detection step + separate Path A / Path B instructions |

## Design Decisions

- **No preference bias**: Both SDK paths are presented equally. Neither is labeled "recommended" — users pick based on which SDK they're already using.
- **Experimental label retained on Option B**: Reflects current tech status, not a preference.
- **Self-contained paths**: Option B's walkthrough does not cross-reference Option A, so users never accidentally pick up the wrong instructions.
- **Both beta9 and beta10+ patterns documented**: AI SDK 3.x code snippets show both the fluent chain (beta10+) and separate-calls (beta9) patterns with clear version guidance.