### PR TITLE
Reword validation error log to avoid implying the error is expected

### DIFF
--- a/src/ServiceProfiler.EventPipe.Upload/TraceUploader.cs
+++ b/src/ServiceProfiler.EventPipe.Upload/TraceUploader.cs
@@ -265,7 +265,8 @@ internal class TraceUploader : ITraceUploader
         }
         catch (ValidateFailedException ex)
         {
-            Logger.LogError(ex, "Expected trace validation error.");
+            Logger.LogWarning("Trace validation failed: {message}", ex.Message);
+            Logger.LogDebug(ex, "Trace validation failure details.");
             if (ex.ShouldStopUploading)
             {
                 // Return an empty list of sample activity is the best indicator that the uploading should be skipped without a major refactor.


### PR DESCRIPTION
# Reword validation error log to avoid implying the error is expected

Close #142 

## Summary

Changed the `ValidateFailedException` log messages in `TraceUploader.cs` from "Expected trace validation error" to "Trace validation failed". The previous wording implied the error was anticipated/normal, when it is actually a handled but undesirable condition.

## Changes

- **`TraceUploader.cs`** — Updated log messages:
  - `"Expected trace validation error: {message}"` → `"Trace validation failed: {message}"`
  - `"Expected trace validation error details."` → `"Trace validation failure details."`
