### PR TITLE
Include XML documentation files in NuGet packages for IntelliSense

### DIFF
--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/Azure.Monitor.OpenTelemetry.Profiler.nuspec
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/Azure.Monitor.OpenTelemetry.Profiler.nuspec
@@ -46,6 +46,7 @@
     <!-- All files and symbols -->
     <file src="bin\$configuration$\$targetFramework$\*.dll" target="lib/$targetFramework$"></file>
     <file src="bin\$configuration$\$targetFramework$\*.pdb" target="lib/$targetFramework$"></file>
+    <file src="bin\$configuration$\$targetFramework$\*.xml" target="lib/$targetFramework$"></file>
 
     <!-- Uploader -->
     <file src="obj\$configuration$\Uploader\Uploader.zip" target="contentFiles\any\any\ServiceProfiler\TraceUpload.zip"></file>

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/OpenTelemetryBuilderExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/OpenTelemetryBuilderExtensions.cs
@@ -7,6 +7,9 @@ using OpenTelemetry;
 
 namespace Azure.Monitor.OpenTelemetry.Profiler;
 
+/// <summary>
+/// Extension methods for <see cref="IOpenTelemetryBuilder"/> to register Azure Monitor Profiler services.
+/// </summary>
 public static class OpenTelemetryBuilderExtensions
 {
     /// <summary>

--- a/src/ServiceProfiler.EventPipe.Otel/Directory.Build.props
+++ b/src/ServiceProfiler.EventPipe.Otel/Directory.Build.props
@@ -8,6 +8,8 @@
   <PropertyGroup>
     <!-- Enable Public API Analyzers by default for all projects under this folder and sub folders -->
     <EnablePublicAPIAnalyzers Condition=" '$(EnablePublicAPIAnalyzers)' == '' ">true</EnablePublicAPIAnalyzers>
+    <!-- Generate XML documentation so consumers get IntelliSense from the NuGet package -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!-- Warning as errors -->

--- a/src/ServiceProfiler.EventPipe/Directory.Build.props
+++ b/src/ServiceProfiler.EventPipe/Directory.Build.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(MSBuildThisFileDirectory)..\</SolutionDir>
     <Nullable>enable</Nullable>
+    <!-- Generate XML documentation so consumers get IntelliSense from the NuGet package -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- Setup Version property. -->
     <MajorVersion>3</MajorVersion>

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.AspNetCore/ServiceProfiler.EventPipe.AspNetCore.nuspec
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.AspNetCore/ServiceProfiler.EventPipe.AspNetCore.nuspec
@@ -38,6 +38,7 @@
     <!--Assemblies-->
     <file src="bin\$configuration$\$targetFramework$\Microsoft.ApplicationInsights.Profiler.AspNetCore.dll" target="lib\$targetFramework$"></file>
     <file src="bin\$configuration$\$targetFramework$\Microsoft.ApplicationInsights.Profiler.AspNetCore.pdb" target="lib\$targetFramework$"></file>
+    <file src="bin\$configuration$\$targetFramework$\Microsoft.ApplicationInsights.Profiler.AspNetCore.xml" target="lib\$targetFramework$"></file>
 
     <!--Uploader-->
     <file src="obj\$configuration$\Uploader\Uploader.zip" target="contentFiles\any\any\ServiceProfiler\TraceUpload.zip"></file>

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfiler.EventPipe.Core.nuspec
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfiler.EventPipe.Core.nuspec
@@ -51,5 +51,6 @@
     <!-- All files and symbols -->
     <file src="bin\$configuration$\$targetFramework$\*.dll" target="lib/$targetFramework$"></file>
     <file src="bin\$configuration$\$targetFramework$\*.pdb" target="lib/$targetFramework$"></file>
+    <file src="bin\$configuration$\$targetFramework$\*.xml" target="lib/$targetFramework$"></file>
   </files>
 </package>


### PR DESCRIPTION
Fixes #85

## Problem

The NuGet packages (`Azure.Monitor.OpenTelemetry.Profiler` and `Microsoft.ApplicationInsights.Profiler.AspNetCore` / `Core`) do not include XML documentation files, so consumers have no IntelliSense or IDE documentation for public APIs.

## Changes

- **`Directory.Build.props`** (both OTel and classic profiler trees) — Added `<GenerateDocumentationFile>true</GenerateDocumentationFile>` so all projects generate XML doc files during build.
- **Nuspec files** (3 total) — Added XML file entries (`*.xml` or explicit `.xml`) alongside existing DLL/PDB entries so the generated docs ship inside the NuGet packages.
- **`OpenTelemetryBuilderExtensions.cs`** — Added missing `<summary>` XML doc comment on the class to resolve the CS1591 warning introduced by enabling doc generation.

## Verification

- Both OTel and classic profiler solutions build and package successfully.
- All 21 OTel profiler tests pass.
- No new CS1591 warnings.