### PR TITLE
Fix thread safety and correctness issues in RequestActivityRelay and TraceSessionListener

### DIFF
--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 using System.Diagnostics.Tracing;
+using System.Threading;
 
 namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 
@@ -18,7 +19,7 @@ internal sealed class RequestActivityRelay
 
     private readonly ILogger<RequestActivityRelay> _logger;
     private readonly ConcurrentDictionary<string, byte> _startedActivityIds = new();
-    private volatile bool _hasActivityReported;
+    private int _hasActivityReported;
 
     public RequestActivityRelay(ILogger<RequestActivityRelay> logger)
     {
@@ -70,12 +71,14 @@ internal sealed class RequestActivityRelay
         {
             _logger.LogDebug("Set current thread activity id: {activityId}", currentActivityId);
         }
+        Guid previousActivityId = EventSource.CurrentThreadActivityId;
         EventSource.SetCurrentThreadActivityId(currentActivityId);
         AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStart(
             name: requestName,
             id: id,
             requestId: requestId,
             operationId: operationId);
+        EventSource.SetCurrentThreadActivityId(previousActivityId);
     }
 
     public void HandleRequestStop(EventWrittenEventArgs eventData, string requestName, string requestId, string operationId, string id)
@@ -104,14 +107,15 @@ internal sealed class RequestActivityRelay
             _logger.LogDebug("Set current thread activity id: {activityId}", currentActivityId);
         }
 
+        Guid previousActivityId = EventSource.CurrentThreadActivityId;
         EventSource.SetCurrentThreadActivityId(currentActivityId);
         AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log.RequestStop(
             name: requestName, id: id, requestId: requestId, operationId: operationId);
+        EventSource.SetCurrentThreadActivityId(previousActivityId);
 
-        if (!_hasActivityReported && _logger.IsEnabled(LogLevel.Information))
+        if (Interlocked.CompareExchange(ref _hasActivityReported, 1, 0) == 0 && _logger.IsEnabled(LogLevel.Information))
         {
             _logger.LogInformation("Activity detected.");
-            _hasActivityReported = true;
         }
     }
 
@@ -119,11 +123,11 @@ internal sealed class RequestActivityRelay
     //                                ver  trace-id (operationId)         span-id (requestId) flags
     public static (string requestId, string operationId) ExtractKeyIds(string id)
     {
-        string[] tokens = id.Split(['-'], StringSplitOptions.RemoveEmptyEntries);
+        string[] tokens = id.Split('-');
 
-        if (tokens.Length < 3)
+        if (tokens.Length != 4 || string.IsNullOrEmpty(tokens[1]) || string.IsNullOrEmpty(tokens[2]))
         {
-            throw new InvalidDataException(FormattableString.Invariant($"Id shall have at least 3 sections separated by `-`. Actual id: {id}"));
+            throw new InvalidDataException(FormattableString.Invariant($"Id shall have exactly 4 sections separated by `-` with non-empty trace-id and span-id. Actual id: {id}"));
         }
 
         return (requestId: tokens[2], operationId: tokens[1]);

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -41,9 +41,15 @@ internal class TraceSessionListener : EventListener
 
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _sampleCollector = sampleCollector ?? throw new ArgumentNullException(nameof(sampleCollector));
-        _handlers = (handlers ?? throw new ArgumentNullException(nameof(handlers))).ToArray();
-        _ctorWaitHandle.Set();
-        logger.LogTrace("Trace session listener created.");
+        try
+        {
+            _handlers = (handlers ?? throw new ArgumentNullException(nameof(handlers))).ToArray();
+            logger.LogTrace("Trace session listener created.");
+        }
+        finally
+        {
+            _ctorWaitHandle.Set();
+        }
     }
 
     protected override void OnEventSourceCreated(EventSource eventSource)


### PR DESCRIPTION
## Changes

### RequestActivityRelay.cs
- **Fix `_hasActivityReported` race condition** — Replace `volatile bool` with `int` + `Interlocked.CompareExchange` for atomic check-and-set, ensuring "Activity detected." is logged exactly once
- **Restore activity ID after EventSource calls** — Save and restore `CurrentThreadActivityId` around `RequestStart`/`RequestStop` to prevent activity ID leaking to other work on the same thread
- **Stricter W3C trace ID validation** — `ExtractKeyIds` now requires exactly 4 dash-separated tokens with non-empty trace-id and span-id, matching the W3C Trace Context spec

### TraceSessionListener.cs
- **Constructor safety** — Wrap handler initialization in try/finally so `_ctorWaitHandle.Set()` is always called, even if the constructor throws — prevents `HandleEventSourceCreatedAsync` tasks from deadlocking