### PR TITLE
Add warning log when upload is skipped due to zero samples

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/PostStopProcessor.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/PostStopProcessor.cs
@@ -101,6 +101,7 @@ internal class PostStopProcessor : IPostStopProcessor
         _logger.LogDebug("There are {sampleNumber} samples before validation.", sampleCount);
         if (sampleCount == 0 && uploadMode != UploadMode.Always)
         {
+            _logger.LogWarning("Skip uploading. No samples collected and upload mode is {mode}.", uploadMode);
             return false;
         }
 


### PR DESCRIPTION
## Summary

Adds a `LogWarning` in `PostStopProcessor.ExecuteUploadAsync` when the upload is skipped because no samples were collected, making the reason visible in Application Insights with default logging configuration.

## Motivation

When a profiling session collects zero samples and the upload mode isn't `Always`, the upload is silently skipped with no log output. This makes it difficult for users to diagnose why no profiling trace appeared in Application Insights.

## Changes

| File | Change |
|------|--------|
| `Services/PostStopProcessor.cs` | Add `LogWarning` before `return false` when `sampleCount == 0` and upload mode is not `Always` |

## Testing

- Build succeeds with 0 errors
- Code reviewed with GPT 5.5 and Claude Opus 4.7 (2 consecutive clean rounds)

## Risk

- **Low** — Single log statement addition; no behavior change.