### PR TITLE
Improve uploader logging: always surface errors, deprecate UploaderEnvironment

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,6 +73,7 @@ Test projects use **xUnit** with **Moq** for mocking.
 - **C# 12 / netstandard2.1** — library projects target `netstandard2.1` with `LangVersion` 12.0, nullable enabled.
 - **InternalsVisibleTo** — test projects access internals via `InternalsVisibleTo` with a test signing key.
 - **Symbolic links** — the repo uses symlinks. On Windows, clone with `git config core.symlinks true` and run `git reset --hard` in an admin prompt.
+- **Dependency injection** — all services use constructor injection. Never use `new` to create a service that could be DI-resolved. Services are created via `ActivatorUtilities.CreateInstance` in factories (e.g., `OutOfProcCallerFactory`), which automatically resolves DI-registered dependencies alongside runtime parameters.
 - **Git workflow** — never amend commits; always append new commits.
 - **Do not modify `ServiceProfiler/src/ServiceProfiler.EventPipe/`** — this path is inside the ServiceProfiler submodule and contains a legacy copy of the uploader and client code. Both the OTel and classic profiler builds use `src/ServiceProfiler.EventPipe.Upload/` (in the main repo) as the uploader source. Changes under the submodule's `ServiceProfiler.EventPipe` path are almost certainly wrong — the code there is not referenced by either build.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,6 +74,7 @@ Test projects use **xUnit** with **Moq** for mocking.
 - **InternalsVisibleTo** — test projects access internals via `InternalsVisibleTo` with a test signing key.
 - **Symbolic links** — the repo uses symlinks. On Windows, clone with `git config core.symlinks true` and run `git reset --hard` in an admin prompt.
 - **Git workflow** — never amend commits; always append new commits.
+- **Do not modify `ServiceProfiler/src/ServiceProfiler.EventPipe/`** — this path is inside the ServiceProfiler submodule and contains a legacy copy of the uploader and client code. Both the OTel and classic profiler builds use `src/ServiceProfiler.EventPipe.Upload/` (in the main repo) as the uploader source. Changes under the submodule's `ServiceProfiler.EventPipe` path are almost certainly wrong — the code there is not referenced by either build.
 
 ## Developer Setup
 

--- a/docs/Configurations.md
+++ b/docs/Configurations.md
@@ -29,8 +29,8 @@ This document summarizes configuration options exposed via `UserConfigurationBas
 | UploadMode | enum | OnSuccess | Options: Never, OnSuccess, Always. Use non-default only for debugging. |
 | PreserveTraceFile | bool | false | Keeps local trace after successful upload. |
 | LocalCacheFolder | string | OS temp path | Override temp directory for trace staging. |
-| SkipEndpointCertificateValidation | bool | false | Disables TLS validation. Only for secure, controlled test environments. |
-| UploaderEnvironment | string | "Production" | Tag to indicate environment (e.g., "Canary"). |
+| SkipEndpointCertificateValidation | bool | false | **Deprecated.** No longer supported by the ProfilerClient pipeline. |
+| UploaderEnvironment | string | "Production" | **Deprecated.** Uploader warnings and errors are now always surfaced automatically. Use standard `Logging__LogLevel__` configuration for deeper diagnostics. |
 
 ## Random / Triggered Profiling
 
@@ -98,7 +98,7 @@ Example: overhead=0.01, duration=0.5 min (30s) → (60 * 0.01)/0.5 = 1.2 session
 ## Safety Checklist
 
 - Production: Keep `AllowsCrash = false`.
-- Do not disable certificate validation outside isolated test networks.
+- Do not use `SkipEndpointCertificateValidation` — it is deprecated and no longer functional.
 - Review storage footprint if `PreserveTraceFile = true`.
 - Validate custom providers in staging before production rollout.
 

--- a/pr.draft.md
+++ b/pr.draft.md
@@ -1,82 +1,63 @@
 # PR Title
 
-**Migrate from stamp frontend (IProfilerFrontendClient) to diagnostics ingestion service (IProfilerClient)**
+**Improve uploader logging: always surface errors, deprecate UploaderEnvironment**
 
 # PR Description
 
 ## Summary
 
-Replace the legacy stamp frontend client (`IProfilerFrontendClient`) with the new Azure Monitor Diagnostics ingestion service (`IProfilerClient` / `ProfilerClient`) for both settings retrieval and trace upload paths. This applies to both the Classic (App Insights SDK) and OTel (OpenTelemetry) profiler packages.
+Fix uploader logging so that errors and warnings always surface in the parent process logs without requiring any configuration. Deprecate the broken `UploaderEnvironment` setting.
 
-## Motivation
+## Problem
 
-The stamp frontend is being retired in favor of the diagnostics ingestion service. This migration:
-- Simplifies the upload flow from 3 steps (GetStampId → GetEtlUploadAccess → ReportFinish) to 2 steps (GetUploadToken → Commit)
-- Uses the v2 generic artifact path instead of the legacy ETL-specific path
-- Emits v2 `ServiceProfilerIndex` and `ServiceProfilerSample` custom events compatible with the Portal UX
+The uploader runs as a separate process, making it hard to debug. The existing `UploaderEnvironment` setting was intended to control uploader logging but had two compounding issues:
+
+1. In Production mode, `logging.ClearProviders()` removed all providers with no replacement — the uploader produced zero stdout, silently swallowing errors
+2. Even when logging was enabled (via `UploaderEnvironment=Development`), the parent process logged all captured stdout at `LogDebug` level, invisible at the default `Information` threshold
 
 ## Changes
 
-### Upload Path
-- Replace 3-step stamp flow with 2-step ingestion flow (`GetProfilerArtifactUploadTokenAsync` → `CommitProfilerArtifactAsync`)
-- Derive deterministic artifact ID from `sessionId + machineName` via `XxHash128` for retry idempotency without cross-machine collisions
-- Capture `StampId` from the server's `AcceptedArtifact` commit response
-- Upload blob with `overwrite: true` for retry safety
-- Add `ArtifactId` and `TriggerTime` to blob metadata
+### New `SubprocessLogForwarder` service
+- Parses SimpleConsole single-line prefixes (`info:`, `warn:`, `fail:`, `crit:`, `dbug:`, `trce:`) and re-emits each line at the matching `LogLevel`
+- Continuation lines (e.g., stack traces) inherit the previous line's level
+- Injected into `OutOfProcCaller` to replace the single `LogDebug` dump
+- Unit tested with 11 test cases covering prefix parsing, multi-line output, continuation lines, and edge cases
 
-### Settings Path
-- `RemoteSettingsServiceBase` now accepts `IProfilerClient` instead of `IProfilerFrontendClient`
+### Uploader `Program.cs`
+- Always registers `SimpleConsole` with `SingleLine = true` at `Trace` minimum level
+- Suppresses `Microsoft.Hosting.Lifetime` logs (removes misleading "Application is shutting down" noise)
+- Removed `IsDevelopment()` conditional and the `Console.WriteLine` debug message
 
-### Custom Events (ServiceProfilerIndex / ServiceProfilerSample)
-- Use v2 `ArtifactLocationProperties` format (AppId + ArtifactId) instead of v1 (stampId + machineName + sessionId)
-- Emit all 5 v2 properties required by the Portal UX: `StampId`, `DataCube`, `ArtifactKind`, `ArtifactId`, `Extension`
-- Remove unused v1-only properties: `FileId`, `MachineName`, `ProcessId`
-- Pass `artifactId` through `IPCAdditionalData` to ensure consistency between agent and uploader
+### Deprecation
+- `UserConfigurationBase.UploaderEnvironment` marked with `[Obsolete]`
+- Removed `--environment` CLI argument from the uploader (`UploadContext`, `UploadContextModel`)
+- Removed `Environment` property from `TraceUploaderProxy` upload context construction
 
-### Interface & DI
-- Extract `IProfilerClient` interface in submodule for testability and DI
-- Add `STRICT_INTERNAL` guards to `ProfilerClient`, `ProfilerClientOptions`, `ProfilerDiagnosticsClientOptions`
-- Register `IProfilerClient` (not concrete `ProfilerClient`) in DI for both Classic and OTel
-- Extract `IProfilerClientFactory` for the uploader with required `AgentString` (fallback + warning for non-named-pipe path)
+### Copilot Instructions
+- Added warning that `ServiceProfiler/src/ServiceProfiler.EventPipe/` must not be modified — both profiler builds use `src/ServiceProfiler.EventPipe.Upload/` from the main repo
 
-### User Agent
-- Differentiate user agent strings: `ServiceProfilerEventPipeAgent-OTel`, `ServiceProfilerEventPipeAgent-Classic`, `EventPipeUploader`
+## Files Changed
 
-### Cleanup
-- Delete `IProfilerFrontendClientBuilder`, `ProfilerFrontendClientBuilder`
-- Remove old `FrontendClient` symlinks, add `Azure.Monitor.Diagnostics` symlinks
-- Update all 3 solution files
-- Deprecate `SkipEndpointCertificateValidation` with `[Obsolete]` + warning log
-- Extract `ArtifactIdDerivation` to shared utility
-
-### NuGet Dependencies
-- Add `Microsoft.Extensions.Configuration.Binder` to OTel nuspec
-- Add `System.IO.Hashing` to both OTel and Classic nuspecs
-
-### Tests
-- Migrate all tests from `IProfilerFrontendClient` to `IProfilerClient` / `IProfilerClientFactory`
-- Delete obsolete `ProfilerFrontendClientBuilderTests`
-- All 107 tests pass (Upload: 20, Client: 58, AI.Profiler: 29)
-
-## Submodule Changes (ServiceProfiler)
-
-PR: [#739994](https://devdiv.visualstudio.com/OnlineServices/_git/ServiceProfiler/pullrequest/739994)
-Tag: `otel-profiler-ref-95ea672c8`
-
-- Add `IProfilerClient` interface with `STRICT_INTERNAL` guard
-- Add `STRICT_INTERNAL` guards to `ProfilerClient`, `ProfilerClientOptions`, `ProfilerDiagnosticsClientOptions`
-- Add `InternalsVisibleTo` entries for consuming assemblies
-- Add `CommitProfilerArtifactAsync` metadata overload to `IProfilerClient`
+| File | Change |
+|------|--------|
+| `SubprocessLogForwarder.cs` | **New** — log-level-aware forwarding service |
+| `OutOfProcCaller.cs` | Uses `SubprocessLogForwarder` instead of `LogDebug` dump |
+| `Program.cs` (uploader) | Always registers SimpleConsole; suppresses hosting lifetime |
+| `UploadContext.cs` (uploader) | Removed `--environment` CLI option |
+| `UploadContextModel.cs` | Removed `Environment` property and serialization |
+| `UserConfigurationBase.cs` | `[Obsolete]` on `UploaderEnvironment` |
+| `TraceUploaderProxy.cs` | Stopped setting `Environment` on upload context |
+| `Profiler.Shared.csproj` | Added `InternalsVisibleTo` for test project |
+| `SubprocessLogForwarderTests.cs` | **New** — 11 test cases |
+| `UploadContextModelTests.cs` | Removed `--environment` from expected strings |
+| `copilot-instructions.md` | Submodule boundary warning |
 
 ## Testing
 
 - Both Classic and OTel private packages build successfully
-- All 107 unit tests pass
-- End-to-end tested with `examples/aspnetcore-aisdk3` against live Azure Monitor
-- Verified `ServiceProfilerIndex` and `ServiceProfilerSample` custom events emit correct v2 format
-- Verified Portal query joins samples with index events correctly
-- Code reviewed across 8 passes using Claude Opus 4.7, Claude Sonnet, and GPT 5.5
+- All tests pass: 21 (OTel) + 58 (Client) + 20 (Upload) = 99 total
+- Code reviewed across 4 passes using GPT-5.5 and Claude Opus 4.7 (2 clean iterations)
 
 ## Breaking Changes
 
-- `SkipEndpointCertificateValidation` is deprecated and no longer functional (logs warning if set)
+- `UploaderEnvironment` is deprecated with `[Obsolete]`. Setting it still compiles but has no effect. Users who suppressed `CS0618` globally will see no impact. Users with `TreatWarningsAsErrors` can suppress with `#pragma warning disable CS0618`.

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/UploadContextModel.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/UploadContextModel.cs
@@ -18,7 +18,6 @@ internal class UploadContextModel
     private const string PipeNameKeyName = "pipeName";
     private const string RoleNameKeyName = "roleName";
     private const string TriggerTypeKeyName = "trigger";
-    private const string EnvironmentKeyName = "environment";
     private const string TraceFileFormatKeyName = "traceFileFormat";
 
 
@@ -45,8 +44,6 @@ internal class UploadContextModel
     public string? PipeName { get; init; }
 
     public string? RoleName { get; init; }
-
-    public string Environment { get; init; } = "Production";
 
     public string? TriggerType { get; init; }
 
@@ -82,11 +79,6 @@ internal class UploadContextModel
         if (!string.IsNullOrEmpty(TriggerType))
         {
             argumentLine += $@" --{TriggerTypeKeyName} ""{TriggerType}""";
-        }
-
-        if (!string.IsNullOrEmpty(Environment))
-        {
-            argumentLine += $@" --{EnvironmentKeyName} ""{Environment}""";
         }
 
         argumentLine += $@" --{TraceFileFormatKeyName} ""{TraceFileFormat}""";

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/UserConfigurationBase.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/UserConfigurationBase.cs
@@ -147,6 +147,7 @@ public abstract class UserConfigurationBase
     /// <summary>
     /// Get or sets the environment for the uploader.
     /// </summary>
+    [Obsolete("UploaderEnvironment is no longer used. Uploader warnings and errors are now always surfaced. Use standard Logging__LogLevel__ configuration for deeper diagnostics. Suppress this warning with #pragma warning disable CS0618.")]
     public string UploaderEnvironment { get; set; } = "Production";
 
     /// <summary>

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Microsoft.ApplicationInsights.Profiler.Shared.csproj
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Microsoft.ApplicationInsights.Profiler.Shared.csproj
@@ -15,6 +15,7 @@
 
     <!--Tests-->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(TestPublicKey)" />
+    <InternalsVisibleTo Include="Azure.Monitor.OpenTelemetry.Profiler.Tests" Key="$(TestPublicKey)" />
     <InternalsVisibleTo Include="ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests" Key="$(TestPublicKey)" />
     <InternalsVisibleTo Include="ServiceProfiler.EventPipe.Client.Tests" Key="$(TestPublicKey)" />
   </ItemGroup>

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/OutOfProcCaller.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/OutOfProcCaller.cs
@@ -21,10 +21,11 @@ internal class OutOfProcCaller : IOutOfProcCaller
     public OutOfProcCaller(
         string fileName,
         string arguments,
+        SubprocessLogForwarder logForwarder,
         ILogger<OutOfProcCaller> logger)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _logForwarder = new SubprocessLogForwarder(logger);
+        _logForwarder = logForwarder ?? throw new ArgumentNullException(nameof(logForwarder));
         
         if (string.IsNullOrEmpty(fileName))
         {

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/OutOfProcCaller.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/OutOfProcCaller.cs
@@ -14,6 +14,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.UploaderProxy;
 internal class OutOfProcCaller : IOutOfProcCaller
 {
     private readonly ILogger _logger;
+    private readonly SubprocessLogForwarder _logForwarder;
     private readonly string _fileName;
     private readonly string _arguments;    
 
@@ -23,6 +24,7 @@ internal class OutOfProcCaller : IOutOfProcCaller
         ILogger<OutOfProcCaller> logger)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logForwarder = new SubprocessLogForwarder(logger);
         
         if (string.IsNullOrEmpty(fileName))
         {
@@ -56,7 +58,7 @@ internal class OutOfProcCaller : IOutOfProcCaller
 
         if (!string.IsNullOrWhiteSpace(stdout))
         {
-            _logger.LogDebug("Uploader stdout: {stdout}", stdout);
+            _logForwarder.Forward(stdout);
         }
         if (!string.IsNullOrWhiteSpace(stderr))
         {

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/SubprocessLogForwarder.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/SubprocessLogForwarder.cs
@@ -25,7 +25,7 @@ internal sealed class SubprocessLogForwarder
 {
     private readonly ILogger _logger;
 
-    public SubprocessLogForwarder(ILogger logger)
+    public SubprocessLogForwarder(ILogger<SubprocessLogForwarder> logger)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/SubprocessLogForwarder.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/SubprocessLogForwarder.cs
@@ -96,7 +96,7 @@ internal sealed class SubprocessLogForwarder
         }
         if (prefix.SequenceEqual("info".AsSpan()))
         {
-            return LogLevel.Debug;
+            return LogLevel.Information;
         }
         if (prefix.SequenceEqual("dbug".AsSpan()))
         {

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/SubprocessLogForwarder.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/SubprocessLogForwarder.cs
@@ -1,0 +1,112 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.UploaderProxy;
+
+/// <summary>
+/// Parses structured console output (SimpleConsole single-line format) from a subprocess
+/// and re-emits each line through <see cref="ILogger"/> at the corresponding log level.
+/// </summary>
+/// <remarks>
+/// The SimpleConsole formatter with SingleLine=true produces lines like:
+///   info: Namespace.Class[0] Message text
+///   warn: Namespace.Class[0] Warning message
+///   fail: Namespace.Class[0] Error message
+///
+/// This class recognizes the standard prefixes (trce, dbug, info, warn, fail, crit)
+/// and maps them to <see cref="LogLevel"/> values. Continuation lines (no recognized prefix)
+/// inherit the level of the preceding line.
+/// </remarks>
+internal sealed class SubprocessLogForwarder
+{
+    private readonly ILogger _logger;
+
+    public SubprocessLogForwarder(ILogger logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Splits <paramref name="output"/> into lines and logs each at the level
+    /// indicated by its prefix.
+    /// </summary>
+    public void Forward(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return;
+        }
+
+        LogLevel currentLevel = LogLevel.Debug;
+
+        foreach (string line in output.Split('\n'))
+        {
+            ReadOnlySpan<char> trimmed = line.AsSpan().TrimEnd('\r');
+            if (trimmed.IsWhiteSpace())
+            {
+                continue;
+            }
+
+            LogLevel parsed = ParseLogLevel(trimmed);
+            if (parsed != LogLevel.None)
+            {
+                currentLevel = parsed;
+            }
+
+            _logger.Log(currentLevel, "[Uploader] {line}", trimmed.ToString());
+        }
+    }
+
+    /// <summary>
+    /// Parses the log level from a Systemd/SimpleConsole-formatted line.
+    /// Returns <see cref="LogLevel.None"/> if no recognized prefix is found.
+    /// </summary>
+    internal static LogLevel ParseLogLevel(ReadOnlySpan<char> line)
+    {
+        // The prefix format is "level: " where level is exactly 4 chars.
+        // Minimum valid line: "info: X" = 7 chars.
+        if (line.Length < 6)
+        {
+            return LogLevel.None;
+        }
+
+        // Check for the colon at position 4.
+        if (line[4] != ':')
+        {
+            return LogLevel.None;
+        }
+
+        ReadOnlySpan<char> prefix = line.Slice(0, 4);
+
+        if (prefix.SequenceEqual("crit".AsSpan()))
+        {
+            return LogLevel.Critical;
+        }
+        if (prefix.SequenceEqual("fail".AsSpan()))
+        {
+            return LogLevel.Error;
+        }
+        if (prefix.SequenceEqual("warn".AsSpan()))
+        {
+            return LogLevel.Warning;
+        }
+        if (prefix.SequenceEqual("info".AsSpan()))
+        {
+            return LogLevel.Debug;
+        }
+        if (prefix.SequenceEqual("dbug".AsSpan()))
+        {
+            return LogLevel.Debug;
+        }
+        if (prefix.SequenceEqual("trce".AsSpan()))
+        {
+            return LogLevel.Trace;
+        }
+
+        return LogLevel.None;
+    }
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/TraceUploaderProxy.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/TraceUploaderProxy.cs
@@ -106,7 +106,6 @@ internal class TraceUploaderProxy : ITraceUploader
             PipeName = namedPipeName,
             RoleName = roleName,
             TriggerType = triggerType,
-            Environment = _userConfiguration.UploaderEnvironment,
             TraceFileFormat = _traceFileFormatDefinition.TraceFileFormatName,
         };
 

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/ServiceCollectionExtensions.cs
@@ -203,6 +203,7 @@ internal static class ServiceCollectionExtensions
         services.AddTransient<IUploaderPathProvider, UploaderPathProvider>();
 
         services.AddSingleton<IOutOfProcCallerFactory, OutOfProcCallerFactory>();
+        services.AddSingleton<SubprocessLogForwarder>();
 
         services.AddTransient<ITraceUploader, TraceUploaderProxy>();
     }

--- a/src/ServiceProfiler.EventPipe.Upload/Program.cs
+++ b/src/ServiceProfiler.EventPipe.Upload/Program.cs
@@ -45,18 +45,16 @@ namespace Microsoft.ApplicationInsights.Profiler.Uploader
                 })
                 .ConfigureLogging((context, logging) =>
                 {
-                    // Clear all previously registered providers.
+                    // Use SimpleConsole in single-line mode so the parent process can
+                    // parse each line's prefix (info:/warn:/fail:/etc.) and forward it
+                    // at the correct log level.
                     logging.ClearProviders();
-
-                    if (context.HostingEnvironment.IsDevelopment())
+                    logging.AddSimpleConsole(configure =>
                     {
-                        Console.WriteLine("Uploader Hosting Environment is set to: Development.");
-                        logging.AddSimpleConsole(configure =>
-                        {
-                            configure.SingleLine = true;
-                        }).SetMinimumLevel(LogLevel.Trace);
-                        logging.AddDebug().SetMinimumLevel(LogLevel.Trace);
-                    }
+                        configure.SingleLine = true;
+                    });
+                    logging.SetMinimumLevel(LogLevel.Trace);
+                    logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.None);
                 })
                 .ConfigureServices((hostContext, services) =>
                 {

--- a/src/ServiceProfiler.EventPipe.Upload/UploadContext.cs
+++ b/src/ServiceProfiler.EventPipe.Upload/UploadContext.cs
@@ -31,9 +31,6 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Contracts
         private const char TriggerTypeShortKeyName = 'u';
         private const string TriggerTypeKeyName = "trigger";
 
-        private const char EnvironmentShortKeyName = 'e';
-        private const string EnvironmentKeyName = "environment";
-
         private const char TraceFileFormatShortKeyName = 'f';
         private const string TraceFileFormatKeyName = "traceFileFormat";
 
@@ -73,9 +70,6 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Contracts
         [Option(RoleNameShortKeyName, RoleNameKeyName, Required = false, HelpText = "Cloud role name of the customer app recorded in the telemetry.")]
         public string? RoleName { get; set; }
 
-        [Option(EnvironmentShortKeyName, EnvironmentKeyName, Required = false, HelpText = "Environment for Uploader.", Default = "Production")]
-        public string? Environment { get; set; }
-
         [Option(TriggerTypeShortKeyName, TriggerTypeKeyName, Required = false, HelpText = "Type of trigger that caused the collection of the trace.")]
         public string? TriggerType { get; set; }
 
@@ -112,11 +106,6 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Contracts
             if (!string.IsNullOrEmpty(TriggerType))
             {
                 argumentLine += $@" --{TriggerTypeKeyName} ""{TriggerType}""";
-            }
-
-            if (!string.IsNullOrEmpty(Environment))
-            {
-                argumentLine += $@" --{EnvironmentKeyName} ""{Environment}"" ";
             }
 
             argumentLine += $@" --{TraceFileFormatKeyName} ""{TraceFileFormat}""";

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/Contracts/UserConfiguration.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/Contracts/UserConfiguration.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Contracts;
 ///         "PreserveTraceFile": false,
 ///         "LocalCacheFolder": "/tmp/",
 ///         "UploadMode": "OnSuccess",
-///         "UploaderEnvironment": "Production",
+///         "UploaderEnvironment": "Production", // Deprecated - no longer used
 ///         "NamedPipe": {
 ///             "ConnectionTimeout": "00:00:30"
 ///         },

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
@@ -259,6 +259,7 @@ internal static class ServiceCollectionExtensions
         services.AddTransient<IUploaderPathProvider, UploaderPathProvider>();
 
         services.AddSingleton<IOutOfProcCallerFactory, OutOfProcCallerFactory>();
+        services.AddSingleton<SubprocessLogForwarder>();
 
         services.AddTransient<ITraceUploader, TraceUploaderProxy>();
 

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/SubprocessLogForwarderTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/SubprocessLogForwarderTests.cs
@@ -1,0 +1,134 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.UploaderProxy;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Tests;
+
+public class SubprocessLogForwarderTests
+{
+    [Theory]
+    [InlineData("crit:", LogLevel.Critical)]
+    [InlineData("fail:", LogLevel.Error)]
+    [InlineData("warn:", LogLevel.Warning)]
+    [InlineData("info:", LogLevel.Debug)]
+    [InlineData("dbug:", LogLevel.Debug)]
+    [InlineData("trce:", LogLevel.Trace)]
+    public void ParseLogLevel_RecognizedPrefix_ReturnsCorrectLevel(string prefix, LogLevel expected)
+    {
+        string line = $"{prefix} Some.Namespace[0] A log message";
+        LogLevel result = SubprocessLogForwarder.ParseLogLevel(line.AsSpan());
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData("some random text without prefix")]
+    [InlineData("INFO: uppercase is not recognized")]
+    public void ParseLogLevel_UnrecognizedOrEmpty_ReturnsNone(string line)
+    {
+        LogLevel result = SubprocessLogForwarder.ParseLogLevel(line.AsSpan());
+        Assert.Equal(LogLevel.None, result);
+    }
+
+    [Fact]
+    public void Forward_EmptyOrWhitespace_DoesNotLog()
+    {
+        var logger = new FakeLogger();
+        var forwarder = new SubprocessLogForwarder(logger);
+
+        forwarder.Forward("");
+        forwarder.Forward("   ");
+        forwarder.Forward(null!);
+
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
+    public void Forward_SingleLine_LogsAtCorrectLevel()
+    {
+        var logger = new FakeLogger();
+        var forwarder = new SubprocessLogForwarder(logger);
+
+        forwarder.Forward("warn: MyApp.Service[0] Something is wrong");
+
+        Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, logger.Entries[0].Level);
+        Assert.Contains("Something is wrong", logger.Entries[0].Message);
+    }
+
+    [Fact]
+    public void Forward_MultipleLines_EachAtCorrectLevel()
+    {
+        var logger = new FakeLogger();
+        var forwarder = new SubprocessLogForwarder(logger);
+
+        string output = string.Join(Environment.NewLine, new[]
+        {
+            "info: MyApp.Upload[0] Upload started",
+            "warn: MyApp.Upload[0] Retrying upload",
+            "fail: MyApp.Upload[0] Upload failed",
+        });
+
+        forwarder.Forward(output);
+
+        Assert.Equal(3, logger.Entries.Count);
+        Assert.Equal(LogLevel.Debug, logger.Entries[0].Level);     // info → Debug
+        Assert.Equal(LogLevel.Warning, logger.Entries[1].Level);
+        Assert.Equal(LogLevel.Error, logger.Entries[2].Level);
+    }
+
+    [Fact]
+    public void Forward_ContinuationLines_InheritPreviousLevel()
+    {
+        var logger = new FakeLogger();
+        var forwarder = new SubprocessLogForwarder(logger);
+
+        string output = string.Join(Environment.NewLine, new[]
+        {
+            "fail: MyApp.Upload[0] Something failed",
+            "      System.Exception: Details here",
+            "         at MyApp.Upload.Method()",
+        });
+
+        forwarder.Forward(output);
+
+        Assert.Equal(3, logger.Entries.Count);
+        // Continuation lines inherit the previous level (Error)
+        Assert.All(logger.Entries, e => Assert.Equal(LogLevel.Error, e.Level));
+    }
+
+    [Fact]
+    public void Forward_SkipsBlankLines()
+    {
+        var logger = new FakeLogger();
+        var forwarder = new SubprocessLogForwarder(logger);
+
+        string output = "info: MyApp[0] First\n\n\nwarn: MyApp[0] Second";
+
+        forwarder.Forward(output);
+
+        Assert.Equal(2, logger.Entries.Count);
+    }
+
+    /// <summary>
+    /// Simple in-memory logger for testing.
+    /// </summary>
+    private sealed class FakeLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+}

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/SubprocessLogForwarderTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/SubprocessLogForwarderTests.cs
@@ -118,7 +118,7 @@ public class SubprocessLogForwarderTests
     /// <summary>
     /// Simple in-memory logger for testing.
     /// </summary>
-    private sealed class FakeLogger : ILogger
+    private sealed class FakeLogger : ILogger<SubprocessLogForwarder>
     {
         public List<(LogLevel Level, string Message)> Entries { get; } = new();
 

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/SubprocessLogForwarderTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/SubprocessLogForwarderTests.cs
@@ -13,7 +13,7 @@ public class SubprocessLogForwarderTests
     [InlineData("crit:", LogLevel.Critical)]
     [InlineData("fail:", LogLevel.Error)]
     [InlineData("warn:", LogLevel.Warning)]
-    [InlineData("info:", LogLevel.Debug)]
+    [InlineData("info:", LogLevel.Information)]
     [InlineData("dbug:", LogLevel.Debug)]
     [InlineData("trce:", LogLevel.Trace)]
     public void ParseLogLevel_RecognizedPrefix_ReturnsCorrectLevel(string prefix, LogLevel expected)
@@ -77,7 +77,7 @@ public class SubprocessLogForwarderTests
         forwarder.Forward(output);
 
         Assert.Equal(3, logger.Entries.Count);
-        Assert.Equal(LogLevel.Debug, logger.Entries[0].Level);     // info → Debug
+        Assert.Equal(LogLevel.Information, logger.Entries[0].Level);     // info → Information
         Assert.Equal(LogLevel.Warning, logger.Entries[1].Level);
         Assert.Equal(LogLevel.Error, logger.Entries[2].Level);
     }

--- a/tests/ServiceProfiler.EventPipe.Client.Tests/UploadContextModelTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Client.Tests/UploadContextModelTests.cs
@@ -31,7 +31,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --environment ""Production"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --traceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -59,7 +59,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --environment ""Production"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --traceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -87,7 +87,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --environment ""Production"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --traceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -116,7 +116,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --roleName ""{roleName}"" --environment ""Production"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --roleName ""{roleName}"" --traceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -144,7 +144,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --environment ""Production"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --traceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -172,7 +172,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --environment ""Production"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --traceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -201,7 +201,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --trigger ""{trigger}"" --environment ""Production"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --trigger ""{trigger}"" --traceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -229,7 +229,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --environment ""Production"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --traceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -257,7 +257,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --environment ""Production"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --traceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }


### PR DESCRIPTION
## Summary

Fix uploader logging so that errors and warnings always surface in the parent process logs without requiring any configuration. Deprecate the broken `UploaderEnvironment` setting.

Close #78.

## Problem

The uploader runs as a separate process, making it hard to debug. The existing `UploaderEnvironment` setting was intended to control uploader logging but had two compounding issues:

1. In Production mode, `logging.ClearProviders()` removed all providers with no replacement — the uploader produced zero stdout, silently swallowing errors
2. Even when logging was enabled (via `UploaderEnvironment=Development`), the parent process logged all captured stdout at `LogDebug` level, invisible at the default `Information` threshold

## Changes

### New `SubprocessLogForwarder` service
- Parses SimpleConsole single-line prefixes (`info:`, `warn:`, `fail:`, `crit:`, `dbug:`, `trce:`) and re-emits each line at the matching `LogLevel`
- Continuation lines (e.g., stack traces) inherit the previous line's level
- Injected into `OutOfProcCaller` to replace the single `LogDebug` dump
- Unit tested with 11 test cases covering prefix parsing, multi-line output, continuation lines, and edge cases

### Uploader `Program.cs`
- Always registers `SimpleConsole` with `SingleLine = true` at `Trace` minimum level
- Suppresses `Microsoft.Hosting.Lifetime` logs (removes misleading "Application is shutting down" noise)
- Removed `IsDevelopment()` conditional and the `Console.WriteLine` debug message

### Deprecation
- `UserConfigurationBase.UploaderEnvironment` marked with `[Obsolete]`
- Removed `--environment` CLI argument from the uploader (`UploadContext`, `UploadContextModel`)
- Removed `Environment` property from `TraceUploaderProxy` upload context construction

### Copilot Instructions
- Added warning that `ServiceProfiler/src/ServiceProfiler.EventPipe/` must not be modified — both profiler builds use `src/ServiceProfiler.EventPipe.Upload/` from the main repo

## Files Changed

| File | Change |
|------|--------|
| `SubprocessLogForwarder.cs` | **New** — log-level-aware forwarding service |
| `OutOfProcCaller.cs` | Uses `SubprocessLogForwarder` instead of `LogDebug` dump |
| `Program.cs` (uploader) | Always registers SimpleConsole; suppresses hosting lifetime |
| `UploadContext.cs` (uploader) | Removed `--environment` CLI option |
| `UploadContextModel.cs` | Removed `Environment` property and serialization |
| `UserConfigurationBase.cs` | `[Obsolete]` on `UploaderEnvironment` |
| `TraceUploaderProxy.cs` | Stopped setting `Environment` on upload context |
| `Profiler.Shared.csproj` | Added `InternalsVisibleTo` for test project |
| `SubprocessLogForwarderTests.cs` | **New** — 11 test cases |
| `UploadContextModelTests.cs` | Removed `--environment` from expected strings |
| `copilot-instructions.md` | Submodule boundary warning |

## Testing

- Both Classic and OTel private packages build successfully
- All tests pass: 21 (OTel) + 58 (Client) + 20 (Upload) = 99 total
- Code reviewed across 4 passes using GPT-5.5 and Claude Opus 4.7 (2 clean iterations)

## Breaking Changes

- `UploaderEnvironment` is deprecated with `[Obsolete]`. Setting it still compiles but has no effect. Users who suppressed `CS0618` globally will see no impact. Users with `TreatWarningsAsErrors` can suppress with `#pragma warning disable CS0618`.