### PR TITLE
Add Azure Service Bus processor activity support and fix EventSource ActivityTracker nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ As an alternative to the manual walkthrough above, you can use Copilot to enable
 
 ## Next
 
+- [Profiling Azure Service Bus Applications](./docs/ServiceBusSetup.md)
 - [Setup the Role name](./docs/SetupCloudRoleName.md)
 - [Configuration Guide](./docs/Configurations.md)
 - [CPU Usage Monitoring](./docs/CpuUsageMonitoring.md)

--- a/docs/ServiceBusSetup.md
+++ b/docs/ServiceBusSetup.md
@@ -1,0 +1,74 @@
+# Profiling Azure Service Bus Applications
+
+This guide explains how to enable the Azure Monitor OpenTelemetry Profiler for applications that process messages from Azure Service Bus using `ServiceBusProcessor` or `ServiceBusSessionProcessor`.
+
+## Prerequisites
+
+- Complete the [Get Started](../Readme.md#get-started) steps first (install packages, call `AddAzureMonitorProfiler()`).
+- Your application uses [`Azure.Messaging.ServiceBus`](https://www.nuget.org/packages/Azure.Messaging.ServiceBus/) to process messages.
+
+## Enable the Azure SDK ActivitySource
+
+The Azure Service Bus SDK's `ActivitySource` is currently marked as experimental. By default, the SDK uses the legacy `DiagnosticListener` path, which the profiler cannot observe. You must opt in to the `ActivitySource`-based instrumentation so the profiler can capture Service Bus request activities.
+
+### Option A: In code (recommended)
+
+Add this line **before** any Azure SDK client is created — typically at the top of `Program.cs`:
+
+```csharp
+AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
+```
+
+**Full example:**
+
+```csharp
+using Azure.Identity;
+using Azure.Messaging.ServiceBus;
+using Azure.Monitor.OpenTelemetry.AspNetCore;
+using Azure.Monitor.OpenTelemetry.Profiler;
+
+// Enable ActivitySource in Azure SDK so the profiler can capture Service Bus activities.
+AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddOpenTelemetry()
+    .UseAzureMonitor()
+    .AddAzureMonitorProfiler();
+
+builder.Services.AddSingleton(new ServiceBusClient(
+    "your-namespace.servicebus.windows.net",
+    new DefaultAzureCredential()));
+
+// Register your hosted service that processes messages...
+builder.Services.AddHostedService<QueueProcessorWorker>();
+
+var host = builder.Build();
+host.Run();
+```
+
+### Option B: Via runtime configuration (no code change)
+
+Add a `runtimeconfig.template.json` file to your project root (next to `.csproj`):
+
+```json
+{
+  "configProperties": {
+    "Azure.Experimental.EnableActivitySource": true
+  }
+}
+```
+
+The MSBuild system merges this into the output `<YourApp>.runtimeconfig.json` at build time. The setting takes effect when the application starts.
+
+> **Note:** This option requires a rebuild after adding the file. If the file is not present at build time, the switch will not be included in the output.
+
+## How it works
+
+When the `ActivitySource` is enabled, the Service Bus SDK emits `System.Diagnostics.Activity` instances for each processed message. The profiler listens for these activities and correlates performance traces (CPU samples, call stacks) with individual message-processing operations — just as it does for incoming HTTP requests in ASP.NET Core.
+
+In Application Insights, you will see profiler traces attached to Service Bus `process` operations, allowing you to inspect the hot path and identify performance bottlenecks in your message handlers.
+
+## Troubleshooting
+
+If you encounter issues with profiling Service Bus applications, please [open an issue](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net/issues/new) with your environment details and relevant log output.

--- a/pr.draft.md
+++ b/pr.draft.md
@@ -1,63 +1,55 @@
 # PR Title
 
-**Improve uploader logging: always surface errors, deprecate UploaderEnvironment**
+**Add Azure Service Bus processor activity support and fix EventSource ActivityTracker nesting**
 
 # PR Description
 
 ## Summary
 
-Fix uploader logging so that errors and warnings always surface in the parent process logs without requiring any configuration. Deprecate the broken `UploaderEnvironment` setting.
+Adds support for capturing Azure Service Bus processor message activities alongside ASP.NET Core HTTP request activities. Also fixes an EventSource ActivityTracker nesting issue that affected relay event ActivityId paths across all profiler variants.
 
-## Problem
+## Motivation
 
-The uploader runs as a separate process, making it hard to debug. The existing `UploaderEnvironment` setting was intended to control uploader logging but had two compounding issues:
-
-1. In Production mode, `logging.ClearProviders()` removed all providers with no replacement — the uploader produced zero stdout, silently swallowing errors
-2. Even when logging was enabled (via `UploaderEnvironment=Development`), the parent process logged all captured stdout at `LogDebug` level, invisible at the default `Information` threshold
+The profiler previously only captured ASP.NET Core HTTP-in request activities. Applications using Azure Service Bus processors had no visibility into message processing performance. This PR extends the profiler to instrument Service Bus processing events, enabling profiling traces for message-driven workloads.
 
 ## Changes
 
-### New `SubprocessLogForwarder` service
-- Parses SimpleConsole single-line prefixes (`info:`, `warn:`, `fail:`, `crit:`, `dbug:`, `trce:`) and re-emits each line at the matching `LogLevel`
-- Continuation lines (e.g., stack traces) inherit the previous line's level
-- Injected into `OutOfProcCaller` to replace the single `LogDebug` dump
-- Unit tested with 11 test cases covering prefix parsing, multi-line output, continuation lines, and edge cases
+### Service Bus support (OTel profiler)
 
-### Uploader `Program.cs`
-- Always registers `SimpleConsole` with `SingleLine = true` at `Trace` minimum level
-- Suppresses `Microsoft.Hosting.Lifetime` logs (removes misleading "Application is shutting down" noise)
-- Removed `IsDevelopment()` conditional and the `Console.WriteLine` debug message
+- **`ServiceBusActivityIdResetListener`** — New `ActivityListener` that resets the thread-local EventSource `ActivityId` when Service Bus processor activities start, preventing the Service Bus SDK's internal activity from contaminating the relay event's `ActivityId` path
+- **`DiagnosticSourceEventSourceHandler`** — Extended to recognize Service Bus processor activity names
+- **`RequestActivityRelay`** — Generalized to handle both HTTP and Service Bus request activities, with deduplication across event source handlers
+- **`TraceSessionListenerFactory`** — Registers the new `ServiceBusActivityIdResetListener` via DI
+- **`DiagnosticsClientTraceConfiguration`** — Added `Azure.Messaging.ServiceBus` EventSource to the EventPipe provider list
 
-### Deprecation
-- `UserConfigurationBase.UploaderEnvironment` marked with `[Obsolete]`
-- Removed `--environment` CLI argument from the uploader (`UploadContext`, `UploadContextModel`)
-- Removed `Environment` property from `TraceUploaderProxy` upload context construction
+### EventSource ActivityTracker fix (all profilers)
 
-### Copilot Instructions
-- Added warning that `ServiceProfiler/src/ServiceProfiler.EventPipe/` must not be modified — both profiler builds use `src/ServiceProfiler.EventPipe.Upload/` from the main repo
+- **`AzureMonitorOpenTelemetryProfilerDataAdapterEventSource`** (OTel) — Added `Task = Tasks.Request` and `ActivityOptions = EventActivityOptions.Disable` on `RequestStart`/`RequestStop` events, preventing EventSource's `ActivityTracker` from pushing/popping the thread's `ActivityId` during `WriteEvent`
+- **`ApplicationInsightsDataRelayEventSource`** (Classic) — Changed `ActivityOptions` from `None` to `Disable`, matching the v3.0 EventSource pattern
+- **`TraceSessionListener` / `TraceSessionListener30`** (Classic) — Save and restore `CurrentThreadActivityId` around relay calls, matching the pattern used by the OTel `RequestActivityRelay`
+- **`SampleActivity.IsValid`** (Shared) — Updated comment to reflect the new invariant; kept `StartsWith` for backward compatibility
 
 ## Files Changed
 
 | File | Change |
 |------|--------|
-| `SubprocessLogForwarder.cs` | **New** — log-level-aware forwarding service |
-| `OutOfProcCaller.cs` | Uses `SubprocessLogForwarder` instead of `LogDebug` dump |
-| `Program.cs` (uploader) | Always registers SimpleConsole; suppresses hosting lifetime |
-| `UploadContext.cs` (uploader) | Removed `--environment` CLI option |
-| `UploadContextModel.cs` | Removed `Environment` property and serialization |
-| `UserConfigurationBase.cs` | `[Obsolete]` on `UploaderEnvironment` |
-| `TraceUploaderProxy.cs` | Stopped setting `Environment` on upload context |
-| `Profiler.Shared.csproj` | Added `InternalsVisibleTo` for test project |
-| `SubprocessLogForwarderTests.cs` | **New** — 11 test cases |
-| `UploadContextModelTests.cs` | Removed `--environment` from expected strings |
-| `copilot-instructions.md` | Submodule boundary warning |
+| `ServiceBusActivityIdResetListener.cs` | **New** — resets EventSource ActivityId for Service Bus activities |
+| `DiagnosticSourceEventSourceHandler.cs` | Recognize Service Bus activity names |
+| `RequestActivityRelay.cs` | Handle HTTP + Service Bus, deduplicate across handlers |
+| `TraceSessionListenerFactory.cs` (OTel) | Register `ServiceBusActivityIdResetListener` |
+| `DiagnosticsClientTraceConfiguration.cs` | Add Service Bus EventSource provider |
+| `AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.cs` | Add `Tasks`, use `Disable` + `Start/Stop` opcodes |
+| `ApplicationInsightsDataRelayEventSource.cs` (Classic) | `ActivityOptions.None` → `Disable` |
+| `TraceSessionListener.cs` (Classic) | Save/restore `CurrentThreadActivityId` |
+| `TraceSessionListener30.cs` (Classic) | Save/restore `CurrentThreadActivityId` |
+| `SampleActivity.cs` (Shared) | Updated validation comment |
 
 ## Testing
 
-- Both Classic and OTel private packages build successfully
-- All tests pass: 21 (OTel) + 58 (Client) + 20 (Upload) = 99 total
-- Code reviewed across 4 passes using GPT-5.5 and Claude Opus 4.7 (2 clean iterations)
+- OTel private package builds successfully
+- Code reviewed with GPT 5.5 and Claude Opus 4.7 (2 consecutive clean iterations per round)
 
-## Breaking Changes
+## Risk
 
-- `UploaderEnvironment` is deprecated with `[Obsolete]`. Setting it still compiles but has no effect. Users who suppressed `CS0618` globally will see no impact. Users with `TreatWarningsAsErrors` can suppress with `#pragma warning disable CS0618`.
+- **Low** — The `EventActivityOptions.Disable` pattern is proven in `ApplicationInsightsDataRelayEventSource30` (used since .NET Core 3.0). The save/restore of `CurrentThreadActivityId` matches the OTel relay's existing pattern.
+- Classic non-30 EventSource change only affects .NET Core 2.x runtime paths (EOL) plus the multi-listener enumeration path.

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/SampleActivity.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/SampleActivity.cs
@@ -43,8 +43,9 @@ internal class SampleActivity
         // There must be start/stop activity id paths
         if (!IsGoodActivityIdPath(StartActivityIdPath, logger)) { return false; }
         if (!IsGoodActivityIdPath(StopActivityIdPath, logger)) { return false; }
-        // Start/Stop activity id path should either be the same (.NET Core 2.x) or the start activity id starts with stop activity id path (.NET Core 3.0).
-        // Notes: this is activity id path for events from Microsoft-ApplicationInsights-DataRelay.
+        // Start/Stop activity id path should be the same now that all relay EventSources
+        // use ActivityOptions.Disable (no ActivityTracker push/pop). StartsWith is kept
+        // for backward compatibility with traces captured before this change.
         if (!StartActivityIdPath!.StartsWith(StopActivityIdPath!, StringComparison.Ordinal)) { return false; }
         if (StartTimeUtc >= StopTimeUtc) { return false; }
         if (Duration.TotalMilliseconds <= 0) { return false; }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/DiagnosticsClientTraceConfiguration.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/DiagnosticsClientTraceConfiguration.cs
@@ -38,8 +38,9 @@ internal class DiagnosticsClientTraceConfiguration : DiagnosticsClientTraceConfi
         }
 
         // Diagnostic Source Event Source — only needed when the DS handler is active.
-        // Narrow FilterAndPayloadSpecs to the exact ASP.NET Core HTTP-in ActivitySource to match the handler;
-        // [AS]* would firehose every ActivitySource in the process (EF Core, HttpClient, custom sources, ...).
+        // Narrow FilterAndPayloadSpecs to the exact ActivitySources we care about (ASP.NET Core HTTP-in
+        // and Azure Service Bus processor) to match the handler; [AS]* would firehose every ActivitySource
+        // in the process (EF Core, HttpClient, custom sources, ...).
         if (mode is RequestSourceMode.DiagnosticSource or RequestSourceMode.Both)
         {
             yield return new EventPipeProvider(TraceSessionListener.DiagnosticSourceEventSourceName, EventLevel.Verbose, keywords: 0xffffffffffff, arguments: new Dictionary<string, string>

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.cs
@@ -10,6 +10,15 @@ internal class AzureMonitorOpenTelemetryProfilerDataAdapterEventSource : EventSo
         public const EventKeywords Operations = (EventKeywords)0x1;
     }
 
+#pragma warning disable CA1724 // Contract by EventSource
+#pragma warning disable CA1034 // Contract by EventSource
+    public static class Tasks
+#pragma warning restore CA1034
+#pragma warning restore CA1724
+    {
+        public const EventTask Request = (EventTask)0x1;
+    }
+
     public const string EventSourceName = "AzureMonitor-OpenTelemetry-Profiler-DataAdapter";
 
     internal static class EventId
@@ -22,17 +31,17 @@ internal class AzureMonitorOpenTelemetryProfilerDataAdapterEventSource : EventSo
     public static AzureMonitorOpenTelemetryProfilerDataAdapterEventSource Log = new();
 #pragma warning restore CA2211 // Non-constant fields should not be visible
 
-    // Explicit Opcode prevents EventSource from auto-inferring Opcode.Start/Stop
-    // based on method names ending in "Start"/"Stop". Without this, the internal
-    // ActivityTracker would push/pop the thread's ActivityId on each WriteEvent,
-    // causing relay events to appear one level deeper than the bridge events.
-    [Event(EventId.RequestStart, Keywords = Keywords.Operations, Opcode = EventOpcode.Info)]
+    // ActivityOptions.Disable prevents EventSource's internal ActivityTracker from
+    // pushing/popping the thread's ActivityId on WriteEvent, which would cause relay
+    // events to appear one level deeper than the bridge events. We keep Opcode.Start/Stop
+    // because the uploader's ActivityListValidator matches events by opcode.
+    [Event(EventId.RequestStart, Keywords = Keywords.Operations, Opcode = EventOpcode.Start, Task = Tasks.Request, ActivityOptions = EventActivityOptions.Disable)]
     public void RequestStart(string name, string id, string requestId, string operationId)
     {
         WriteEvent(EventId.RequestStart, name, id, requestId, operationId);
     }
 
-    [Event(EventId.RequestStop, Keywords = Keywords.Operations, Opcode = EventOpcode.Info)]
+    [Event(EventId.RequestStop, Keywords = Keywords.Operations, Opcode = EventOpcode.Stop, Task = Tasks.Request, ActivityOptions = EventActivityOptions.Disable)]
     public void RequestStop(string name, string id, string requestId, string operationId)
     {
         WriteEvent(EventId.RequestStop, name, id, requestId, operationId);

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.cs
@@ -22,13 +22,17 @@ internal class AzureMonitorOpenTelemetryProfilerDataAdapterEventSource : EventSo
     public static AzureMonitorOpenTelemetryProfilerDataAdapterEventSource Log = new();
 #pragma warning restore CA2211 // Non-constant fields should not be visible
 
-    [Event(EventId.RequestStart, Keywords = Keywords.Operations)]
+    // Explicit Opcode prevents EventSource from auto-inferring Opcode.Start/Stop
+    // based on method names ending in "Start"/"Stop". Without this, the internal
+    // ActivityTracker would push/pop the thread's ActivityId on each WriteEvent,
+    // causing relay events to appear one level deeper than the bridge events.
+    [Event(EventId.RequestStart, Keywords = Keywords.Operations, Opcode = EventOpcode.Info)]
     public void RequestStart(string name, string id, string requestId, string operationId)
     {
         WriteEvent(EventId.RequestStart, name, id, requestId, operationId);
     }
 
-    [Event(EventId.RequestStop, Keywords = Keywords.Operations)]
+    [Event(EventId.RequestStop, Keywords = Keywords.Operations, Opcode = EventOpcode.Info)]
     public void RequestStop(string name, string id, string requestId, string operationId)
     {
         WriteEvent(EventId.RequestStop, name, id, requestId, operationId);

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
@@ -5,9 +5,9 @@ namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 
 /// <summary>
 /// Handler for the <c>Microsoft-Diagnostics-DiagnosticSource</c> EventSource bridge.
-/// Subscribes to ASP.NET Core HTTP-in start/stop diagnostic events via <c>FilterAndPayloadSpecs</c>,
-/// mapping them onto the bridge's <c>Activity1Start</c>/<c>Activity1Stop</c> EventSource events,
-/// then forwards parsed payloads to the shared <see cref="RequestActivityRelay"/>.
+/// Subscribes to ASP.NET Core HTTP-in and Azure Service Bus processor start/stop diagnostic events
+/// via <c>FilterAndPayloadSpecs</c>, mapping them onto the bridge's <c>Activity1Start</c>/<c>Activity1Stop</c>
+/// EventSource events, then forwards parsed payloads to the shared <see cref="RequestActivityRelay"/>.
 /// </summary>
 internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
 {
@@ -42,7 +42,18 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
     //
     // The ActivitySource name is "Microsoft.AspNetCore" (NOT "Microsoft.AspNetCore.Hosting" —
     // that's the ActivityName / OperationName, e.g. "Microsoft.AspNetCore.Hosting.HttpRequestIn").
-    internal const string FilterAndPayloadSpecs = "[AS]Microsoft.AspNetCore/";
+    //
+    // Azure Service Bus processor ActivitySource names are dynamically constructed by the SDK as
+    // "<DiagnosticNamespace>.<ClientType>", e.g. "Azure.Messaging.ServiceBus.ServiceBusProcessor".
+    // The processor creates activities with ActivityKind.Consumer and names like
+    // "ServiceBusProcessor.ProcessMessage" and "ServiceBusSessionProcessor.ProcessSessionMessage".
+    // ActivitySource is enabled by default in Azure.Core 1.36.0+.
+    //
+    // Multiple specs are newline-separated per DiagnosticSourceEventSource convention.
+    internal const string FilterAndPayloadSpecs =
+        "[AS]Microsoft.AspNetCore/\n" +
+        "[AS]Azure.Messaging.ServiceBus.ServiceBusProcessor/\n" +
+        "[AS]Azure.Messaging.ServiceBus.ServiceBusSessionProcessor/";
 
     private readonly RequestActivityRelay _relay;
     private readonly ILogger<DiagnosticSourceEventSourceHandler> _logger;

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
@@ -6,8 +6,9 @@ using System.Threading;
 namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 
 /// <summary>
-/// Tracks in-flight "interesting" request activities (currently ASP.NET Core HTTP-in) and forwards
-/// matched start/stop pairs onto <see cref="AzureMonitorOpenTelemetryProfilerDataAdapterEventSource"/>.
+/// Tracks in-flight "interesting" request activities (ASP.NET Core HTTP-in and Azure Service Bus
+/// processor messages) and forwards matched start/stop pairs onto
+/// <see cref="AzureMonitorOpenTelemetryProfilerDataAdapterEventSource"/>.
 ///
 /// Lives once per <see cref="TraceSessionListener"/> and is shared by every <see cref="IEventSourceHandler"/>
 /// that produces request activities, so a Start emitted by one source can correlate with (or be deduped
@@ -16,6 +17,8 @@ namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 internal sealed class RequestActivityRelay
 {
     private const string AspNetCoreHttpRequestInName = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
+    private const string ServiceBusProcessMessageName = "ServiceBusProcessor.ProcessMessage";
+    private const string ServiceBusProcessSessionMessageName = "ServiceBusSessionProcessor.ProcessSessionMessage";
 
     private readonly ILogger<RequestActivityRelay> _logger;
     private readonly ConcurrentDictionary<string, byte> _startedActivityIds = new();
@@ -27,10 +30,13 @@ internal sealed class RequestActivityRelay
     }
 
     /// <summary>
-    /// We only capture HTTP-in requests. HTTP-out (e.g. HttpClient) is excluded.
+    /// We capture HTTP-in requests and Service Bus processor messages.
+    /// HTTP-out (e.g. HttpClient) and other Service Bus operations (send, receive) are excluded.
     /// </summary>
     private static bool IsInterestingRequest(string requestName)
-        => string.Equals(AspNetCoreHttpRequestInName, requestName, StringComparison.Ordinal);
+        => string.Equals(AspNetCoreHttpRequestInName, requestName, StringComparison.Ordinal)
+        || string.Equals(ServiceBusProcessMessageName, requestName, StringComparison.Ordinal)
+        || string.Equals(ServiceBusProcessSessionMessageName, requestName, StringComparison.Ordinal);
 
     public void HandleRequestStart(EventWrittenEventArgs eventData, string requestName, string requestId, string operationId, string id)
     {

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/ServiceBusActivityIdResetListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/ServiceBusActivityIdResetListener.cs
@@ -35,25 +35,17 @@ internal sealed class ServiceBusActivityIdResetListener : IDisposable
     {
         _listener = new ActivityListener
         {
-            ShouldListenTo = static source =>
+            ShouldListenTo = source =>
                 source.Name == "Azure.Messaging.ServiceBus.ServiceBusProcessor" ||
                 source.Name == "Azure.Messaging.ServiceBus.ServiceBusSessionProcessor",
 
-            // Reset the thread-local EventSource ActivityId in the Sample callback,
-            // NOT in ActivityStarted. The runtime guarantees that ALL Sample callbacks
-            // complete before ANY ActivityStarted callback fires. ActivityStarted
-            // callbacks fire in reverse registration order (last-registered first),
-            // so the bridge's ActivityStarted fires before ours — too late to reset.
-            // Sample callbacks also fire in reverse order, but since the bridge's
-            // Sample has no thread-state side effects, our reset in Sample is
-            // effective regardless of ordering.
-            Sample = static (ref ActivityCreationOptions<ActivityContext> options) =>
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
             {
                 EventSource.SetCurrentThreadActivityId(Guid.Empty);
                 return ActivitySamplingResult.AllDataAndRecorded;
             },
 
-            SampleUsingParentId = static (ref ActivityCreationOptions<string> options) =>
+            SampleUsingParentId = (ref ActivityCreationOptions<string> options) =>
             {
                 EventSource.SetCurrentThreadActivityId(Guid.Empty);
                 return ActivitySamplingResult.AllDataAndRecorded;
@@ -61,7 +53,7 @@ internal sealed class ServiceBusActivityIdResetListener : IDisposable
         };
 
         ActivitySource.AddActivityListener(_listener);
-        logger.LogDebug("Registered ActivityListener to reset EventSource ActivityId for Service Bus processor activities.");
+        logger.LogDebug("Registered ActivityListener for Service Bus processor activities.");
     }
 
     public void Dispose() => _listener.Dispose();

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/ServiceBusActivityIdResetListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/ServiceBusActivityIdResetListener.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
+
+/// <summary>
+/// Registers an <see cref="ActivityListener"/> for Azure Service Bus processor ActivitySources
+/// that resets the thread-local EventSource ActivityId to <see cref="Guid.Empty"/> in the
+/// <see cref="ActivityListener.Sample"/> callback.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This fixes a nesting issue in the <c>DiagnosticSourceEventSource</c> bridge's
+/// <c>Activity1Start</c>/<c>Activity1Stop</c> events. The bridge uses EventSource's thread-local
+/// ActivityId with <see cref="EventOpcode.Start"/> to push a child ActivityId. For async processing
+/// (like Service Bus), the <c>Activity1Stop</c> fires on a different thread, so the Start thread's
+/// ActivityId is never popped. When the thread is reused for the next message, the bridge pushes
+/// under the stale (un-popped) parent, creating a nested tree instead of flat siblings.
+/// </para>
+/// <para>
+/// The reset is performed in the <see cref="ActivityListener.Sample"/> callback rather than
+/// <see cref="ActivityListener.ActivityStarted"/> because the runtime guarantees that ALL
+/// <c>Sample</c> callbacks complete before ANY <c>ActivityStarted</c> callback fires.
+/// <c>ActivityStarted</c> callbacks fire in reverse registration order (last-registered first),
+/// so the bridge's <c>ActivityStarted</c> — which writes the <c>Activity1Start</c> EventSource
+/// event — fires before ours. Resetting in <c>ActivityStarted</c> would be too late.
+/// </para>
+/// </remarks>
+internal sealed class ServiceBusActivityIdResetListener : IDisposable
+{
+    private readonly ActivityListener _listener;
+
+    public ServiceBusActivityIdResetListener(ILogger<ServiceBusActivityIdResetListener> logger)
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = static source =>
+                source.Name == "Azure.Messaging.ServiceBus.ServiceBusProcessor" ||
+                source.Name == "Azure.Messaging.ServiceBus.ServiceBusSessionProcessor",
+
+            // Reset the thread-local EventSource ActivityId in the Sample callback,
+            // NOT in ActivityStarted. The runtime guarantees that ALL Sample callbacks
+            // complete before ANY ActivityStarted callback fires. ActivityStarted
+            // callbacks fire in reverse registration order (last-registered first),
+            // so the bridge's ActivityStarted fires before ours — too late to reset.
+            // Sample callbacks also fire in reverse order, but since the bridge's
+            // Sample has no thread-state side effects, our reset in Sample is
+            // effective regardless of ordering.
+            Sample = static (ref ActivityCreationOptions<ActivityContext> options) =>
+            {
+                EventSource.SetCurrentThreadActivityId(Guid.Empty);
+                return ActivitySamplingResult.AllDataAndRecorded;
+            },
+
+            SampleUsingParentId = static (ref ActivityCreationOptions<string> options) =>
+            {
+                EventSource.SetCurrentThreadActivityId(Guid.Empty);
+                return ActivitySamplingResult.AllDataAndRecorded;
+            },
+        };
+
+        ActivitySource.AddActivityListener(_listener);
+        logger.LogDebug("Registered ActivityListener to reset EventSource ActivityId for Service Bus processor activities.");
+    }
+
+    public void Dispose() => _listener.Dispose();
+}

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -24,6 +24,8 @@ internal class TraceSessionListener : EventListener
     // Typed as array (not IReadOnlyList<>) so the foreach in OnEventWritten uses the no-alloc
     // array enumerator — this is a hot path.
     private readonly IEventSourceHandler[] _handlers;
+    // Owned for disposal — resets EventSource ActivityId for async Service Bus activities.
+    private readonly ServiceBusActivityIdResetListener _resetListener;
     // Field initializer (runs before the base EventListener ctor) — important because the base
     // ctor synchronously dispatches OnEventSourceCreated for every existing EventSource, and
     // those callbacks rely on this handle being non-null.
@@ -35,12 +37,14 @@ internal class TraceSessionListener : EventListener
     public TraceSessionListener(
         SampleCollector sampleCollector,
         IEnumerable<IEventSourceHandler> handlers,
+        ServiceBusActivityIdResetListener resetListener,
         ILogger<TraceSessionListener> logger)
     {
         logger.LogTrace("Trace session listener ctor.");
 
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _sampleCollector = sampleCollector ?? throw new ArgumentNullException(nameof(sampleCollector));
+        _resetListener = resetListener ?? throw new ArgumentNullException(nameof(resetListener));
         try
         {
             _handlers = (handlers ?? throw new ArgumentNullException(nameof(handlers))).ToArray();
@@ -148,6 +152,7 @@ internal class TraceSessionListener : EventListener
         {
         }
         _ctorWaitHandle.Dispose();
+        _resetListener.Dispose();
         base.Dispose();
     }
 

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListenerFactory.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListenerFactory.cs
@@ -20,6 +20,14 @@ internal class TraceSessionListenerFactory
         RequestSourceMode mode = RequestSourceModeResolver.Resolve(logger);
         logger.LogInformation("Request event source mode: {mode}", mode);
 
+        // Register the Service Bus ActivityId reset listener BEFORE any handler that calls
+        // EnableEvents with FilterAndPayloadSpecs. The bridge's internal ActivityListener is
+        // created during EnableEvents, and ActivityStarted callbacks fire in registration order.
+        // Our listener must fire first to reset the thread-local ActivityId before the bridge
+        // pushes a child under a potentially stale parent (async thread reuse issue).
+        ServiceBusActivityIdResetListener resetListener =
+            ActivatorUtilities.CreateInstance<ServiceBusActivityIdResetListener>(_serviceProvider);
+
         // One RequestActivityRelay per listener lifetime, shared across this listener's handlers so that
         // a Start emitted by one source can correlate with a Stop emitted by another (when in Both mode).
         RequestActivityRelay relay = ActivatorUtilities.CreateInstance<RequestActivityRelay>(_serviceProvider);
@@ -39,6 +47,9 @@ internal class TraceSessionListenerFactory
         // TPL is unrelated to the request-source choice; it just propagates activity IDs.
         handlers.Add(ActivatorUtilities.CreateInstance<TplEventSourceHandler>(_serviceProvider));
 
-        return ActivatorUtilities.CreateInstance<TraceSessionListener>(_serviceProvider, (IEnumerable<IEventSourceHandler>)handlers);
+        return ActivatorUtilities.CreateInstance<TraceSessionListener>(
+            _serviceProvider,
+            (IEnumerable<IEventSourceHandler>)handlers,
+            resetListener);
     }
 }

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/EventListeners/ApplicationInsightsDataRelayEventSource.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/EventListeners/ApplicationInsightsDataRelayEventSource.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.EventListeners
 
         public static ApplicationInsightsDataRelayEventSource Log { get; } = new ApplicationInsightsDataRelayEventSource();
 
-        [Event(EventIds.RequestStart, Keywords = Keywords.Request, Level = EventLevel.Verbose, Opcode = EventOpcode.Start, Task = Tasks.Request, ActivityOptions = EventActivityOptions.None)]
+        [Event(EventIds.RequestStart, Keywords = Keywords.Request, Level = EventLevel.Verbose, Opcode = EventOpcode.Start, Task = Tasks.Request, ActivityOptions = EventActivityOptions.Disable)]
         public void RequestStart(
             string id,
             string name,
@@ -68,7 +68,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.EventListeners
             operationId);
         }
 
-        [Event(EventIds.RequestStop, Keywords = Keywords.Request, Level = EventLevel.Verbose, Opcode = EventOpcode.Stop, Task = Tasks.Request, ActivityOptions = EventActivityOptions.None)]
+        [Event(EventIds.RequestStop, Keywords = Keywords.Request, Level = EventLevel.Verbose, Opcode = EventOpcode.Stop, Task = Tasks.Request, ActivityOptions = EventActivityOptions.Disable)]
         public void RequestStop(
             string id,
             string name,

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/EventListeners/TraceSessionListener.cs
@@ -212,6 +212,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.EventListeners
 
         protected virtual void RelayStopRequest(ApplicationInsightsOperationEvent operationEventData, long startTimeUTCTicks, Guid activityId)
         {
+            Guid previousActivityId = EventSource.CurrentThreadActivityId;
             AlignCurrentThreadActivityId(activityId);
             ApplicationInsightsDataRelayEventSource.Log.RequestStop(
                                         operationEventData.EventId.ToString(CultureInfo.InvariantCulture),
@@ -222,10 +223,12 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.EventListeners
                                         operationName: operationEventData.OperationName,
                                         machineName: Environment.MachineName,
                                         operationId: operationEventData.OperationId);
+            ApplicationInsightsDataRelayEventSource.SetCurrentThreadActivityId(previousActivityId);
         }
 
         protected virtual void RelayStartRequest(ApplicationInsightsOperationEvent operationEventData, Guid activityId)
         {
+            Guid previousActivityId = EventSource.CurrentThreadActivityId;
             AlignCurrentThreadActivityId(activityId);
             ApplicationInsightsDataRelayEventSource.Log.RequestStart(
                 operationEventData.EventId.ToString(CultureInfo.InvariantCulture),
@@ -237,6 +240,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.EventListeners
                 operationName: operationEventData.OperationName,
                 machineName: Environment.MachineName,
                 operationId: operationEventData.OperationId);
+            ApplicationInsightsDataRelayEventSource.SetCurrentThreadActivityId(previousActivityId);
         }
 
         private void AppendSampleActivity(SampleActivity activity)

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/EventListeners/TraceSessionListener30.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/EventListeners/TraceSessionListener30.cs
@@ -3,6 +3,7 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.ApplicationInsights.Profiler.Shared.Samples;
@@ -28,6 +29,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.EventListeners
 
         protected override void RelayStartRequest(ApplicationInsightsOperationEvent operationEventData, Guid activityId)
         {
+            Guid previousActivityId = EventSource.CurrentThreadActivityId;
             AlignCurrentThreadActivityId(activityId);
             ApplicationInsightsDataRelayEventSource30.Log.RequestStart(
                 operationEventData.EventId.ToString(CultureInfo.InvariantCulture),
@@ -39,10 +41,12 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.EventListeners
                 operationName: operationEventData.OperationName,
                 machineName: Environment.MachineName,
                 operationId: operationEventData.OperationId);
+            ApplicationInsightsDataRelayEventSource30.SetCurrentThreadActivityId(previousActivityId);
         }
 
         protected override void RelayStopRequest(ApplicationInsightsOperationEvent operationEventData, long startTimeUTCTicks, Guid activityId)
         {
+            Guid previousActivityId = EventSource.CurrentThreadActivityId;
             AlignCurrentThreadActivityId(activityId);
             ApplicationInsightsDataRelayEventSource30.Log.RequestStop(
                 operationEventData.EventId.ToString(CultureInfo.InvariantCulture),
@@ -53,6 +57,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.EventListeners
                 operationName: operationEventData.OperationName,
                 machineName: Environment.MachineName,
                 operationId: operationEventData.OperationId);
+            ApplicationInsightsDataRelayEventSource30.SetCurrentThreadActivityId(previousActivityId);
         }
     }
 }


### PR DESCRIPTION

## Summary

Close #132.

Adds support for capturing Azure Service Bus processor message activities alongside ASP.NET Core HTTP request activities. Also fixes an EventSource ActivityTracker nesting issue that affected relay event ActivityId paths across all profiler variants.

## Motivation

The profiler previously only captured ASP.NET Core HTTP-in request activities. Applications using Azure Service Bus processors had no visibility into message processing performance. This PR extends the profiler to instrument Service Bus processing events, enabling profiling traces for message-driven workloads.

## Changes

### Service Bus support (OTel profiler)

- **`ServiceBusActivityIdResetListener`** — New `ActivityListener` that resets the thread-local EventSource `ActivityId` when Service Bus processor activities start, preventing the Service Bus SDK's internal activity from contaminating the relay event's `ActivityId` path
- **`DiagnosticSourceEventSourceHandler`** — Extended to recognize Service Bus processor activity names
- **`RequestActivityRelay`** — Generalized to handle both HTTP and Service Bus request activities, with deduplication across event source handlers
- **`TraceSessionListenerFactory`** — Registers the new `ServiceBusActivityIdResetListener` via DI
- **`DiagnosticsClientTraceConfiguration`** — Added `Azure.Messaging.ServiceBus` EventSource to the EventPipe provider list

### EventSource ActivityTracker fix (all profilers)

- **`AzureMonitorOpenTelemetryProfilerDataAdapterEventSource`** (OTel) — Added `Task = Tasks.Request` and `ActivityOptions = EventActivityOptions.Disable` on `RequestStart`/`RequestStop` events, preventing EventSource's `ActivityTracker` from pushing/popping the thread's `ActivityId` during `WriteEvent`
- **`ApplicationInsightsDataRelayEventSource`** (Classic) — Changed `ActivityOptions` from `None` to `Disable`, matching the v3.0 EventSource pattern
- **`TraceSessionListener` / `TraceSessionListener30`** (Classic) — Save and restore `CurrentThreadActivityId` around relay calls, matching the pattern used by the OTel `RequestActivityRelay`
- **`SampleActivity.IsValid`** (Shared) — Updated comment to reflect the new invariant; kept `StartsWith` for backward compatibility

## Files Changed

| File | Change |
|------|--------|
| `ServiceBusActivityIdResetListener.cs` | **New** — resets EventSource ActivityId for Service Bus activities |
| `DiagnosticSourceEventSourceHandler.cs` | Recognize Service Bus activity names |
| `RequestActivityRelay.cs` | Handle HTTP + Service Bus, deduplicate across handlers |
| `TraceSessionListenerFactory.cs` (OTel) | Register `ServiceBusActivityIdResetListener` |
| `DiagnosticsClientTraceConfiguration.cs` | Add Service Bus EventSource provider |
| `AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.cs` | Add `Tasks`, use `Disable` + `Start/Stop` opcodes |
| `ApplicationInsightsDataRelayEventSource.cs` (Classic) | `ActivityOptions.None` → `Disable` |
| `TraceSessionListener.cs` (Classic) | Save/restore `CurrentThreadActivityId` |
| `TraceSessionListener30.cs` (Classic) | Save/restore `CurrentThreadActivityId` |
| `SampleActivity.cs` (Shared) | Updated validation comment |

## Testing

- OTel private package builds successfully
- Code reviewed with GPT 5.5 and Claude Opus 4.7 (2 consecutive clean iterations per round)

## Risk

- **Low** — The `EventActivityOptions.Disable` pattern is proven in `ApplicationInsightsDataRelayEventSource30` (used since .NET Core 3.0). The save/restore of `CurrentThreadActivityId` matches the OTel relay's existing pattern.
- Classic non-30 EventSource change only affects .NET Core 2.x runtime paths (EOL) plus the multi-listener enumeration path.
