### PR TITLE
Support DiagnosticSource as alternative to internal OTel EventSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -483,3 +483,6 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+# Language server cache
+*.lscache

--- a/docs/RequestSourceModeKillSwitch.md
+++ b/docs/RequestSourceModeKillSwitch.md
@@ -1,0 +1,39 @@
+# ⚠️ Internal Environment Variable — Testing Only
+
+> **This environment variable is for internal testing only and will be removed in a future release.**
+> Do not depend on it in production.
+
+## `MICROSOFT_PROFILER_INTERNAL_REQUEST_SOURCE`
+
+Controls which EventSource the profiler uses to detect ASP.NET Core HTTP request start/stop events. It exists as a kill switch during the migration from `OpenTelemetry-Sdk` EventSource to `DiagnosticSource`.
+
+### Background
+
+The OpenTelemetry SDK EventSource is internal and not reliable to depend on — changes in the SDK can break the profiler without warning. We are migrating to `Microsoft-Diagnostics-DiagnosticSource` as the primary request event source. This environment variable allows switching between sources for testing and validation.
+
+### Accepted Values
+
+| Value | Description |
+|-------|-------------|
+| `ds` | **(Default)** Use `Microsoft-Diagnostics-DiagnosticSource` only |
+| `otel` | Use `OpenTelemetry-Sdk` RequestStart/Stop events only (legacy) |
+| `both` | Subscribe to both sources; deduplication ensures exactly one Start/Stop pair per request |
+
+### Usage
+
+```bash
+# Linux / macOS
+export MICROSOFT_PROFILER_INTERNAL_REQUEST_SOURCE=both
+
+# Windows (PowerShell)
+$env:MICROSOFT_PROFILER_INTERNAL_REQUEST_SOURCE = "both"
+
+# Windows (cmd)
+set MICROSOFT_PROFILER_INTERNAL_REQUEST_SOURCE=both
+```
+
+### Behavior
+
+- If the variable is **unset or empty**, the default mode (`ds`) is used.
+- If the variable contains an **unrecognized value**, it falls back to the default (`ds`) and logs a warning.
+- Values are **case-insensitive**.

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/DiagnosticsClientTraceConfiguration.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/DiagnosticsClientTraceConfiguration.cs
@@ -30,5 +30,11 @@ internal class DiagnosticsClientTraceConfiguration : DiagnosticsClientTraceConfi
 
         // Open Telemetry Profiler Data adapter event source so that trace analysis knows about the activities
         yield return new EventPipeProvider(AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.EventSourceName, EventLevel.Verbose, keywords: 0xffffffffffff, arguments: null);
+
+        // Diagnostic Source Event Source
+        yield return new EventPipeProvider(TraceSessionListener.DiagnosticSourceEventSourceName, EventLevel.Verbose, keywords: 0xffffffffffff, arguments: new Dictionary<string, string>
+        {
+            ["FilterAndPayloadSpecs"] = "[AS]*"
+        });
     }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/DiagnosticsClientTraceConfiguration.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/DiagnosticsClientTraceConfiguration.cs
@@ -13,28 +13,43 @@ namespace Azure.Monitor.OpenTelemetry.Profiler.Core;
 
 internal class DiagnosticsClientTraceConfiguration : DiagnosticsClientTraceConfigurationBase
 {
+    private readonly ILogger _logger;
+
     public DiagnosticsClientTraceConfiguration(
         IOptions<UserConfigurationBase> userConfiguration,
         ILogger<DiagnosticsClientTraceConfigurationBase> logger)
         : base(userConfiguration, logger)
     {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     /// <inheritdoc />
     protected override IEnumerable<EventPipeProvider> AppendEventPipeProviders()
     {
-        // Two event pipe providers that is specific to OTel.
-        
-        // Open Telemetry SDK Event Source
-        yield return new EventPipeProvider(TraceSessionListener.OpenTelemetrySDKEventSourceName, EventLevel.Verbose, keywords: 0xffffffffffff, arguments: null);
+        // Gate the EventPipe providers by the same request-source kill switch used by
+        // TraceSessionListenerFactory. This avoids enabling (and serializing through EventPipe)
+        // providers whose events would be dropped by the in-process handler selection.
+        RequestSourceMode mode = RequestSourceModeResolver.Resolve(_logger);
 
-        // Open Telemetry Profiler Data adapter event source so that trace analysis knows about the activities
-        yield return new EventPipeProvider(AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.EventSourceName, EventLevel.Verbose, keywords: 0xffffffffffff, arguments: null);
-
-        // Diagnostic Source Event Source
-        yield return new EventPipeProvider(TraceSessionListener.DiagnosticSourceEventSourceName, EventLevel.Verbose, keywords: 0xffffffffffff, arguments: new Dictionary<string, string>
+        // Open Telemetry SDK Event Source — only needed when the OTel-SDK handler is active.
+        if (mode is RequestSourceMode.OpenTelemetrySdk or RequestSourceMode.Both)
         {
-            ["FilterAndPayloadSpecs"] = "[AS]*"
-        });
+            yield return new EventPipeProvider(TraceSessionListener.OpenTelemetrySDKEventSourceName, EventLevel.Verbose, keywords: 0xffffffffffff, arguments: null);
+        }
+
+        // Diagnostic Source Event Source — only needed when the DS handler is active.
+        // Narrow FilterAndPayloadSpecs to the exact ASP.NET Core HTTP-in ActivitySource to match the handler;
+        // [AS]* would firehose every ActivitySource in the process (EF Core, HttpClient, custom sources, ...).
+        if (mode is RequestSourceMode.DiagnosticSource or RequestSourceMode.Both)
+        {
+            yield return new EventPipeProvider(TraceSessionListener.DiagnosticSourceEventSourceName, EventLevel.Verbose, keywords: 0xffffffffffff, arguments: new Dictionary<string, string>
+            {
+                ["FilterAndPayloadSpecs"] = DiagnosticSourceEventSourceHandler.FilterAndPayloadSpecs,
+            });
+        }
+
+        // Open Telemetry Profiler Data adapter event source so that trace analysis knows about the activities.
+        // Always on — this is our own emitter.
+        yield return new EventPipeProvider(AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.EventSourceName, EventLevel.Verbose, keywords: 0xffffffffffff, arguments: null);
     }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
@@ -14,16 +14,35 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
     public const string EventSourceName = "Microsoft-Diagnostics-DiagnosticSource";
 
     // FilterAndPayloadSpecs grammar: see DiagnosticSourceEventSource source-of-truth comment block.
-    //   <DiagnosticSourceName>/<DiagnosticEventName>@<EventSourceEventName>:<TRANSFORM_SPECS>
-    // The leading '-' suppresses implicit payload serialization; we explicitly project only Activity name + Id.
-    private const string FilterAndPayloadSpecs =
-        "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:" +
-            "-ActivityName=Activity.OperationName" +
-            ";Id=Activity.Id" +
-        "\n" +
-        "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop@Activity1Stop:" +
-            "-ActivityName=Activity.OperationName" +
-            ";Id=Activity.Id";
+    //
+    // We use the ActivitySource path (the "[AS]" prefix), NOT the DiagnosticListener path:
+    //   [AS]<ActivitySourceName>/[<ActivityName>][:<TRANSFORM_SPECS>]
+    //
+    // Why ActivitySource and not DiagnosticListener:
+    //   The ActivitySource bridge is Activity-aware — it auto-populates standard Activity fields
+    //   (Id, ActivityName, parent ids, status, etc.) into the Activity{N}Start/Stop event's
+    //   Arguments payload, with no transform spec required. The DiagnosticListener path can only
+    //   walk properties of the diagnostic event payload object (e.g. HttpContext for
+    //   HttpRequestIn.Start), which has no Activity property — so any "Activity.Id" transform
+    //   resolves to null and is silently dropped (verified empirically).
+    //
+    // Why EventSource bridge and not direct DiagnosticListener subscription:
+    //   We need to keep the option open to consume these events out-of-process via EventPipe / ETW
+    //   in the future. Direct DiagnosticListener subscription is in-process only (no IPC).
+    //   The EventSource bridge re-emits the same events as ETW/EventPipe events, so the same spec
+    //   works whether the consumer is an in-proc EventListener (today) or an out-of-proc
+    //   DiagnosticsClient session (tomorrow).
+    //
+    // **REQUIRES .NET 8+** because ASP.NET Core only exposed an ActivitySource named
+    // "Microsoft.AspNetCore" starting in .NET 8. On .NET 6/7 ASP.NET Core created
+    // request Activities directly via `new Activity(...)`/`DiagnosticSource.StartActivity(...)`
+    // without an ActivitySource, so this spec captures nothing on those runtimes. Older
+    // runtimes are covered by the OpenTelemetry-Sdk handler (OTel's ASP.NET Core
+    // instrumentation has the same .NET-8+ floor in modern releases anyway).
+    //
+    // The ActivitySource name is "Microsoft.AspNetCore" (NOT "Microsoft.AspNetCore.Hosting" —
+    // that's the ActivityName / OperationName, e.g. "Microsoft.AspNetCore.Hosting.HttpRequestIn").
+    private const string FilterAndPayloadSpecs = "[AS]Microsoft.AspNetCore/";
 
     private readonly RequestActivityRelay _relay;
     private readonly ILogger<DiagnosticSourceEventSourceHandler> _logger;
@@ -57,21 +76,29 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
 
     public void OnEventWritten(EventWrittenEventArgs eventData)
     {
-        // We only care about the bridged Activity{N}Start / Activity{N}Stop events.
+        // We only care about the bridged ActivityStart / ActivityStop events (Events 11/12 from the
+        // ActivitySource bridge path). Their payload shape is:
+        //   (string SourceName, string ActivityName, IEnumerable<KeyValuePair<string,string>> Arguments)
+        // SourceName + ActivityName are top-level payload fields. Activity Id / parent ids / status
+        // are projected into Arguments by the runtime bridge.
         string? eventName = eventData.EventName;
         if (eventName is null || (!eventName.EndsWith("Start", StringComparison.Ordinal) && !eventName.EndsWith("Stop", StringComparison.Ordinal)))
         {
             return;
         }
 
-        // The bridged Activity1Start/Activity1Stop events have the payload shape:
-        //   (string SourceName, string EventName, IEnumerable<KeyValuePair<string,string>> Arguments)
-        // EventListener surfaces Arguments as object[] of IDictionary<string,object> with "Key"/"Value".
-        object[] arguments = eventData.GetPayload<object[]>("Arguments")
-            ?? throw new InvalidDataException("Arguments payload is missing.");
+        string requestName = eventData.GetPayload<string>("ActivityName") ?? "Unknown";
 
-        string requestName = GetArgumentValue(arguments, "ActivityName") ?? "Unknown";
-        string id = GetArgumentValue(arguments, "Id") ?? throw new InvalidDataException("Id argument is missing.");
+        // Arguments is an object[] of IDictionary<string,object> with "Key"/"Value" entries.
+        object[]? arguments = eventData.GetPayload<object[]>("Arguments");
+        string? id = arguments is null ? null : GetArgumentValue(arguments, "Id");
+        if (string.IsNullOrEmpty(id))
+        {
+            // Foreign listeners can route different diagnostic events into the shared
+            // Activity{N}Start/Stop slots with different payload projections. Skip silently.
+            return;
+        }
+
         (string operationId, string requestId) = RequestActivityRelay.ExtractKeyIds(id);
 
         if (eventName.EndsWith("Start", StringComparison.Ordinal))

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
@@ -42,7 +42,7 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
     //
     // The ActivitySource name is "Microsoft.AspNetCore" (NOT "Microsoft.AspNetCore.Hosting" —
     // that's the ActivityName / OperationName, e.g. "Microsoft.AspNetCore.Hosting.HttpRequestIn").
-    private const string FilterAndPayloadSpecs = "[AS]Microsoft.AspNetCore/";
+    internal const string FilterAndPayloadSpecs = "[AS]Microsoft.AspNetCore/";
 
     private readonly RequestActivityRelay _relay;
     private readonly ILogger<DiagnosticSourceEventSourceHandler> _logger;
@@ -99,7 +99,7 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
             return;
         }
 
-        (string operationId, string requestId) = RequestActivityRelay.ExtractKeyIds(id);
+        (string requestId, string operationId) = RequestActivityRelay.ExtractKeyIds(id);
 
         if (eventName.EndsWith("Start", StringComparison.Ordinal))
         {

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Logging;
+using System.Diagnostics.Tracing;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
+
+/// <summary>
+/// Handler for the <c>Microsoft-Diagnostics-DiagnosticSource</c> EventSource bridge.
+/// Subscribes to ASP.NET Core HTTP-in start/stop diagnostic events via <c>FilterAndPayloadSpecs</c>,
+/// mapping them onto the bridge's <c>Activity1Start</c>/<c>Activity1Stop</c> EventSource events,
+/// then forwards parsed payloads to the shared <see cref="RequestActivityRelay"/>.
+/// </summary>
+internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
+{
+    public const string EventSourceName = "Microsoft-Diagnostics-DiagnosticSource";
+
+    // FilterAndPayloadSpecs grammar: see DiagnosticSourceEventSource source-of-truth comment block.
+    //   <DiagnosticSourceName>/<DiagnosticEventName>@<EventSourceEventName>:<TRANSFORM_SPECS>
+    // The leading '-' suppresses implicit payload serialization; we explicitly project only Activity name + Id.
+    private const string FilterAndPayloadSpecs =
+        "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:" +
+            "-ActivityName=Activity.OperationName" +
+            ";Id=Activity.Id" +
+        "\n" +
+        "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop@Activity1Stop:" +
+            "-ActivityName=Activity.OperationName" +
+            ";Id=Activity.Id";
+
+    private readonly RequestActivityRelay _relay;
+    private readonly ILogger<DiagnosticSourceEventSourceHandler> _logger;
+
+    public DiagnosticSourceEventSourceHandler(
+        RequestActivityRelay relay,
+        ILogger<DiagnosticSourceEventSourceHandler> logger)
+    {
+        _relay = relay ?? throw new ArgumentNullException(nameof(relay));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public bool CanHandle(EventSource eventSource)
+        => string.Equals(eventSource.Name, EventSourceName, StringComparison.Ordinal);
+
+    public void Enable(EventListener listener, EventSource eventSource)
+    {
+        _logger.LogDebug("Enabling EventSource: {eventSourceName}", eventSource.Name);
+
+        // Keyword 0x2 == DiagnosticSourceEventSource.Keywords.Events, which gates FilterAndPayloadSpecs processing.
+        // Do NOT set 0x800 (IgnoreShortCutKeywords): keeping it off preserves the AspNetCoreHosting/EFCore shortcut keywords.
+        listener.EnableEvents(
+            eventSource,
+            EventLevel.Informational,
+            (EventKeywords)0x2,
+            new Dictionary<string, string>
+            {
+                ["FilterAndPayloadSpecs"] = FilterAndPayloadSpecs,
+            });
+    }
+
+    public void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        // We only care about the bridged Activity{N}Start / Activity{N}Stop events.
+        string? eventName = eventData.EventName;
+        if (eventName is null || (!eventName.EndsWith("Start", StringComparison.Ordinal) && !eventName.EndsWith("Stop", StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        // The bridged Activity1Start/Activity1Stop events have the payload shape:
+        //   (string SourceName, string EventName, IEnumerable<KeyValuePair<string,string>> Arguments)
+        // EventListener surfaces Arguments as object[] of IDictionary<string,object> with "Key"/"Value".
+        object[] arguments = eventData.GetPayload<object[]>("Arguments")
+            ?? throw new InvalidDataException("Arguments payload is missing.");
+
+        string requestName = GetArgumentValue(arguments, "ActivityName") ?? "Unknown";
+        string id = GetArgumentValue(arguments, "Id") ?? throw new InvalidDataException("Id argument is missing.");
+        (string operationId, string requestId) = RequestActivityRelay.ExtractKeyIds(id);
+
+        if (eventName.EndsWith("Start", StringComparison.Ordinal))
+        {
+            _relay.HandleRequestStart(eventData, requestName, requestId, operationId, id);
+        }
+        else
+        {
+            _relay.HandleRequestStop(eventData, requestName, requestId, operationId, id);
+        }
+    }
+
+    // Each element of the bridged Arguments payload is an IDictionary<string,object>
+    // with two entries: { "Key" -> <name>, "Value" -> <value> }.
+    private static string? GetArgumentValue(object[] arguments, string key)
+    {
+        foreach (object? argument in arguments)
+        {
+            if (argument is IDictionary<string, object> kvp
+                && kvp.TryGetValue("Key", out object? k)
+                && k is string keyName
+                && string.Equals(keyName, key, StringComparison.Ordinal)
+                && kvp.TryGetValue("Value", out object? v))
+            {
+                return v as string;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/IEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/IEventSourceHandler.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics.Tracing;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
+
+/// <summary>
+/// Strategy for handling a single <see cref="EventSource"/> from inside <see cref="TraceSessionListener"/>.
+/// Each handler owns the source-specific knowledge (which source name to bind, which keywords / payload spec
+/// to enable it with, and how to interpret incoming events) so that the listener stays a thin dispatcher.
+/// </summary>
+internal interface IEventSourceHandler
+{
+    /// <summary>
+    /// Returns true when this handler wants to enable and consume events from <paramref name="eventSource"/>.
+    /// Typically a name match.
+    /// </summary>
+    bool CanHandle(EventSource eventSource);
+
+    /// <summary>
+    /// Enables the source on the supplied listener. Called from <see cref="EventListener.OnEventSourceCreated"/>.
+    /// </summary>
+    void Enable(EventListener listener, EventSource eventSource);
+
+    /// <summary>
+    /// Interprets one event written by a previously-enabled source.
+    /// </summary>
+    void OnEventWritten(EventWrittenEventArgs eventData);
+}

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/OpenTelemetrySdkEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/OpenTelemetrySdkEventSourceHandler.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Logging;
+using System.Diagnostics.Tracing;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
+
+/// <summary>
+/// Handler for the <c>OpenTelemetry-Sdk</c> EventSource. Maps its RequestStart (24) /
+/// RequestStop (25) events onto the shared <see cref="RequestActivityRelay"/>.
+/// </summary>
+internal sealed class OpenTelemetrySdkEventSourceHandler : IEventSourceHandler
+{
+    public const string EventSourceName = "OpenTelemetry-Sdk";
+
+    // Event ids defined by the OpenTelemetry-Sdk EventSource.
+    private const int RequestStartEventId = 24;
+    private const int RequestStopEventId = 25;
+
+    private readonly RequestActivityRelay _relay;
+    private readonly ILogger<OpenTelemetrySdkEventSourceHandler> _logger;
+
+    public OpenTelemetrySdkEventSourceHandler(
+        RequestActivityRelay relay,
+        ILogger<OpenTelemetrySdkEventSourceHandler> logger)
+    {
+        _relay = relay ?? throw new ArgumentNullException(nameof(relay));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public bool CanHandle(EventSource eventSource)
+        => string.Equals(eventSource.Name, EventSourceName, StringComparison.OrdinalIgnoreCase);
+
+    public void Enable(EventListener listener, EventSource eventSource)
+    {
+        // 0x0000F covers the keyword bits the OTel SDK uses for activity start/stop reporting.
+        const EventKeywords keywords = (EventKeywords)0x0000F;
+        _logger.LogDebug("Enabling EventSource: {eventSourceName}", eventSource.Name);
+        listener.EnableEvents(eventSource, EventLevel.Verbose, keywords);
+    }
+
+    public void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        if (eventData.EventId != RequestStartEventId && eventData.EventId != RequestStopEventId)
+        {
+            return;
+        }
+
+        string requestName = eventData.GetPayload<string>("name") ?? "Unknown";
+        string id = eventData.GetPayload<string>("id") ?? throw new InvalidDataException("id payload is missing.");
+
+        (string operationId, string requestId) = RequestActivityRelay.ExtractKeyIds(id);
+
+        if (eventData.EventId == RequestStartEventId)
+        {
+            _relay.HandleRequestStart(eventData, requestName, requestId, operationId, id);
+        }
+        else
+        {
+            _relay.HandleRequestStop(eventData, requestName, requestId, operationId, id);
+        }
+    }
+}

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/OpenTelemetrySdkEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/OpenTelemetrySdkEventSourceHandler.cs
@@ -47,7 +47,7 @@ internal sealed class OpenTelemetrySdkEventSourceHandler : IEventSourceHandler
         string requestName = eventData.GetPayload<string>("name") ?? "Unknown";
         string id = eventData.GetPayload<string>("id") ?? throw new InvalidDataException("id payload is missing.");
 
-        (string operationId, string requestId) = RequestActivityRelay.ExtractKeyIds(id);
+        (string requestId, string operationId) = RequestActivityRelay.ExtractKeyIds(id);
 
         if (eventData.EventId == RequestStartEventId)
         {

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
@@ -115,8 +115,9 @@ internal sealed class RequestActivityRelay
         }
     }
 
-    // id example: 00-4dee62c12eaa9efca3d1f0565f3efda6-b3c470a7ee10c13b-01
-    public static (string operationId, string requestId) ExtractKeyIds(string id)
+    // W3C Trace Context id example: 00-4dee62c12eaa9efca3d1f0565f3efda6-b3c470a7ee10c13b-01
+    //                                ver  trace-id (operationId)         span-id (requestId) flags
+    public static (string requestId, string operationId) ExtractKeyIds(string id)
     {
         string[] tokens = id.Split(['-'], StringSplitOptions.RemoveEmptyEntries);
 
@@ -125,6 +126,6 @@ internal sealed class RequestActivityRelay
             throw new InvalidDataException(FormattableString.Invariant($"Id shall have at least 3 sections separated by `-`. Actual id: {id}"));
         }
 
-        return (tokens[1], tokens[2]);
+        return (requestId: tokens[2], operationId: tokens[1]);
     }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
@@ -1,0 +1,130 @@
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using System.Diagnostics.Tracing;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
+
+/// <summary>
+/// Tracks in-flight "interesting" request activities (currently ASP.NET Core HTTP-in) and forwards
+/// matched start/stop pairs onto <see cref="AzureMonitorOpenTelemetryProfilerDataAdapterEventSource"/>.
+///
+/// Lives once per <see cref="TraceSessionListener"/> and is shared by every <see cref="IEventSourceHandler"/>
+/// that produces request activities, so a Start emitted by one source can correlate with (or be deduped
+/// against) a Stop emitted by another.
+/// </summary>
+internal sealed class RequestActivityRelay
+{
+    private const string AspNetCoreHttpRequestInName = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
+
+    private readonly ILogger<RequestActivityRelay> _logger;
+    private readonly ConcurrentDictionary<string, byte> _startedActivityIds = new();
+    private volatile bool _hasActivityReported;
+
+    public RequestActivityRelay(ILogger<RequestActivityRelay> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// We only capture HTTP-in requests. HTTP-out (e.g. HttpClient) is excluded.
+    /// </summary>
+    private static bool IsInterestingRequest(string requestName)
+        => string.Equals(AspNetCoreHttpRequestInName, requestName, StringComparison.Ordinal);
+
+    public void HandleRequestStart(EventWrittenEventArgs eventData, string requestName, string requestId, string operationId, string id)
+    {
+        Guid currentActivityId = eventData.ActivityId;
+        bool isDebugLoggingEnabled = _logger.IsEnabled(LogLevel.Debug);
+        if (isDebugLoggingEnabled)
+        {
+            _logger.LogDebug("Request started: Activity Id: {activityId}", currentActivityId);
+        }
+
+        if (!IsInterestingRequest(requestName))
+        {
+            if (isDebugLoggingEnabled)
+            {
+                _logger.LogDebug("Drop uninteresting request by name: {requestName}, id: {id}", requestName, id);
+            }
+            return;
+        }
+
+        if (isDebugLoggingEnabled)
+        {
+            _logger.LogDebug("Interesting start activity, name: {name}, id: {id}", requestName, id);
+        }
+
+        // Note to the started-activities bag, so that when stop happens, it knows to match.
+        // Multiple handlers (e.g. the OpenTelemetry-Sdk and DiagnosticSource bridges) can both observe
+        // the same ASP.NET Core HTTP-in activity. Dedupe so we don't double-emit to the relay EventSource.
+        if (!_startedActivityIds.TryAdd(id, default))
+        {
+            if (isDebugLoggingEnabled)
+            {
+                _logger.LogDebug("Duplicate start for id {id} (already relayed by another handler); skipping.", id);
+            }
+            return;
+        }
+
+        if (isDebugLoggingEnabled)
+        {
+            _logger.LogDebug("Set current thread activity id: {activityId}", currentActivityId);
+        }
+        EventSource.SetCurrentThreadActivityId(currentActivityId);
+        AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStart(
+            name: requestName,
+            id: id,
+            requestId: requestId,
+            operationId: operationId);
+    }
+
+    public void HandleRequestStop(EventWrittenEventArgs eventData, string requestName, string requestId, string operationId, string id)
+    {
+        bool isDebugLoggingEnabled = _logger.IsEnabled(LogLevel.Debug);
+        Guid currentActivityId = eventData.ActivityId;
+
+        if (isDebugLoggingEnabled)
+        {
+            _logger.LogDebug("Request stopped: Activity Id: {activityId}", currentActivityId);
+        }
+
+        if (!_startedActivityIds.TryRemove(id, out _))
+        {
+            if (isDebugLoggingEnabled)
+            {
+                _logger.LogDebug("No start activity found for this stop activity. Request name: {requestName}, id: {id}", requestName, id);
+            }
+            // No interesting start activity captured, it doesn't make sense to capture the stop alone.
+            return;
+        }
+
+        if (isDebugLoggingEnabled)
+        {
+            _logger.LogDebug("Interesting activity found. Name: {name}, id: {id}", requestName, id);
+            _logger.LogDebug("Set current thread activity id: {activityId}", currentActivityId);
+        }
+
+        EventSource.SetCurrentThreadActivityId(currentActivityId);
+        AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStop(
+            name: requestName, id: id, requestId: requestId, operationId: operationId);
+
+        if (!_hasActivityReported && _logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation("Activity detected.");
+            _hasActivityReported = true;
+        }
+    }
+
+    // id example: 00-4dee62c12eaa9efca3d1f0565f3efda6-b3c470a7ee10c13b-01
+    public static (string operationId, string requestId) ExtractKeyIds(string id)
+    {
+        string[] tokens = id.Split(['-'], StringSplitOptions.RemoveEmptyEntries);
+
+        if (tokens.Length < 3)
+        {
+            throw new InvalidDataException(FormattableString.Invariant($"Id shall have at least 3 sections separated by `-`. Actual id: {id}"));
+        }
+
+        return (tokens[1], tokens[2]);
+    }
+}

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestSourceMode.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestSourceMode.cs
@@ -1,0 +1,24 @@
+namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
+
+/// <summary>
+/// Selects which EventSource(s) the <see cref="TraceSessionListener"/> consumes for ASP.NET Core
+/// HTTP-in request start/stop events. Internal kill switch — not user-facing configuration.
+/// </summary>
+internal enum RequestSourceMode
+{
+    /// <summary>
+    /// Only the <c>Microsoft-Diagnostics-DiagnosticSource</c> bridge is used. Default.
+    /// </summary>
+    DiagnosticSource,
+
+    /// <summary>
+    /// Only the <c>OpenTelemetry-Sdk</c> RequestStart/Stop events are used. Legacy.
+    /// </summary>
+    OpenTelemetrySdk,
+
+    /// <summary>
+    /// Both sources are subscribed. The shared <see cref="RequestActivityRelay"/> dedupes
+    /// by activity id so the relay EventSource still sees exactly one Start/Stop pair.
+    /// </summary>
+    Both,
+}

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestSourceModeResolver.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestSourceModeResolver.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
+
+/// <summary>
+/// Resolves the request-event-source <see cref="RequestSourceMode"/> from the internal kill-switch
+/// environment variable. Shared by <see cref="TraceSessionListenerFactory"/> (in-process handler
+/// selection) and the EventPipe provider configuration (which providers to enable on the session).
+/// </summary>
+internal static class RequestSourceModeResolver
+{
+    // Internal, undocumented kill switch. Lets us A/B the two request-event sources during the
+    // migration away from OpenTelemetry-Sdk's RequestStart/Stop toward DiagnosticSource.
+    // Accepted values (case-insensitive): "ds" | "otel" | "both". Anything else falls back to default.
+    internal const string EnvVarName = "MICROSOFT_PROFILER_INTERNAL_REQUEST_SOURCE";
+
+    internal const RequestSourceMode Default = RequestSourceMode.DiagnosticSource;
+
+    public static RequestSourceMode Resolve(ILogger logger)
+    {
+        string? raw = Environment.GetEnvironmentVariable(EnvVarName);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return Default;
+        }
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "ds" => RequestSourceMode.DiagnosticSource,
+            "otel" => RequestSourceMode.OpenTelemetrySdk,
+            "both" => RequestSourceMode.Both,
+            _ => LogUnrecognizedAndUseDefault(logger, raw),
+        };
+    }
+
+    private static RequestSourceMode LogUnrecognizedAndUseDefault(ILogger logger, string raw)
+    {
+        logger.LogWarning(
+            "Unrecognized value '{value}' for {envVar}; falling back to {default}. Expected: ds | otel | both.",
+            raw, EnvVarName, Default);
+        return Default;
+    }
+}

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TplEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TplEventSourceHandler.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Logging;
+using System.Diagnostics.Tracing;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
+
+/// <summary>
+/// Handler for the TPL EventSource. Activity IDs aren't enabled by default; turning on keyword 0x80
+/// makes them flow so that other listeners (and ETW consumers) see correlated activity IDs.
+/// This handler does not consume any events itself.
+/// </summary>
+internal sealed class TplEventSourceHandler : IEventSourceHandler
+{
+    public const string EventSourceName = "System.Threading.Tasks.TplEventSource";
+
+    private readonly ILogger<TplEventSourceHandler> _logger;
+
+    public TplEventSourceHandler(ILogger<TplEventSourceHandler> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public bool CanHandle(EventSource eventSource)
+        => string.Equals(eventSource.Name, EventSourceName, StringComparison.Ordinal);
+
+    public void Enable(EventListener listener, EventSource eventSource)
+    {
+        _logger.LogDebug("Enabling EventSource: {eventSourceName}", eventSource.Name);
+        // Keyword 0x80 turns on Activity IDs.
+        listener.EnableEvents(eventSource, EventLevel.LogAlways, (EventKeywords)0x80);
+    }
+
+    public void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        // No-op: we enable this source only so that activity IDs propagate.
+    }
+}

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -228,10 +228,8 @@ internal class TraceSessionListener : EventListener
             _logger.LogWarning("Failed to add started activity. Activity by id {id} already exists? Please report a bug.", id);
         }
 
-        var sourceName = eventData.EventSource.Name;
-
         AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStart(
-            name: sourceName + requestName,
+            name: requestName,
             id: id,
             requestId: requestId,
             operationId: operationId);
@@ -261,10 +259,9 @@ internal class TraceSessionListener : EventListener
             _logger.LogDebug("Interesting activity found. Name: {name}, id: {id}", requestName, id);
         }
 
-        var sourceName = eventData.EventSource.Name;
         // Interesting start activity was captured, relay this stop activity.
         AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStop(
-            name: sourceName + requestName, id: id, requestId: requestId, operationId: operationId);
+            name: requestName, id: id, requestId: requestId, operationId: operationId);
 
         if (!_hasActivityReported && _logger.IsEnabled(LogLevel.Information))
         {

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -60,7 +60,7 @@ internal class TraceSessionListener : EventListener
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)
     {
-        _logger.LogInformation("OnEventWritten by {eventSource}", eventData.EventSource.Name);
+        _logger.LogTrace("OnEventWritten by {eventSource}", eventData.EventSource.Name);
 
         try
         {

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -228,6 +228,11 @@ internal class TraceSessionListener : EventListener
             _logger.LogWarning("Failed to add started activity. Activity by id {id} already exists? Please report a bug.", id);
         }
 
+        if (isDebugLoggingEnabled)
+        {
+            _logger.LogDebug("Set current thread activity id: {activityId}", currentActivityId);
+        }
+        EventSource.SetCurrentThreadActivityId(currentActivityId);
         AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStart(
             name: requestName,
             id: id,
@@ -238,9 +243,11 @@ internal class TraceSessionListener : EventListener
     private void HandleRequestStop(EventWrittenEventArgs eventData, string requestName, string requestId, string operationId, string id)
     {
         bool isDebugLoggingEnabled = _logger.IsEnabled(LogLevel.Debug);
+        Guid currentActivityId = eventData.ActivityId;
+
         if (isDebugLoggingEnabled)
         {
-            _logger.LogDebug("Request stopped: Activity Id: {activityId}", eventData.ActivityId);
+            _logger.LogDebug("Request stopped: Activity Id: {activityId}", currentActivityId);
         }
 
         if (!_startedActivityIds.TryRemove(id, out _))
@@ -257,9 +264,12 @@ internal class TraceSessionListener : EventListener
         if (isDebugLoggingEnabled)
         {
             _logger.LogDebug("Interesting activity found. Name: {name}, id: {id}", requestName, id);
+            _logger.LogDebug("Set current thread activity id: {activityId}", currentActivityId);
         }
 
         // Interesting start activity was captured, relay this stop activity.
+        EventSource.SetCurrentThreadActivityId(currentActivityId);
+
         AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStop(
             name: requestName, id: id, requestId: requestId, operationId: operationId);
 
@@ -292,13 +302,13 @@ internal class TraceSessionListener : EventListener
     private static (string operationId, string requestId) ExtractKeyIds(string id)
     {
         string[] tokens = id.Split(['-'], StringSplitOptions.RemoveEmptyEntries);
-        
+
         // It at least contains 3 parts.
         if (tokens.Length < 3)
         {
             throw new InvalidDataException(FormattableString.Invariant($"Id shall have at least 3 sections separated by `-`. Actual id: {id}"));
         }
-        
+
         return (tokens[1], tokens[2]);
     }
 
@@ -317,7 +327,7 @@ internal class TraceSessionListener : EventListener
                 }
             }
         }
-        
+
         return string.Empty;
     }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -1,39 +1,36 @@
 #define CONSOLE_LOGGING
 #undef CONSOLE_LOGGING    // Comment out this line for traces before the finishing of the constructor
 
-using CommandLine;
 using Microsoft.ApplicationInsights.Profiler.Shared.Samples;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
 using Microsoft.Extensions.Logging;
-using System.Collections.Concurrent;
 using System.Diagnostics.Tracing;
 
 namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 
+/// <summary>
+/// Thin <see cref="EventListener"/> that dispatches to a list of <see cref="IEventSourceHandler"/>
+/// strategies. Each handler owns the source-specific knowledge (which source to bind to, which
+/// keywords / FilterAndPayloadSpecs to enable it with, how to interpret incoming events).
+/// </summary>
 internal class TraceSessionListener : EventListener
 {
-    // OpenTelemetry-SDK event source event ids.
-    static class EventId
-    {
-        public const int RequestStart = 24;
-        public const int RequestStop = 25;
-    }
+    // Kept here as the public surface relied on by DiagnosticsClientTraceConfiguration and similar.
+    public const string OpenTelemetrySDKEventSourceName = OpenTelemetrySdkEventSourceHandler.EventSourceName;
+    public const string DiagnosticSourceEventSourceName = DiagnosticSourceEventSourceHandler.EventSourceName;
 
-    public const string OpenTelemetrySDKEventSourceName = "OpenTelemetry-Sdk";
-    public const string DiagnosticSourceEventSourceName = "Microsoft-Diagnostics-DiagnosticSource";
     private readonly ISerializationProvider _serializer;
     private readonly SampleCollector _sampleCollector;
     private readonly ILogger<TraceSessionListener> _logger;
+    private readonly IReadOnlyList<IEventSourceHandler> _handlers;
     private readonly ManualResetEventSlim _ctorWaitHandle = new(false);
-    private volatile bool _hasActivityReported = false;
 
     public SampleActivityContainer? SampleActivities => _sampleCollector?.SampleActivities;
-
-    private readonly ConcurrentDictionary<string, byte> _startedActivityIds = new();
 
     public TraceSessionListener(
         ISerializationProvider serializer,
         SampleCollector sampleCollector,
+        IEnumerable<IEventSourceHandler> handlers,
         ILogger<TraceSessionListener> logger)
     {
         logger.LogTrace("Trace session listener ctor.");
@@ -41,6 +38,7 @@ internal class TraceSessionListener : EventListener
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         _sampleCollector = sampleCollector ?? throw new ArgumentNullException(nameof(sampleCollector));
+        _handlers = (handlers ?? throw new ArgumentNullException(nameof(handlers))).ToArray();
         _ctorWaitHandle.Set();
         logger.LogTrace("Trace session listener created.");
     }
@@ -49,11 +47,10 @@ internal class TraceSessionListener : EventListener
     {
         // This event might trigger before the constructor is done.
         TryLogDebug($"Event source creating: {eventSource.Name}");
-        // Dispatch this onto a different thread to avoid holding the thread to finish 
-        // the constructor
+        // Dispatch onto a different thread to avoid holding the thread that is finishing the constructor.
         Task.Run(() =>
         {
-            _ = HandleEventSourceCreated(eventSource).ConfigureAwait(false);
+            _ = HandleEventSourceCreatedAsync(eventSource).ConfigureAwait(false);
         });
         TryLogDebug($"Event source created: {eventSource.Name}");
     }
@@ -64,13 +61,15 @@ internal class TraceSessionListener : EventListener
 
         try
         {
-            if (!string.Equals(eventData.EventSource.Name, OpenTelemetrySDKEventSourceName, StringComparison.Ordinal) &&
-                !string.Equals(eventData.EventSource.Name, DiagnosticSourceEventSourceName, StringComparison.Ordinal))
+            // Handlers are few; a linear scan is cheaper than a dictionary lookup.
+            foreach (IEventSourceHandler handler in _handlers)
             {
-                return;
+                if (handler.CanHandle(eventData.EventSource))
+                {
+                    handler.OnEventWritten(eventData);
+                    return;
+                }
             }
-
-            OnRichPayloadEventWritten(eventData);
         }
         catch (Exception ex)
         {
@@ -80,81 +79,9 @@ internal class TraceSessionListener : EventListener
         }
     }
 
-    /// <summary>
-    /// Parses the rich payload EventSource event, adapter it and pump it into the Relay EventSource.
-    /// </summary>
-    /// <param name="eventData"></param>
-    public void OnRichPayloadEventWritten(EventWrittenEventArgs eventData)
+    private async Task HandleEventSourceCreatedAsync(EventSource eventSource)
     {
-        _logger.LogTrace("[{Source}] {Action} - ActivityId: {activityId}, EventName: {eventName}, Keywords: {keyWords}, OpCode: {opCode}",
-            eventData.EventSource.Name,
-            nameof(OnRichPayloadEventWritten),
-            eventData.ActivityId,
-            eventData.EventName,
-            eventData.Keywords,
-            eventData.Opcode);
-
-        if (string.IsNullOrEmpty(eventData.EventName))
-        {
-            return;
-        }
-
-        object? payload = eventData.Payload;
-        if (payload is null)
-        {
-            _logger.LogWarning("Unexpected empty payload.");
-            return;
-        }
-
-        if (string.Equals(eventData.EventSource.Name, OpenTelemetrySDKEventSourceName, StringComparison.Ordinal) &&
-            (eventData.EventId == EventId.RequestStart || eventData.EventId == EventId.RequestStop))
-        {
-            string requestName = eventData.GetPayload<string>("name") ?? "Unknown";
-            string id = eventData.GetPayload<string>("id") ?? throw new InvalidDataException("id payload is missing.");
-
-            (string operationId, string requestId) = ExtractKeyIds(id);
-
-            if (eventData.EventId == 24) // Started
-            {
-                //HandleRequestStart(eventData, requestName, requestId, operationId, id);
-                return;
-            }
-
-            if (eventData.EventId == 25) // Stopped
-            {
-                //HandleRequestStop(eventData, requestName, requestId, operationId, id);
-                return;
-            }
-        }
-
-        // handles DiagnosticSourceEventSource
-        if (string.Equals(eventData.EventSource.Name, DiagnosticSourceEventSourceName, StringComparison.Ordinal) &&
-            (eventData.EventName.EndsWith("Start") || eventData.EventName.EndsWith("Stop")))
-        {
-            string requestName = eventData.GetPayload<string>("ActivityName") ?? "Unknown";
-            var arguments = eventData.GetPayload<System.Object[]>("Arguments") ?? throw new InvalidDataException("Argument payload is missing");
-            // Fixing the CS7036 error by replacing the incorrect 'Find' method with 'FirstOrDefault' from LINQ
-            var updatedArguments = arguments.Select(argument =>
-                argument.Cast<IDictionary<string, object>>());
-
-            string id = TryGetIdFromArguments(updatedArguments) ?? throw new InvalidDataException("Id argument is missing.");
-            (string operationId, string requestId) = ExtractKeyIds(id);
-            if (eventData.EventName.EndsWith("Start"))
-            {
-                HandleRequestStart(eventData, requestName, requestId, operationId, id);
-                return;
-            }
-            if (eventData.EventName.EndsWith("Stop"))
-            {
-                HandleRequestStop(eventData, requestName, requestId, operationId, id);
-                return;
-            }
-        }
-    }
-
-    private async Task HandleEventSourceCreated(EventSource eventSource)
-    {
-        // This has to be the very first statement to making sure the objects are constructed.
+        // This has to be the very first statement to ensure handlers/logger are constructed.
         _ctorWaitHandle.Wait();
 
         try
@@ -162,121 +89,19 @@ internal class TraceSessionListener : EventListener
             _logger.LogDebug("Got manual trigger for source: {name}", eventSource.Name);
 
             await Task.Yield();
-            if (string.Equals(eventSource.Name, OpenTelemetrySDKEventSourceName, StringComparison.OrdinalIgnoreCase))
+
+            foreach (IEventSourceHandler handler in _handlers)
             {
-                EventKeywords keywordsMask = (EventKeywords)0x0000F;
-                _logger.LogDebug("Enabling EventSource: {eventSourceName}", eventSource.Name);
-                EnableEvents(eventSource, EventLevel.Verbose, keywordsMask);
-            }
-            else if (eventSource.Name == "System.Threading.Tasks.TplEventSource")
-            {
-                // Activity IDs aren't enabled by default.
-                // Enabling Keyword 0x80 on the TplEventSource turns them on
-                EnableEvents(eventSource, EventLevel.LogAlways, (EventKeywords)0x80);
-            }
-            else if (eventSource.Name == DiagnosticSourceEventSourceName)
-            {
-                EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)0xffffffffffff, new Dictionary<string, string>
+                if (handler.CanHandle(eventSource))
                 {
-                    ["FilterAndPayloadSpecs"] = "[AS]*"
-                });
+                    handler.Enable(this, eventSource);
+                    return;
+                }
             }
         }
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Error enabling event source: {name}", eventSource.Name);
-        }
-    }
-
-    private bool IsInterestingRequest(string requestName)
-    {
-        // We only are interested capturing Http In requests.
-        // Http request out, for example, from HttpClient will be excluded.
-        return string.Equals("Microsoft.AspNetCore.Hosting.HttpRequestIn", requestName, StringComparison.Ordinal);
-    }
-
-    private void HandleRequestStart(EventWrittenEventArgs eventData, string requestName, string requestId, string operationId, string id)
-    {
-        Guid currentActivityId = eventData.ActivityId;
-        bool isDebugLoggingEnabled = _logger.IsEnabled(LogLevel.Debug);
-        if (isDebugLoggingEnabled)
-        {
-            _logger.LogDebug("Request started: Activity Id: {activityId}", currentActivityId);
-        }
-
-        if (!IsInterestingRequest(requestName))
-        {
-            if (isDebugLoggingEnabled)
-            {
-                _logger.LogDebug("Drop uninteresting request by name: {requestName}, id: {id}", requestName, id);
-            }
-
-            // Do not relay this event since it is not interesting.
-            return;
-        }
-
-        // Interesting request
-
-        if (isDebugLoggingEnabled)
-        {
-            _logger.LogDebug("Interesting start activity, name: {name}, id: {id}", requestName, id);
-        }
-
-        // Note to the _startedActivityIds bag, so that when stop happens, it knows to match.
-        if (!_startedActivityIds.TryAdd(id, default))
-        {
-            _logger.LogWarning("Failed to add started activity. Activity by id {id} already exists? Please report a bug.", id);
-        }
-
-        if (isDebugLoggingEnabled)
-        {
-            _logger.LogDebug("Set current thread activity id: {activityId}", currentActivityId);
-        }
-        EventSource.SetCurrentThreadActivityId(currentActivityId);
-        AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStart(
-            name: requestName,
-            id: id,
-            requestId: requestId,
-            operationId: operationId);
-    }
-
-    private void HandleRequestStop(EventWrittenEventArgs eventData, string requestName, string requestId, string operationId, string id)
-    {
-        bool isDebugLoggingEnabled = _logger.IsEnabled(LogLevel.Debug);
-        Guid currentActivityId = eventData.ActivityId;
-
-        if (isDebugLoggingEnabled)
-        {
-            _logger.LogDebug("Request stopped: Activity Id: {activityId}", currentActivityId);
-        }
-
-        if (!_startedActivityIds.TryRemove(id, out _))
-        {
-            if (isDebugLoggingEnabled)
-            {
-                _logger.LogDebug("No start activity found for this stop activity. Request name: {requestName}, id: {id}", requestName, id);
-            }
-
-            // No interesting start activity captured, it then doesn't make sense to just capture the stop.
-            return;
-        }
-
-        if (isDebugLoggingEnabled)
-        {
-            _logger.LogDebug("Interesting activity found. Name: {name}, id: {id}", requestName, id);
-            _logger.LogDebug("Set current thread activity id: {activityId}", currentActivityId);
-        }
-
-        // Interesting start activity was captured, relay this stop activity.
-        EventSource.SetCurrentThreadActivityId(currentActivityId);
-
-        AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStop(
-            name: requestName, id: id, requestId: requestId, operationId: operationId);
-
-        if (!_hasActivityReported && _logger.IsEnabled(LogLevel.Information))
-        {
-            _logger.LogInformation("Activity detected.");
-            _hasActivityReported = true;
         }
     }
 
@@ -296,38 +121,5 @@ internal class TraceSessionListener : EventListener
             return;
         }
         _logger.LogDebug(message);
-    }
-
-    // id example: 00-4dee62c12eaa9efca3d1f0565f3efda6-b3c470a7ee10c13b-01
-    private static (string operationId, string requestId) ExtractKeyIds(string id)
-    {
-        string[] tokens = id.Split(['-'], StringSplitOptions.RemoveEmptyEntries);
-
-        // It at least contains 3 parts.
-        if (tokens.Length < 3)
-        {
-            throw new InvalidDataException(FormattableString.Invariant($"Id shall have at least 3 sections separated by `-`. Actual id: {id}"));
-        }
-
-        return (tokens[1], tokens[2]);
-    }
-
-    private static string TryGetIdFromArguments(IEnumerable<IDictionary<string, object>> arguments)
-    {
-        foreach (var argument in arguments)
-        {
-            var values = argument.Values.ToList();
-            if (values.Count > 1 && values[0].ToString() == "Id")
-            {
-                var idValue = values[1].ToString();
-
-                if (!string.IsNullOrEmpty(idValue))
-                {
-                    return idValue;
-                }
-            }
-        }
-
-        return string.Empty;
     }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -24,6 +24,9 @@ internal class TraceSessionListener : EventListener
     // Typed as array (not IReadOnlyList<>) so the foreach in OnEventWritten uses the no-alloc
     // array enumerator — this is a hot path.
     private readonly IEventSourceHandler[] _handlers;
+    // Field initializer (runs before the base EventListener ctor) — important because the base
+    // ctor synchronously dispatches OnEventSourceCreated for every existing EventSource, and
+    // those callbacks rely on this handle being non-null.
     private readonly ManualResetEventSlim _ctorWaitHandle = new(false);
     private volatile bool _disposed;
 
@@ -81,10 +84,16 @@ internal class TraceSessionListener : EventListener
 
     private async Task HandleEventSourceCreatedAsync(EventSource eventSource)
     {
+        // Yield FIRST so we detach from the caller's thread before doing anything that could
+        // block. The caller may be the base EventListener ctor (enumerating pre-existing
+        // EventSources synchronously) — blocking on _ctorWaitHandle on that thread would
+        // deadlock, since only our derived ctor body (which hasn't run yet) can Set the handle.
+        await Task.Yield();
+
         try
         {
-            // Wait until the constructor is finished — but bail out cheaply if we've been disposed
-            // before the handle is signaled (avoids ObjectDisposedException on the wait handle).
+            // Wait until the derived constructor is finished — but bail out cheaply if we've been
+            // disposed before the handle is signaled (avoids ObjectDisposedException on the wait).
             if (_disposed)
             {
                 return;
@@ -97,10 +106,13 @@ internal class TraceSessionListener : EventListener
 
             _logger.LogDebug("Got manual trigger for source: {name}", eventSource.Name);
 
-            await Task.Yield();
-
             foreach (IEventSourceHandler handler in _handlers)
             {
+                // Re-check before each Enable — Dispose may race with us and tear down the listener.
+                if (_disposed)
+                {
+                    return;
+                }
                 if (handler.CanHandle(eventSource))
                 {
                     handler.Enable(this, eventSource);

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -1,8 +1,7 @@
-#define CONSOLE_LOGGING
-#undef CONSOLE_LOGGING    // Comment out this line for traces before the finishing of the constructor
+// Uncomment the following line to enable Console-based fallback logging for early ctor traces.
+// #define CONSOLE_LOGGING
 
 using Microsoft.ApplicationInsights.Profiler.Shared.Samples;
-using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics.Tracing;
 
@@ -16,19 +15,21 @@ namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 internal class TraceSessionListener : EventListener
 {
     // Kept here as the public surface relied on by DiagnosticsClientTraceConfiguration and similar.
+    // Note: SDK casing preserved for backward compatibility with existing references.
     public const string OpenTelemetrySDKEventSourceName = OpenTelemetrySdkEventSourceHandler.EventSourceName;
     public const string DiagnosticSourceEventSourceName = DiagnosticSourceEventSourceHandler.EventSourceName;
 
-    private readonly ISerializationProvider _serializer;
     private readonly SampleCollector _sampleCollector;
     private readonly ILogger<TraceSessionListener> _logger;
-    private readonly IReadOnlyList<IEventSourceHandler> _handlers;
+    // Typed as array (not IReadOnlyList<>) so the foreach in OnEventWritten uses the no-alloc
+    // array enumerator — this is a hot path.
+    private readonly IEventSourceHandler[] _handlers;
     private readonly ManualResetEventSlim _ctorWaitHandle = new(false);
+    private volatile bool _disposed;
 
     public SampleActivityContainer? SampleActivities => _sampleCollector?.SampleActivities;
 
     public TraceSessionListener(
-        ISerializationProvider serializer,
         SampleCollector sampleCollector,
         IEnumerable<IEventSourceHandler> handlers,
         ILogger<TraceSessionListener> logger)
@@ -36,7 +37,6 @@ internal class TraceSessionListener : EventListener
         logger.LogTrace("Trace session listener ctor.");
 
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         _sampleCollector = sampleCollector ?? throw new ArgumentNullException(nameof(sampleCollector));
         _handlers = (handlers ?? throw new ArgumentNullException(nameof(handlers))).ToArray();
         _ctorWaitHandle.Set();
@@ -47,18 +47,18 @@ internal class TraceSessionListener : EventListener
     {
         // This event might trigger before the constructor is done.
         TryLogDebug($"Event source creating: {eventSource.Name}");
-        // Dispatch onto a different thread to avoid holding the thread that is finishing the constructor.
-        Task.Run(() =>
-        {
-            _ = HandleEventSourceCreatedAsync(eventSource).ConfigureAwait(false);
-        });
+        // HandleEventSourceCreatedAsync detaches from this thread on its first await; no Task.Run needed.
+        // The method swallows all its own exceptions, so the discarded Task can't escape unobserved.
+        _ = HandleEventSourceCreatedAsync(eventSource);
         TryLogDebug($"Event source created: {eventSource.Name}");
     }
 
+    /// <summary>
+    /// Dispatches each event to the first handler whose <see cref="IEventSourceHandler.CanHandle"/>
+    /// returns true. EventSource names are unique, so first-match is sufficient.
+    /// </summary>
     protected override void OnEventWritten(EventWrittenEventArgs eventData)
     {
-        _logger.LogTrace("OnEventWritten by {eventSource}", eventData.EventSource.Name);
-
         try
         {
             // Handlers are few; a linear scan is cheaper than a dictionary lookup.
@@ -81,11 +81,20 @@ internal class TraceSessionListener : EventListener
 
     private async Task HandleEventSourceCreatedAsync(EventSource eventSource)
     {
-        // This has to be the very first statement to ensure handlers/logger are constructed.
-        _ctorWaitHandle.Wait();
-
         try
         {
+            // Wait until the constructor is finished — but bail out cheaply if we've been disposed
+            // before the handle is signaled (avoids ObjectDisposedException on the wait handle).
+            if (_disposed)
+            {
+                return;
+            }
+            _ctorWaitHandle.Wait();
+            if (_disposed)
+            {
+                return;
+            }
+
             _logger.LogDebug("Got manual trigger for source: {name}", eventSource.Name);
 
             await Task.Yield();
@@ -99,14 +108,27 @@ internal class TraceSessionListener : EventListener
                 }
             }
         }
+        catch (ObjectDisposedException)
+        {
+            // Raced with Dispose() — ignore.
+        }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "Error enabling event source: {name}", eventSource.Name);
+            _logger.LogError(ex, "Error enabling event source: {name}", eventSource.Name);
         }
     }
 
     public override void Dispose()
     {
+        _disposed = true;
+        // Signal any waiter so it can observe _disposed and exit promptly.
+        try
+        {
+            _ctorWaitHandle.Set();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
         _ctorWaitHandle.Dispose();
         base.Dispose();
     }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListenerFactory.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListenerFactory.cs
@@ -5,13 +5,6 @@ namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 
 internal class TraceSessionListenerFactory
 {
-    // Internal, undocumented kill switch. Lets us A/B the two request-event sources during the
-    // migration away from OpenTelemetry-Sdk's RequestStart/Stop toward DiagnosticSource.
-    // Accepted values (case-insensitive): "ds" | "otel" | "both". Anything else falls back to default.
-    internal const string RequestSourceEnvVarName = "MICROSOFT_PROFILER_INTERNAL_REQUEST_SOURCE";
-
-    private const RequestSourceMode DefaultRequestSourceMode = RequestSourceMode.DiagnosticSource;
-
     private readonly IServiceProvider _serviceProvider;
 
     public TraceSessionListenerFactory(IServiceProvider serviceProvider)
@@ -24,7 +17,7 @@ internal class TraceSessionListenerFactory
         ILogger<TraceSessionListenerFactory> logger = _serviceProvider
             .GetRequiredService<ILogger<TraceSessionListenerFactory>>();
 
-        RequestSourceMode mode = ReadRequestSourceMode(logger);
+        RequestSourceMode mode = RequestSourceModeResolver.Resolve(logger);
         logger.LogInformation("Request event source mode: {mode}", mode);
 
         // One RequestActivityRelay per listener lifetime, shared across this listener's handlers so that
@@ -47,30 +40,5 @@ internal class TraceSessionListenerFactory
         handlers.Add(ActivatorUtilities.CreateInstance<TplEventSourceHandler>(_serviceProvider));
 
         return ActivatorUtilities.CreateInstance<TraceSessionListener>(_serviceProvider, (IEnumerable<IEventSourceHandler>)handlers);
-    }
-
-    private static RequestSourceMode ReadRequestSourceMode(ILogger logger)
-    {
-        string? raw = Environment.GetEnvironmentVariable(RequestSourceEnvVarName);
-        if (string.IsNullOrWhiteSpace(raw))
-        {
-            return DefaultRequestSourceMode;
-        }
-
-        return raw.Trim().ToLowerInvariant() switch
-        {
-            "ds" => RequestSourceMode.DiagnosticSource,
-            "otel" => RequestSourceMode.OpenTelemetrySdk,
-            "both" => RequestSourceMode.Both,
-            _ => LogUnrecognizedAndUseDefault(logger, raw),
-        };
-    }
-
-    private static RequestSourceMode LogUnrecognizedAndUseDefault(ILogger logger, string raw)
-    {
-        logger.LogWarning(
-            "Unrecognized value '{value}' for {envVar}; falling back to {default}. Expected: ds | otel | both.",
-            raw, RequestSourceEnvVarName, DefaultRequestSourceMode);
-        return DefaultRequestSourceMode;
     }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListenerFactory.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListenerFactory.cs
@@ -11,6 +11,19 @@ internal class TraceSessionListenerFactory
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
     }
 
-    public TraceSessionListener Create() 
-        => ActivatorUtilities.CreateInstance<TraceSessionListener>(_serviceProvider);
+    public TraceSessionListener Create()
+    {
+        // One RequestActivityRelay per listener lifetime, shared across this listener's handlers so that
+        // a Start emitted by one source can correlate with a Stop emitted by another.
+        RequestActivityRelay relay = ActivatorUtilities.CreateInstance<RequestActivityRelay>(_serviceProvider);
+
+        IEventSourceHandler[] handlers =
+        [
+            ActivatorUtilities.CreateInstance<OpenTelemetrySdkEventSourceHandler>(_serviceProvider, relay),
+            ActivatorUtilities.CreateInstance<DiagnosticSourceEventSourceHandler>(_serviceProvider, relay),
+            ActivatorUtilities.CreateInstance<TplEventSourceHandler>(_serviceProvider),
+        ];
+
+        return ActivatorUtilities.CreateInstance<TraceSessionListener>(_serviceProvider, (IEnumerable<IEventSourceHandler>)handlers);
+    }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListenerFactory.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListenerFactory.cs
@@ -1,9 +1,17 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 
 internal class TraceSessionListenerFactory
 {
+    // Internal, undocumented kill switch. Lets us A/B the two request-event sources during the
+    // migration away from OpenTelemetry-Sdk's RequestStart/Stop toward DiagnosticSource.
+    // Accepted values (case-insensitive): "ds" | "otel" | "both". Anything else falls back to default.
+    internal const string RequestSourceEnvVarName = "MICROSOFT_PROFILER_INTERNAL_REQUEST_SOURCE";
+
+    private const RequestSourceMode DefaultRequestSourceMode = RequestSourceMode.DiagnosticSource;
+
     private readonly IServiceProvider _serviceProvider;
 
     public TraceSessionListenerFactory(IServiceProvider serviceProvider)
@@ -13,17 +21,56 @@ internal class TraceSessionListenerFactory
 
     public TraceSessionListener Create()
     {
+        ILogger<TraceSessionListenerFactory> logger = _serviceProvider
+            .GetRequiredService<ILogger<TraceSessionListenerFactory>>();
+
+        RequestSourceMode mode = ReadRequestSourceMode(logger);
+        logger.LogInformation("Request event source mode: {mode}", mode);
+
         // One RequestActivityRelay per listener lifetime, shared across this listener's handlers so that
-        // a Start emitted by one source can correlate with a Stop emitted by another.
+        // a Start emitted by one source can correlate with a Stop emitted by another (when in Both mode).
         RequestActivityRelay relay = ActivatorUtilities.CreateInstance<RequestActivityRelay>(_serviceProvider);
 
-        IEventSourceHandler[] handlers =
-        [
-            ActivatorUtilities.CreateInstance<OpenTelemetrySdkEventSourceHandler>(_serviceProvider, relay),
-            ActivatorUtilities.CreateInstance<DiagnosticSourceEventSourceHandler>(_serviceProvider, relay),
-            ActivatorUtilities.CreateInstance<TplEventSourceHandler>(_serviceProvider),
-        ];
+        List<IEventSourceHandler> handlers = new(capacity: 3);
+
+        if (mode is RequestSourceMode.OpenTelemetrySdk or RequestSourceMode.Both)
+        {
+            handlers.Add(ActivatorUtilities.CreateInstance<OpenTelemetrySdkEventSourceHandler>(_serviceProvider, relay));
+        }
+
+        if (mode is RequestSourceMode.DiagnosticSource or RequestSourceMode.Both)
+        {
+            handlers.Add(ActivatorUtilities.CreateInstance<DiagnosticSourceEventSourceHandler>(_serviceProvider, relay));
+        }
+
+        // TPL is unrelated to the request-source choice; it just propagates activity IDs.
+        handlers.Add(ActivatorUtilities.CreateInstance<TplEventSourceHandler>(_serviceProvider));
 
         return ActivatorUtilities.CreateInstance<TraceSessionListener>(_serviceProvider, (IEnumerable<IEventSourceHandler>)handlers);
+    }
+
+    private static RequestSourceMode ReadRequestSourceMode(ILogger logger)
+    {
+        string? raw = Environment.GetEnvironmentVariable(RequestSourceEnvVarName);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return DefaultRequestSourceMode;
+        }
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "ds" => RequestSourceMode.DiagnosticSource,
+            "otel" => RequestSourceMode.OpenTelemetrySdk,
+            "both" => RequestSourceMode.Both,
+            _ => LogUnrecognizedAndUseDefault(logger, raw),
+        };
+    }
+
+    private static RequestSourceMode LogUnrecognizedAndUseDefault(ILogger logger, string raw)
+    {
+        logger.LogWarning(
+            "Unrecognized value '{value}' for {envVar}; falling back to {default}. Expected: ds | otel | both.",
+            raw, RequestSourceEnvVarName, DefaultRequestSourceMode);
+        return DefaultRequestSourceMode;
     }
 }


### PR DESCRIPTION
Close #70.

## Problem

The OpenTelemetry SDK EventSource is internal and not reliable to depend on. Changes in the SDK can break the profiler without warning.

## Solution

Add DiagnosticSource as an alternative request event source, providing a more stable and supported mechanism for tracking HTTP request activities.

## Changes

- **IEventSourceHandler** — New interface to abstract per-source event handling
- **DiagnosticSourceEventSourceHandler** — Bridges DiagnosticSource events for request tracking
- **OpenTelemetrySdkEventSourceHandler** — Extracted handler for the existing OTel SDK EventSource
- **TplEventSourceHandler** — Extracted handler for TPL EventSource
- **RequestActivityRelay** — Relays request activity information across event sources
- **RequestSourceMode** — Internal kill switch to select the request event source
- **TraceSessionListener** — Simplified by delegating to per-source handlers
- **TraceSessionListenerFactory** — Extended to wire up new handlers and configuration


