### PR TITLE
Bump submodule and package overrides to 10.0.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,10 +5,10 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <PropertyGroup>
-    <_SystemDiagnosticsDiagnosticSourceVersion>9.0.8</_SystemDiagnosticsDiagnosticSourceVersion>
-    <_SystemIOHashingVersion>9.0.0</_SystemIOHashingVersion>
-    <_SystemMemoryDataVersion>9.0.0</_SystemMemoryDataVersion>
-    <_SystemSecurityCryptographyProtectedDataVersion>9.0.0</_SystemSecurityCryptographyProtectedDataVersion>
+    <_SystemDiagnosticsDiagnosticSourceVersion>10.0.0</_SystemDiagnosticsDiagnosticSourceVersion>
+    <_SystemIOHashingVersion>10.0.0</_SystemIOHashingVersion>
+    <_SystemMemoryDataVersion>10.0.0</_SystemMemoryDataVersion>
+    <_SystemSecurityCryptographyProtectedDataVersion>10.0.0</_SystemSecurityCryptographyProtectedDataVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Update="System.Diagnostics.DiagnosticSource" Version="$(_SystemDiagnosticsDiagnosticSourceVersion)" />

--- a/src/ServiceProfiler.EventPipe.Otel/Directory.Packages.props
+++ b/src/ServiceProfiler.EventPipe.Otel/Directory.Packages.props
@@ -10,8 +10,8 @@
     <_AzureMonitorOpenTelemetryExporterVersion>1.4.0</_AzureMonitorOpenTelemetryExporterVersion>
     <_MicrosoftDiagnosticsNETCoreClientVersion>0.2.621003</_MicrosoftDiagnosticsNETCoreClientVersion>
     <_SystemCollectionsImmutableVersion>8.0.0</_SystemCollectionsImmutableVersion>
-    <_SystemMemoryDataVersion>9.0.0</_SystemMemoryDataVersion>
-    <_SystemSecurityCryptographyProtectedDataVersion>9.0.0</_SystemSecurityCryptographyProtectedDataVersion>
+    <_SystemMemoryDataVersion>10.0.0</_SystemMemoryDataVersion>
+    <_SystemSecurityCryptographyProtectedDataVersion>10.0.0</_SystemSecurityCryptographyProtectedDataVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Update ServiceProfiler submodule to latest main (95dd93adc) which brings Microsoft.Extensions.*, System.Text.Json, System.Text.Encodings.Web, and System.Diagnostics.DiagnosticSource to 10.0.0.

Bump remaining package version overrides in src/Directory.Packages.props and OTel Directory.Packages.props to 10.0.0:
- System.Diagnostics.DiagnosticSource
- System.IO.Hashing
- System.Memory.Data
- System.Security.Cryptography.ProtectedData

This prevents NU1109 downgrade errors where System.Memory.Data 10.0.0 transitively requires System.Text.Json >= 10.0.0 and System.Text.Encodings.Web >= 10.0.0.