### PR TITLE
Bump System.Text.Json and System.Text.Encodings.Web to 10.0.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,11 +9,15 @@
     <_SystemIOHashingVersion>10.0.0</_SystemIOHashingVersion>
     <_SystemMemoryDataVersion>10.0.0</_SystemMemoryDataVersion>
     <_SystemSecurityCryptographyProtectedDataVersion>10.0.0</_SystemSecurityCryptographyProtectedDataVersion>
+    <_SystemTextEncodingsWebVersion>10.0.0</_SystemTextEncodingsWebVersion>
+    <_SystemTextJsonVersion>10.0.0</_SystemTextJsonVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Update="System.Diagnostics.DiagnosticSource" Version="$(_SystemDiagnosticsDiagnosticSourceVersion)" />
     <PackageVersion Include="System.IO.Hashing" Version="$(_SystemIOHashingVersion)" />
     <PackageVersion Update="System.Memory.Data" Version="$(_SystemMemoryDataVersion)" />
     <PackageVersion Update="System.Security.Cryptography.ProtectedData" Version="$(_SystemSecurityCryptographyProtectedDataVersion)" />
+    <PackageVersion Update="System.Text.Encodings.Web" Version="$(_SystemTextEncodingsWebVersion)" />
+    <PackageVersion Update="System.Text.Json" Version="$(_SystemTextJsonVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
System.Memory.Data 10.0.0 requires System.Text.Json >= 10.0.0 but the central package versions pinned it to 9.0.8, causing NU1109 package downgrade errors in Release builds.

Bump both System.Text.Json and System.Text.Encodings.Web (its dependency) to 10.0.0 in root Directory.Packages.props, and add explicit overrides in src/Directory.Packages.props to keep them aligned with the other 10.0.0 System.* packages already pinned there.