### PR TITLE
Capture and correlate Azure Functions (isolated) Service Bus invocations

### DIFF
--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/Azure.Monitor.OpenTelemetry.Profiler.Core.csproj
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/Azure.Monitor.OpenTelemetry.Profiler.Core.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <!-- Shipping -->
     <InternalsVisibleTo Include="Azure.Monitor.OpenTelemetry.Profiler" />
+    <!-- Test -->
+    <InternalsVisibleTo Include="Azure.Monitor.OpenTelemetry.Profiler.Tests" Key="$(TestPublicKey)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/DiagnosticsClientTraceConfiguration.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/DiagnosticsClientTraceConfiguration.cs
@@ -39,9 +39,9 @@ internal class DiagnosticsClientTraceConfiguration : DiagnosticsClientTraceConfi
 
         // Diagnostic Source Event Source — only needed when the DS handler is active.
         // Narrow FilterAndPayloadSpecs to the exact ActivitySources we care about (ASP.NET Core HTTP-in,
-        // Azure Service Bus processor/receiver, and the Azure Functions isolated worker invocation) to
-        // match the handler; [AS]* would firehose every ActivitySource in the process (EF Core,
-        // HttpClient, custom sources, ...).
+        // the Azure Service Bus processor, and the Azure Functions isolated worker invocation) to match
+        // the handler; [AS]* would firehose every ActivitySource in the process (EF Core, HttpClient,
+        // custom sources, ...).
         if (mode is RequestSourceMode.DiagnosticSource or RequestSourceMode.Both)
         {
             yield return new EventPipeProvider(TraceSessionListener.DiagnosticSourceEventSourceName, EventLevel.Verbose, keywords: 0xffffffffffff, arguments: new Dictionary<string, string>

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/DiagnosticsClientTraceConfiguration.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/DiagnosticsClientTraceConfiguration.cs
@@ -38,9 +38,10 @@ internal class DiagnosticsClientTraceConfiguration : DiagnosticsClientTraceConfi
         }
 
         // Diagnostic Source Event Source — only needed when the DS handler is active.
-        // Narrow FilterAndPayloadSpecs to the exact ActivitySources we care about (ASP.NET Core HTTP-in
-        // and Azure Service Bus processor) to match the handler; [AS]* would firehose every ActivitySource
-        // in the process (EF Core, HttpClient, custom sources, ...).
+        // Narrow FilterAndPayloadSpecs to the exact ActivitySources we care about (ASP.NET Core HTTP-in,
+        // Azure Service Bus processor/receiver, and the Azure Functions isolated worker invocation) to
+        // match the handler; [AS]* would firehose every ActivitySource in the process (EF Core,
+        // HttpClient, custom sources, ...).
         if (mode is RequestSourceMode.DiagnosticSource or RequestSourceMode.Both)
         {
             yield return new EventPipeProvider(TraceSessionListener.DiagnosticSourceEventSourceName, EventLevel.Verbose, keywords: 0xffffffffffff, arguments: new Dictionary<string, string>

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
@@ -43,17 +43,37 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
     // The ActivitySource name is "Microsoft.AspNetCore" (NOT "Microsoft.AspNetCore.Hosting" —
     // that's the ActivityName / OperationName, e.g. "Microsoft.AspNetCore.Hosting.HttpRequestIn").
     //
-    // Azure Service Bus processor ActivitySource names are dynamically constructed by the SDK as
-    // "<DiagnosticNamespace>.<ClientType>", e.g. "Azure.Messaging.ServiceBus.ServiceBusProcessor".
-    // The processor creates activities with ActivityKind.Consumer and names like
-    // "ServiceBusProcessor.ProcessMessage" and "ServiceBusSessionProcessor.ProcessSessionMessage".
+    // Azure Service Bus ActivitySource names are NOT a fixed "<namespace>.<ClientType>" string; the SDK
+    // derives them from the operation name. Azure.Core's DiagnosticScopeFactory.GetActivitySource builds
+    // the source name as "<DiagnosticNamespace>.<operation-name up to the first dot>", where
+    // DiagnosticNamespace is "Azure.Messaging.ServiceBus" and the operation name is one of the
+    // DiagnosticProperty.*ActivityName constants. So, for example:
+    //   "ServiceBusProcessor.ProcessMessage"      -> [AS]Azure.Messaging.ServiceBus.ServiceBusProcessor
+    //   "ServiceBusSessionProcessor.ProcessSessionMessage" -> [AS]...ServiceBusSessionProcessor
+    //   "ServiceBusReceiver.Receive"/".Complete"/".Abandon"/... -> [AS]...ServiceBusReceiver
+    //   "ServiceBusSessionReceiver.RenewSessionLock"/...        -> [AS]...ServiceBusSessionReceiver
+    //
+    // We must subscribe to the receiver sources in addition to the processor sources: Azure Functions
+    // Service Bus triggers (and other receiver-based consumers) drive message consumption through the
+    // receiver, so their consumer activities are emitted under "...ServiceBusReceiver" /
+    // "...ServiceBusSessionReceiver", NOT under the processor sources.
     // ActivitySource is enabled by default in Azure.Core 1.36.0+.
+    //
+    // Azure Functions isolated worker: the .NET isolated worker emits a per-invocation Activity from a
+    // plain ActivitySource named "Microsoft.Azure.Functions.Worker" with the operation name "Invoke"
+    // (Microsoft.Azure.Functions.Worker, TraceConstants.ActivityAttributes). In the isolated model the
+    // Service Bus SDK (processor/receiver) runs in the Functions *host* process, so only this worker-side
+    // invocation Activity is visible to an in-worker profiler. The worker only creates this Activity when
+    // its OpenTelemetry/telemetry integration is wired up; our [AS] subscription satisfies HasListeners().
     //
     // Multiple specs are newline-separated per DiagnosticSourceEventSource convention.
     internal const string FilterAndPayloadSpecs =
         "[AS]Microsoft.AspNetCore/\n" +
         "[AS]Azure.Messaging.ServiceBus.ServiceBusProcessor/\n" +
-        "[AS]Azure.Messaging.ServiceBus.ServiceBusSessionProcessor/";
+        "[AS]Azure.Messaging.ServiceBus.ServiceBusSessionProcessor/\n" +
+        "[AS]Azure.Messaging.ServiceBus.ServiceBusReceiver/\n" +
+        "[AS]Azure.Messaging.ServiceBus.ServiceBusSessionReceiver/\n" +
+        "[AS]Microsoft.Azure.Functions.Worker/";
 
     private readonly RequestActivityRelay _relay;
     private readonly ILogger<DiagnosticSourceEventSourceHandler> _logger;

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
@@ -13,6 +13,11 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
 {
     public const string EventSourceName = "Microsoft-Diagnostics-DiagnosticSource";
 
+    // ActivitySource name of the Azure Functions .NET isolated worker. Activities from this source are
+    // the per-invocation "function <name>" spans (ActivityKind.Internal). See OnEventWritten for why their
+    // parent id (not their own id) is used to correlate the profiler sample to a request.
+    internal const string FunctionsWorkerActivitySourceName = "Microsoft.Azure.Functions.Worker";
+
     // FilterAndPayloadSpecs grammar: see DiagnosticSourceEventSource source-of-truth comment block.
     //
     // We use the ActivitySource path (the "[AS]" prefix), NOT the DiagnosticListener path:
@@ -132,6 +137,25 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
         }
 
         (string requestId, string operationId) = RequestActivityRelay.ExtractKeyIds(id);
+
+        // Azure Functions isolated worker correlation fixup.
+        // The worker's "function <name>" activity is ActivityKind.Internal, so Azure Monitor records it as
+        // a *dependency*, not a request. The actual request (e.g. "ServiceBusProcessor.ProcessMessage" or
+        // an HTTP request) is emitted by the Functions *host* process and is the PARENT of this worker
+        // activity. Service Profiler correlates samples to requests by id, so anchoring on the worker
+        // activity's own (dependency) span id leaves the sample with no matching request. Use the parent
+        // span id instead, which is the host-emitted request. Falls back to the own id if there is no
+        // well-formed parent (e.g. an invocation without propagated context).
+        string? sourceName = eventData.GetPayload<string>("SourceName");
+        if (string.Equals(sourceName, FunctionsWorkerActivitySourceName, StringComparison.Ordinal))
+        {
+            string? parentId = GetArgumentValue(arguments!, "ParentId");
+            if (RequestActivityRelay.TryExtractKeyIds(parentId, out string parentRequestId, out string parentOperationId))
+            {
+                requestId = parentRequestId;
+                operationId = parentOperationId;
+            }
+        }
 
         if (eventName.EndsWith("Start", StringComparison.Ordinal))
         {

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
@@ -139,15 +139,18 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
         (string requestId, string operationId) = RequestActivityRelay.ExtractKeyIds(id);
 
         // Azure Functions isolated worker correlation fixup.
-        // The worker's "function <name>" activity is ActivityKind.Internal, so Azure Monitor records it as
-        // a *dependency*, not a request. The actual request (e.g. "ServiceBusProcessor.ProcessMessage" or
-        // an HTTP request) is emitted by the Functions *host* process and is the PARENT of this worker
-        // activity. Service Profiler correlates samples to requests by id, so anchoring on the worker
-        // activity's own (dependency) span id leaves the sample with no matching request. Use the parent
-        // span id instead, which is the host-emitted request. Falls back to the own id if there is no
-        // well-formed parent (e.g. an invocation without propagated context).
+        // The worker's invocation activity is recorded by Azure Monitor differently depending on the
+        // worker's OpenTelemetry schema version (see TelemetryProvider.Kind in the worker SDK):
+        //   - schema <= 1.17.0: name "Invoke", ActivityKind.Server  -> exported as a REQUEST (own span id
+        //     is the request id, so DO NOT remap).
+        //   - schema 1.37.0+:   name "function <name>", ActivityKind.Internal -> exported as a DEPENDENCY,
+        //     a child of the request that the Functions HOST process emits (e.g.
+        //     "ServiceBusProcessor.ProcessMessage"). Anchoring on the worker activity's own (dependency)
+        //     span id leaves the sample with no matching request, so use the PARENT span id instead.
+        // Only the Internal "function <name>" schema is remapped; falls back to the own id if there is no
+        // well-formed parent.
         string? sourceName = eventData.GetPayload<string>("SourceName");
-        if (string.Equals(sourceName, FunctionsWorkerActivitySourceName, StringComparison.Ordinal))
+        if (ShouldRemapToParentRequest(sourceName, requestName))
         {
             string? parentId = GetArgumentValue(arguments!, "ParentId");
             if (RequestActivityRelay.TryExtractKeyIds(parentId, out string parentRequestId, out string parentOperationId))
@@ -166,6 +169,15 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
             _relay.HandleRequestStop(eventData, requestName, requestId, operationId, id);
         }
     }
+
+    // Decides whether a captured activity's request/operation id should be remapped to its PARENT span id
+    // for App Insights correlation. True only for the Azure Functions isolated worker's Internal-schema
+    // invocation activity ("function <name>", ActivityKind.Internal -> a dependency child of the host
+    // request). The worker's older "Invoke" activity (ActivityKind.Server) is a request itself and keeps
+    // its own id, as do all other captured sources (ASP.NET Core, Service Bus).
+    internal static bool ShouldRemapToParentRequest(string? sourceName, string requestName)
+        => string.Equals(sourceName, FunctionsWorkerActivitySourceName, StringComparison.Ordinal)
+        && requestName.StartsWith(RequestActivityRelay.FunctionsWorkerActivityNamePrefix, StringComparison.Ordinal);
 
     // Each element of the bridged Arguments payload is an IDictionary<string,object>
     // with two entries: { "Key" -> <name>, "Value" -> <value> }.

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
@@ -55,30 +55,27 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
     // DiagnosticProperty.*ActivityName constants. So, for example:
     //   "ServiceBusProcessor.ProcessMessage"      -> [AS]Azure.Messaging.ServiceBus.ServiceBusProcessor
     //   "ServiceBusSessionProcessor.ProcessSessionMessage" -> [AS]...ServiceBusSessionProcessor
-    //   "ServiceBusReceiver.Receive"/".Complete"/".Abandon"/... -> [AS]...ServiceBusReceiver
-    //   "ServiceBusSessionReceiver.RenewSessionLock"/...        -> [AS]...ServiceBusSessionReceiver
     //
-    // We must subscribe to the receiver sources in addition to the processor sources: Azure Functions
-    // Service Bus triggers (and other receiver-based consumers) drive message consumption through the
-    // receiver, so their consumer activities are emitted under "...ServiceBusReceiver" /
-    // "...ServiceBusSessionReceiver", NOT under the processor sources.
-    // ActivitySource is enabled by default in Azure.Core 1.36.0+.
+    // We subscribe ONLY to the processor sources, NOT the receiver sources. The processor's
+    // ProcessMessage / ProcessSessionMessage activities are ActivityKind.Consumer, which Azure Monitor
+    // records as *requests* — the right anchor for a profiler sample. Receiver operations
+    // ("ServiceBusReceiver.Receive"/".Complete"/...) are ActivityKind.Client and are recorded as
+    // *dependencies*, so they would never correlate to a request; they also fire internally inside the
+    // processor's own receive loop. ActivitySource is enabled by default in Azure.Core 1.36.0+.
     //
     // Azure Functions isolated worker: the .NET isolated worker emits a per-invocation Activity from a
     // plain ActivitySource named "Microsoft.Azure.Functions.Worker". The operation name varies by the
     // worker's OpenTelemetry schema version: "Invoke" on older schemas (<= 1.17.0) and
     // "function <FunctionName>" on schema 1.37.0+ (e.g. "function MySBFuncTest"). In the isolated model the
-    // Service Bus SDK (processor/receiver) runs in the Functions *host* process, so only this worker-side
-    // invocation Activity is visible to an in-worker profiler. The worker only creates this Activity when
-    // its OpenTelemetry/telemetry integration is wired up; our [AS] subscription satisfies HasListeners().
+    // Service Bus SDK runs in the Functions *host* process, so only this worker-side invocation Activity is
+    // visible to an in-worker profiler. The worker only creates this Activity when its OpenTelemetry/
+    // telemetry integration is wired up; our [AS] subscription satisfies HasListeners().
     //
     // Multiple specs are newline-separated per DiagnosticSourceEventSource convention.
     internal const string FilterAndPayloadSpecs =
         "[AS]Microsoft.AspNetCore/\n" +
         "[AS]Azure.Messaging.ServiceBus.ServiceBusProcessor/\n" +
         "[AS]Azure.Messaging.ServiceBus.ServiceBusSessionProcessor/\n" +
-        "[AS]Azure.Messaging.ServiceBus.ServiceBusReceiver/\n" +
-        "[AS]Azure.Messaging.ServiceBus.ServiceBusSessionReceiver/\n" +
         "[AS]Microsoft.Azure.Functions.Worker/";
 
     private readonly RequestActivityRelay _relay;

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/DiagnosticSourceEventSourceHandler.cs
@@ -60,8 +60,9 @@ internal sealed class DiagnosticSourceEventSourceHandler : IEventSourceHandler
     // ActivitySource is enabled by default in Azure.Core 1.36.0+.
     //
     // Azure Functions isolated worker: the .NET isolated worker emits a per-invocation Activity from a
-    // plain ActivitySource named "Microsoft.Azure.Functions.Worker" with the operation name "Invoke"
-    // (Microsoft.Azure.Functions.Worker, TraceConstants.ActivityAttributes). In the isolated model the
+    // plain ActivitySource named "Microsoft.Azure.Functions.Worker". The operation name varies by the
+    // worker's OpenTelemetry schema version: "Invoke" on older schemas (<= 1.17.0) and
+    // "function <FunctionName>" on schema 1.37.0+ (e.g. "function MySBFuncTest"). In the isolated model the
     // Service Bus SDK (processor/receiver) runs in the Functions *host* process, so only this worker-side
     // invocation Activity is visible to an in-worker profiler. The worker only creates this Activity when
     // its OpenTelemetry/telemetry integration is wired up; our [AS] subscription satisfies HasListeners().

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/OpenTelemetrySdkEventSourceHandler.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/OpenTelemetrySdkEventSourceHandler.cs
@@ -45,6 +45,19 @@ internal sealed class OpenTelemetrySdkEventSourceHandler : IEventSourceHandler
         }
 
         string requestName = eventData.GetPayload<string>("name") ?? "Unknown";
+
+        // The Azure Functions isolated worker Internal-schema invocation ("function <name>") requires the
+        // host-request parent-id correlation remap (see DiagnosticSourceEventSourceHandler), which needs
+        // the Activity's ParentId. That is only available on the DiagnosticSource bridge path, not in the
+        // OpenTelemetry-Sdk RequestStart/Stop payload. Leave these to the DiagnosticSource handler: in
+        // "Both" mode the two handlers share one relay (deduping by activity id), and forwarding the worker
+        // activity here with its own id would race the DiagnosticSource handler's parent-id mapping and
+        // could emit a Start/Stop pair with mismatched request ids that fail to pair.
+        if (requestName.StartsWith(RequestActivityRelay.FunctionsWorkerActivityNamePrefix, StringComparison.Ordinal))
+        {
+            return;
+        }
+
         string id = eventData.GetPayload<string>("id") ?? throw new InvalidDataException("id payload is missing.");
 
         (string requestId, string operationId) = RequestActivityRelay.ExtractKeyIds(id);

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityIdResetListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityIdResetListener.cs
@@ -5,8 +5,9 @@ using Microsoft.Extensions.Logging;
 namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 
 /// <summary>
-/// Registers an <see cref="ActivityListener"/> for Azure Service Bus processor ActivitySources
-/// that resets the thread-local EventSource ActivityId to <see cref="Guid.Empty"/> in the
+/// Registers an <see cref="ActivityListener"/> for the async, request-like ActivitySources we capture
+/// (Azure Service Bus processor / session-processor and the Azure Functions isolated worker) that resets
+/// the thread-local EventSource ActivityId to <see cref="Guid.Empty"/> in the
 /// <see cref="ActivityListener.Sample"/> callback.
 /// </summary>
 /// <remarks>
@@ -14,9 +15,10 @@ namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 /// This fixes a nesting issue in the <c>DiagnosticSourceEventSource</c> bridge's
 /// <c>Activity1Start</c>/<c>Activity1Stop</c> events. The bridge uses EventSource's thread-local
 /// ActivityId with <see cref="EventOpcode.Start"/> to push a child ActivityId. For async processing
-/// (like Service Bus), the <c>Activity1Stop</c> fires on a different thread, so the Start thread's
-/// ActivityId is never popped. When the thread is reused for the next message, the bridge pushes
-/// under the stale (un-popped) parent, creating a nested tree instead of flat siblings.
+/// (Service Bus messages, Functions worker invocations), the <c>Activity1Stop</c> can fire on a different
+/// thread, so the Start thread's ActivityId is never popped. When the thread is reused for the next
+/// message/invocation, the bridge pushes under the stale (un-popped) parent, creating a nested tree
+/// instead of flat siblings.
 /// </para>
 /// <para>
 /// The reset is performed in the <see cref="ActivityListener.Sample"/> callback rather than
@@ -27,17 +29,18 @@ namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 /// event — fires before ours. Resetting in <c>ActivityStarted</c> would be too late.
 /// </para>
 /// </remarks>
-internal sealed class ServiceBusActivityIdResetListener : IDisposable
+internal sealed class RequestActivityIdResetListener : IDisposable
 {
     private readonly ActivityListener _listener;
 
-    public ServiceBusActivityIdResetListener(ILogger<ServiceBusActivityIdResetListener> logger)
+    public RequestActivityIdResetListener(ILogger<RequestActivityIdResetListener> logger)
     {
         _listener = new ActivityListener
         {
             ShouldListenTo = source =>
                 source.Name == "Azure.Messaging.ServiceBus.ServiceBusProcessor" ||
-                source.Name == "Azure.Messaging.ServiceBus.ServiceBusSessionProcessor",
+                source.Name == "Azure.Messaging.ServiceBus.ServiceBusSessionProcessor" ||
+                source.Name == DiagnosticSourceEventSourceHandler.FunctionsWorkerActivitySourceName,
 
             Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
             {
@@ -53,7 +56,7 @@ internal sealed class ServiceBusActivityIdResetListener : IDisposable
         };
 
         ActivitySource.AddActivityListener(_listener);
-        logger.LogDebug("Registered ActivityListener for Service Bus processor activities.");
+        logger.LogDebug("Registered ActivityListener for Service Bus processor and Functions worker activities.");
     }
 
     public void Dispose() => _listener.Dispose();

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
@@ -6,8 +6,9 @@ using System.Threading;
 namespace Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
 
 /// <summary>
-/// Tracks in-flight "interesting" request activities (ASP.NET Core HTTP-in and Azure Service Bus
-/// processor messages) and forwards matched start/stop pairs onto
+/// Tracks in-flight "interesting" request activities (ASP.NET Core HTTP-in, Azure Service Bus
+/// processor messages, receiver-based message consumption, and Azure Functions isolated worker
+/// invocations) and forwards matched start/stop pairs onto
 /// <see cref="AzureMonitorOpenTelemetryProfilerDataAdapterEventSource"/>.
 ///
 /// Lives once per <see cref="TraceSessionListener"/> and is shared by every <see cref="IEventSourceHandler"/>
@@ -19,6 +20,17 @@ internal sealed class RequestActivityRelay
     private const string AspNetCoreHttpRequestInName = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
     private const string ServiceBusProcessMessageName = "ServiceBusProcessor.ProcessMessage";
     private const string ServiceBusProcessSessionMessageName = "ServiceBusSessionProcessor.ProcessSessionMessage";
+    // Receiver-based consumption (Azure Functions batch Service Bus triggers and other consumers that
+    // pump via ServiceBusReceiver.ReceiveMessagesAsync rather than the processor) surfaces as this
+    // activity. The SDK shares this name for both regular and session receivers — session receivers only
+    // use the "ServiceBusSessionReceiver" prefix for session lock/state operations, not for receive.
+    private const string ServiceBusReceiveName = "ServiceBusReceiver.Receive";
+    // Azure Functions isolated worker per-invocation activity (ActivitySource
+    // "Microsoft.Azure.Functions.Worker", operation name "Invoke"). In the isolated model the Service Bus
+    // SDK runs in the host process, so this worker-side invocation span is the only request-like activity
+    // visible to an in-worker profiler. Note: this fires for every trigger type (HTTP, timer, Service Bus,
+    // ...), not just Service Bus.
+    private const string FunctionsWorkerInvokeName = "Invoke";
 
     private readonly ILogger<RequestActivityRelay> _logger;
     private readonly ConcurrentDictionary<string, byte> _startedActivityIds = new();
@@ -30,13 +42,18 @@ internal sealed class RequestActivityRelay
     }
 
     /// <summary>
-    /// We capture HTTP-in requests and Service Bus processor messages.
-    /// HTTP-out (e.g. HttpClient) and other Service Bus operations (send, receive) are excluded.
+    /// We capture HTTP-in requests, Service Bus processor messages, receiver-based message
+    /// consumption (e.g. Azure Functions batch Service Bus triggers), and Azure Functions isolated
+    /// worker invocations.
+    /// HTTP-out (e.g. HttpClient) and other Service Bus operations (send, settle, peek, lock renewal)
+    /// are excluded.
     /// </summary>
-    private static bool IsInterestingRequest(string requestName)
+    internal static bool IsInterestingRequest(string requestName)
         => string.Equals(AspNetCoreHttpRequestInName, requestName, StringComparison.Ordinal)
         || string.Equals(ServiceBusProcessMessageName, requestName, StringComparison.Ordinal)
-        || string.Equals(ServiceBusProcessSessionMessageName, requestName, StringComparison.Ordinal);
+        || string.Equals(ServiceBusProcessSessionMessageName, requestName, StringComparison.Ordinal)
+        || string.Equals(ServiceBusReceiveName, requestName, StringComparison.Ordinal)
+        || string.Equals(FunctionsWorkerInvokeName, requestName, StringComparison.Ordinal);
 
     public void HandleRequestStart(EventWrittenEventArgs eventData, string requestName, string requestId, string operationId, string id)
     {

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
@@ -166,4 +166,30 @@ internal sealed class RequestActivityRelay
 
         return (requestId: tokens[2], operationId: tokens[1]);
     }
+
+    /// <summary>
+    /// Non-throwing variant of <see cref="ExtractKeyIds"/>. Returns false (with empty out values) when
+    /// <paramref name="id"/> is null/empty or not a well-formed W3C trace-context id, instead of throwing.
+    /// Used for optional ids (e.g. a parent id) that may be absent.
+    /// </summary>
+    public static bool TryExtractKeyIds(string? id, out string requestId, out string operationId)
+    {
+        requestId = string.Empty;
+        operationId = string.Empty;
+
+        if (string.IsNullOrEmpty(id))
+        {
+            return false;
+        }
+
+        string[] tokens = id!.Split('-');
+        if (tokens.Length != 4 || string.IsNullOrEmpty(tokens[1]) || string.IsNullOrEmpty(tokens[2]))
+        {
+            return false;
+        }
+
+        requestId = tokens[2];
+        operationId = tokens[1];
+        return true;
+    }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
@@ -40,7 +40,10 @@ internal sealed class RequestActivityRelay
     // because gate 1 (FilterAndPayloadSpecs) only subscribes to this worker source plus ASP.NET Core and
     // Service Bus, none of which produce "function "-prefixed activity names.
     private const string FunctionsWorkerInvokeName = "Invoke";
-    private const string FunctionsWorkerActivityNamePrefix = "function ";
+    // Shared with DiagnosticSourceEventSourceHandler, which gates the parent-id correlation remap on this
+    // same prefix (the schema 1.37.0+ "function <name>" activity is ActivityKind.Internal / a dependency,
+    // whereas the "Invoke" activity is ActivityKind.Server / a request).
+    internal const string FunctionsWorkerActivityNamePrefix = "function ";
 
     private readonly ILogger<RequestActivityRelay> _logger;
     private readonly ConcurrentDictionary<string, byte> _startedActivityIds = new();

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
@@ -26,11 +26,21 @@ internal sealed class RequestActivityRelay
     // use the "ServiceBusSessionReceiver" prefix for session lock/state operations, not for receive.
     private const string ServiceBusReceiveName = "ServiceBusReceiver.Receive";
     // Azure Functions isolated worker per-invocation activity (ActivitySource
-    // "Microsoft.Azure.Functions.Worker", operation name "Invoke"). In the isolated model the Service Bus
-    // SDK runs in the host process, so this worker-side invocation span is the only request-like activity
-    // visible to an in-worker profiler. Note: this fires for every trigger type (HTTP, timer, Service Bus,
-    // ...), not just Service Bus.
+    // "Microsoft.Azure.Functions.Worker"). In the isolated model the Service Bus SDK runs in the host
+    // process, so this worker-side invocation span is the only request-like activity visible to an
+    // in-worker profiler. Note: this fires for every trigger type (HTTP, timer, Service Bus, ...), not
+    // just Service Bus.
+    //
+    // The activity's operation name depends on the worker's OpenTelemetry schema version
+    // (Microsoft.Azure.Functions.Worker, TelemetryProvider.GetActivityName):
+    //   - schema <= 1.17.0: the literal "Invoke" (TraceConstants.ActivityAttributes.InvokeActivityName).
+    //   - schema >= 1.37.0: "function <FunctionName>", e.g. "function MySBFuncTest"
+    //     ($"{FunctionActivityName} {FunctionDefinition.Name}", FunctionActivityName == "function").
+    // We match both so the capture is robust across worker versions. The "function " prefix is safe here
+    // because gate 1 (FilterAndPayloadSpecs) only subscribes to this worker source plus ASP.NET Core and
+    // Service Bus, none of which produce "function "-prefixed activity names.
     private const string FunctionsWorkerInvokeName = "Invoke";
+    private const string FunctionsWorkerActivityNamePrefix = "function ";
 
     private readonly ILogger<RequestActivityRelay> _logger;
     private readonly ConcurrentDictionary<string, byte> _startedActivityIds = new();
@@ -53,7 +63,8 @@ internal sealed class RequestActivityRelay
         || string.Equals(ServiceBusProcessMessageName, requestName, StringComparison.Ordinal)
         || string.Equals(ServiceBusProcessSessionMessageName, requestName, StringComparison.Ordinal)
         || string.Equals(ServiceBusReceiveName, requestName, StringComparison.Ordinal)
-        || string.Equals(FunctionsWorkerInvokeName, requestName, StringComparison.Ordinal);
+        || string.Equals(FunctionsWorkerInvokeName, requestName, StringComparison.Ordinal)
+        || requestName.StartsWith(FunctionsWorkerActivityNamePrefix, StringComparison.Ordinal);
 
     public void HandleRequestStart(EventWrittenEventArgs eventData, string requestName, string requestId, string operationId, string id)
     {

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/RequestActivityRelay.cs
@@ -20,11 +20,6 @@ internal sealed class RequestActivityRelay
     private const string AspNetCoreHttpRequestInName = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
     private const string ServiceBusProcessMessageName = "ServiceBusProcessor.ProcessMessage";
     private const string ServiceBusProcessSessionMessageName = "ServiceBusSessionProcessor.ProcessSessionMessage";
-    // Receiver-based consumption (Azure Functions batch Service Bus triggers and other consumers that
-    // pump via ServiceBusReceiver.ReceiveMessagesAsync rather than the processor) surfaces as this
-    // activity. The SDK shares this name for both regular and session receivers — session receivers only
-    // use the "ServiceBusSessionReceiver" prefix for session lock/state operations, not for receive.
-    private const string ServiceBusReceiveName = "ServiceBusReceiver.Receive";
     // Azure Functions isolated worker per-invocation activity (ActivitySource
     // "Microsoft.Azure.Functions.Worker"). In the isolated model the Service Bus SDK runs in the host
     // process, so this worker-side invocation span is the only request-like activity visible to an
@@ -38,7 +33,7 @@ internal sealed class RequestActivityRelay
     //     ($"{FunctionActivityName} {FunctionDefinition.Name}", FunctionActivityName == "function").
     // We match both so the capture is robust across worker versions. The "function " prefix is safe here
     // because gate 1 (FilterAndPayloadSpecs) only subscribes to this worker source plus ASP.NET Core and
-    // Service Bus, none of which produce "function "-prefixed activity names.
+    // the Service Bus processor sources, none of which produce "function "-prefixed activity names.
     private const string FunctionsWorkerInvokeName = "Invoke";
     // Shared with DiagnosticSourceEventSourceHandler, which gates the parent-id correlation remap on this
     // same prefix (the schema 1.37.0+ "function <name>" activity is ActivityKind.Internal / a dependency,
@@ -55,17 +50,17 @@ internal sealed class RequestActivityRelay
     }
 
     /// <summary>
-    /// We capture HTTP-in requests, Service Bus processor messages, receiver-based message
-    /// consumption (e.g. Azure Functions batch Service Bus triggers), and Azure Functions isolated
-    /// worker invocations.
-    /// HTTP-out (e.g. HttpClient) and other Service Bus operations (send, settle, peek, lock renewal)
-    /// are excluded.
+    /// We capture HTTP-in requests, Service Bus processor messages, and Azure Functions isolated worker
+    /// invocations — i.e. activities that Azure Monitor records as *requests* (ActivityKind.Server /
+    /// Consumer), or the worker invocation span.
+    /// HTTP-out (e.g. HttpClient) and Service Bus receiver/sender operations (receive, send, settle, peek,
+    /// lock renewal) are excluded: they are ActivityKind.Client/Producer and are recorded as dependencies,
+    /// so they would never correlate to a request.
     /// </summary>
     internal static bool IsInterestingRequest(string requestName)
         => string.Equals(AspNetCoreHttpRequestInName, requestName, StringComparison.Ordinal)
         || string.Equals(ServiceBusProcessMessageName, requestName, StringComparison.Ordinal)
         || string.Equals(ServiceBusProcessSessionMessageName, requestName, StringComparison.Ordinal)
-        || string.Equals(ServiceBusReceiveName, requestName, StringComparison.Ordinal)
         || string.Equals(FunctionsWorkerInvokeName, requestName, StringComparison.Ordinal)
         || requestName.StartsWith(FunctionsWorkerActivityNamePrefix, StringComparison.Ordinal);
 

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/SampleCollector.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/SampleCollector.cs
@@ -34,6 +34,21 @@ internal class SampleCollector : EventListener
         SampleActivities = sampleActivityContainer ?? throw new ArgumentNullException(nameof(sampleActivityContainer));
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         _ctorWaitHandle.Set();
+
+        // Eagerly construct and synchronously enable our own data-adapter EventSource here, at
+        // construction time (session start), so this listener is guaranteed to be receiving events before
+        // the first request is relayed.
+        //
+        // The relay creates this EventSource lazily, on its first RequestStart write. Relying on the
+        // OnEventSourceCreated -> Task.Run -> EnableEvents path to enable it is racy: a concurrent burst of
+        // requests at that very instant — e.g. an Azure Functions batch Service Bus trigger, where many
+        // invocations start simultaneously the moment the source is first created — runs ahead of the async
+        // enable, so the Start events are dropped and no samples are produced (the uploader then fails trace
+        // validation with "No sample activities to match."). Spread-out requests (ASP.NET Core, Service Bus
+        // single-dispatch) mostly survive the race, which is why this stayed hidden. Accessing .Log
+        // constructs the singleton; EnableEvents on it is synchronous and idempotent with the async path.
+        EnableEvents(AzureMonitorOpenTelemetryProfilerDataAdapterEventSource.Log, EventLevel.Verbose, (EventKeywords)0xfffffffff);
+
         logger.LogTrace("{name} created.", nameof(SampleCollector));
     }
 

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListener.cs
@@ -24,8 +24,8 @@ internal class TraceSessionListener : EventListener
     // Typed as array (not IReadOnlyList<>) so the foreach in OnEventWritten uses the no-alloc
     // array enumerator — this is a hot path.
     private readonly IEventSourceHandler[] _handlers;
-    // Owned for disposal — resets EventSource ActivityId for async Service Bus activities.
-    private readonly ServiceBusActivityIdResetListener _resetListener;
+    // Owned for disposal — resets EventSource ActivityId for async Service Bus and Functions worker activities.
+    private readonly RequestActivityIdResetListener _resetListener;
     // Field initializer (runs before the base EventListener ctor) — important because the base
     // ctor synchronously dispatches OnEventSourceCreated for every existing EventSource, and
     // those callbacks rely on this handle being non-null.
@@ -37,7 +37,7 @@ internal class TraceSessionListener : EventListener
     public TraceSessionListener(
         SampleCollector sampleCollector,
         IEnumerable<IEventSourceHandler> handlers,
-        ServiceBusActivityIdResetListener resetListener,
+        RequestActivityIdResetListener resetListener,
         ILogger<TraceSessionListener> logger)
     {
         logger.LogTrace("Trace session listener ctor.");

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListenerFactory.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/EventListeners/TraceSessionListenerFactory.cs
@@ -20,13 +20,13 @@ internal class TraceSessionListenerFactory
         RequestSourceMode mode = RequestSourceModeResolver.Resolve(logger);
         logger.LogInformation("Request event source mode: {mode}", mode);
 
-        // Register the Service Bus ActivityId reset listener BEFORE any handler that calls
+        // Register the request ActivityId reset listener BEFORE any handler that calls
         // EnableEvents with FilterAndPayloadSpecs. The bridge's internal ActivityListener is
         // created during EnableEvents, and ActivityStarted callbacks fire in registration order.
         // Our listener must fire first to reset the thread-local ActivityId before the bridge
         // pushes a child under a potentially stale parent (async thread reuse issue).
-        ServiceBusActivityIdResetListener resetListener =
-            ActivatorUtilities.CreateInstance<ServiceBusActivityIdResetListener>(_serviceProvider);
+        RequestActivityIdResetListener resetListener =
+            ActivatorUtilities.CreateInstance<RequestActivityIdResetListener>(_serviceProvider);
 
         // One RequestActivityRelay per listener lifetime, shared across this listener's handlers so that
         // a Start emitted by one source can correlate with a Stop emitted by another (when in Both mode).

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/DiagnosticSourceEventSourceHandlerTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/DiagnosticSourceEventSourceHandlerTests.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Tests;
+
+public class DiagnosticSourceEventSourceHandlerTests
+{
+    [Theory]
+    // ASP.NET Core HTTP-in.
+    [InlineData("[AS]Microsoft.AspNetCore/")]
+    // Service Bus single-dispatch (processor) sources.
+    [InlineData("[AS]Azure.Messaging.ServiceBus.ServiceBusProcessor/")]
+    [InlineData("[AS]Azure.Messaging.ServiceBus.ServiceBusSessionProcessor/")]
+    // Service Bus batch (receiver) sources.
+    [InlineData("[AS]Azure.Messaging.ServiceBus.ServiceBusReceiver/")]
+    [InlineData("[AS]Azure.Messaging.ServiceBus.ServiceBusSessionReceiver/")]
+    // Azure Functions isolated worker source.
+    [InlineData("[AS]Microsoft.Azure.Functions.Worker/")]
+    public void FilterAndPayloadSpecs_SubscribesToExpectedActivitySource(string expectedSpec)
+    {
+        string[] specs = DiagnosticSourceEventSourceHandler.FilterAndPayloadSpecs
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Contains(expectedSpec, specs);
+    }
+
+    [Fact]
+    public void FilterAndPayloadSpecs_OnlyContainsExpectedSources()
+    {
+        string[] specs = DiagnosticSourceEventSourceHandler.FilterAndPayloadSpecs
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // Guard against accidental [AS]* firehose or stray DiagnosticListener specs.
+        Assert.All(specs, spec => Assert.StartsWith("[AS]", spec));
+        Assert.DoesNotContain("[AS]*", specs);
+        Assert.Equal(6, specs.Length);
+    }
+}

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/DiagnosticSourceEventSourceHandlerTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/DiagnosticSourceEventSourceHandlerTests.cs
@@ -11,12 +11,9 @@ public class DiagnosticSourceEventSourceHandlerTests
     [Theory]
     // ASP.NET Core HTTP-in.
     [InlineData("[AS]Microsoft.AspNetCore/")]
-    // Service Bus single-dispatch (processor) sources.
+    // Service Bus single-dispatch (processor) sources — Consumer kind -> request.
     [InlineData("[AS]Azure.Messaging.ServiceBus.ServiceBusProcessor/")]
     [InlineData("[AS]Azure.Messaging.ServiceBus.ServiceBusSessionProcessor/")]
-    // Service Bus batch (receiver) sources.
-    [InlineData("[AS]Azure.Messaging.ServiceBus.ServiceBusReceiver/")]
-    [InlineData("[AS]Azure.Messaging.ServiceBus.ServiceBusSessionReceiver/")]
     // Azure Functions isolated worker source.
     [InlineData("[AS]Microsoft.Azure.Functions.Worker/")]
     public void FilterAndPayloadSpecs_SubscribesToExpectedActivitySource(string expectedSpec)
@@ -25,6 +22,18 @@ public class DiagnosticSourceEventSourceHandlerTests
             .Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Contains(expectedSpec, specs);
+    }
+
+    [Theory]
+    // Service Bus receiver sources are ActivityKind.Client (dependencies), not requests — not subscribed.
+    [InlineData("[AS]Azure.Messaging.ServiceBus.ServiceBusReceiver/")]
+    [InlineData("[AS]Azure.Messaging.ServiceBus.ServiceBusSessionReceiver/")]
+    public void FilterAndPayloadSpecs_DoesNotSubscribeToReceiverSources(string unexpectedSpec)
+    {
+        string[] specs = DiagnosticSourceEventSourceHandler.FilterAndPayloadSpecs
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.DoesNotContain(unexpectedSpec, specs);
     }
 
     [Fact]
@@ -36,7 +45,7 @@ public class DiagnosticSourceEventSourceHandlerTests
         // Guard against accidental [AS]* firehose or stray DiagnosticListener specs.
         Assert.All(specs, spec => Assert.StartsWith("[AS]", spec));
         Assert.DoesNotContain("[AS]*", specs);
-        Assert.Equal(6, specs.Length);
+        Assert.Equal(4, specs.Length);
     }
 
     [Theory]

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/DiagnosticSourceEventSourceHandlerTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/DiagnosticSourceEventSourceHandlerTests.cs
@@ -38,4 +38,22 @@ public class DiagnosticSourceEventSourceHandlerTests
         Assert.DoesNotContain("[AS]*", specs);
         Assert.Equal(6, specs.Length);
     }
+
+    [Theory]
+    // Functions worker, schema 1.37.0+ ("function <name>", ActivityKind.Internal -> dependency): remap.
+    [InlineData("Microsoft.Azure.Functions.Worker", "function MySBFuncTest", true)]
+    [InlineData("Microsoft.Azure.Functions.Worker", "function SomeOtherFunction", true)]
+    // Functions worker, schema <= 1.17.0 ("Invoke", ActivityKind.Server -> request): do NOT remap.
+    [InlineData("Microsoft.Azure.Functions.Worker", "Invoke", false)]
+    // "function" without the trailing space is not the worker invocation naming.
+    [InlineData("Microsoft.Azure.Functions.Worker", "function", false)]
+    // Non-worker sources are never remapped, even with a "function "-like name.
+    [InlineData("Microsoft.AspNetCore", "function MySBFuncTest", false)]
+    [InlineData("Azure.Messaging.ServiceBus.ServiceBusProcessor", "ServiceBusProcessor.ProcessMessage", false)]
+    [InlineData("Azure.Messaging.ServiceBus.ServiceBusReceiver", "ServiceBusReceiver.Receive", false)]
+    [InlineData(null, "function MySBFuncTest", false)]
+    public void ShouldRemapToParentRequest_OnlyForInternalWorkerSchema(string? sourceName, string requestName, bool expected)
+    {
+        Assert.Equal(expected, DiagnosticSourceEventSourceHandler.ShouldRemapToParentRequest(sourceName, requestName));
+    }
 }

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/RequestActivityRelayTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/RequestActivityRelayTests.cs
@@ -11,11 +11,9 @@ public class RequestActivityRelayTests
     [Theory]
     // ASP.NET Core HTTP-in.
     [InlineData("Microsoft.AspNetCore.Hosting.HttpRequestIn")]
-    // Service Bus single-dispatch (processor) consumption.
+    // Service Bus single-dispatch (processor) consumption — ActivityKind.Consumer -> request.
     [InlineData("ServiceBusProcessor.ProcessMessage")]
     [InlineData("ServiceBusSessionProcessor.ProcessSessionMessage")]
-    // Service Bus batch (receiver) consumption, e.g. Azure Functions batch triggers.
-    [InlineData("ServiceBusReceiver.Receive")]
     // Azure Functions isolated worker per-invocation activity.
     // Older worker schema (<= 1.17.0) uses the literal "Invoke".
     [InlineData("Invoke")]
@@ -30,7 +28,8 @@ public class RequestActivityRelayTests
     [Theory]
     // HTTP-out is explicitly excluded.
     [InlineData("System.Net.Http.HttpRequestOut")]
-    // Non-consumption Service Bus receiver operations are excluded.
+    // Service Bus receiver operations are ActivityKind.Client (dependencies), not requests — excluded.
+    [InlineData("ServiceBusReceiver.Receive")]
     [InlineData("ServiceBusReceiver.Complete")]
     [InlineData("ServiceBusReceiver.Abandon")]
     [InlineData("ServiceBusReceiver.Peek")]

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/RequestActivityRelayTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/RequestActivityRelayTests.cs
@@ -76,4 +76,32 @@ public class RequestActivityRelayTests
     {
         Assert.Throws<InvalidDataException>(() => RequestActivityRelay.ExtractKeyIds(id));
     }
+
+    [Fact]
+    public void TryExtractKeyIds_ValidW3CId_ReturnsTrueWithSpanAndTraceId()
+    {
+        bool ok = RequestActivityRelay.TryExtractKeyIds(
+            "00-10a36f22b23e6acb788d5412acd510c7-aca3108a6da34543-01",
+            out string requestId,
+            out string operationId);
+
+        Assert.True(ok);
+        Assert.Equal("aca3108a6da34543", requestId);                  // span-id (parent → request id)
+        Assert.Equal("10a36f22b23e6acb788d5412acd510c7", operationId); // trace-id
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("00-traceid-spanid")]          // only 3 sections
+    [InlineData("00--spanid-01")]              // empty trace-id
+    [InlineData("00-traceid--01")]             // empty span-id
+    public void TryExtractKeyIds_InvalidId_ReturnsFalse(string? id)
+    {
+        bool ok = RequestActivityRelay.TryExtractKeyIds(id, out string requestId, out string operationId);
+
+        Assert.False(ok);
+        Assert.Equal(string.Empty, requestId);
+        Assert.Equal(string.Empty, operationId);
+    }
 }

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/RequestActivityRelayTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/RequestActivityRelayTests.cs
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using Azure.Monitor.OpenTelemetry.Profiler.Core.EventListeners;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Tests;
+
+public class RequestActivityRelayTests
+{
+    [Theory]
+    // ASP.NET Core HTTP-in.
+    [InlineData("Microsoft.AspNetCore.Hosting.HttpRequestIn")]
+    // Service Bus single-dispatch (processor) consumption.
+    [InlineData("ServiceBusProcessor.ProcessMessage")]
+    [InlineData("ServiceBusSessionProcessor.ProcessSessionMessage")]
+    // Service Bus batch (receiver) consumption, e.g. Azure Functions batch triggers.
+    [InlineData("ServiceBusReceiver.Receive")]
+    // Azure Functions isolated worker per-invocation activity.
+    [InlineData("Invoke")]
+    public void IsInterestingRequest_KnownRequestNames_ReturnsTrue(string requestName)
+    {
+        Assert.True(RequestActivityRelay.IsInterestingRequest(requestName));
+    }
+
+    [Theory]
+    // HTTP-out is explicitly excluded.
+    [InlineData("System.Net.Http.HttpRequestOut")]
+    // Non-consumption Service Bus receiver operations are excluded.
+    [InlineData("ServiceBusReceiver.Complete")]
+    [InlineData("ServiceBusReceiver.Abandon")]
+    [InlineData("ServiceBusReceiver.Peek")]
+    [InlineData("ServiceBusReceiver.RenewMessageLock")]
+    // Service Bus send is excluded.
+    [InlineData("ServiceBusSender.Send")]
+    // Session lock/state operations are excluded.
+    [InlineData("ServiceBusSessionReceiver.RenewSessionLock")]
+    // Case sensitivity: matching is ordinal.
+    [InlineData("invoke")]
+    [InlineData("servicebusprocessor.processmessage")]
+    // Unrelated / empty.
+    [InlineData("")]
+    [InlineData("SomeOther.Activity")]
+    public void IsInterestingRequest_UnknownRequestNames_ReturnsFalse(string requestName)
+    {
+        Assert.False(RequestActivityRelay.IsInterestingRequest(requestName));
+    }
+
+    [Fact]
+    public void ExtractKeyIds_ValidW3CId_ReturnsSpanIdAndTraceId()
+    {
+        // W3C trace context: 00-<trace-id>-<span-id>-<flags>
+        string id = "00-4dee62c12eaa9efca3d1f0565f3efda6-b3c470a7ee10c13b-01";
+
+        (string requestId, string operationId) = RequestActivityRelay.ExtractKeyIds(id);
+
+        Assert.Equal("b3c470a7ee10c13b", requestId);   // span-id
+        Assert.Equal("4dee62c12eaa9efca3d1f0565f3efda6", operationId); // trace-id
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("00-traceid-spanid")]               // only 3 sections
+    [InlineData("00-traceid-spanid-01-extra")]      // 5 sections
+    [InlineData("00--spanid-01")]                   // empty trace-id
+    [InlineData("00-traceid--01")]                  // empty span-id
+    public void ExtractKeyIds_InvalidId_Throws(string id)
+    {
+        Assert.Throws<InvalidDataException>(() => RequestActivityRelay.ExtractKeyIds(id));
+    }
+}

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/RequestActivityRelayTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/RequestActivityRelayTests.cs
@@ -17,7 +17,11 @@ public class RequestActivityRelayTests
     // Service Bus batch (receiver) consumption, e.g. Azure Functions batch triggers.
     [InlineData("ServiceBusReceiver.Receive")]
     // Azure Functions isolated worker per-invocation activity.
+    // Older worker schema (<= 1.17.0) uses the literal "Invoke".
     [InlineData("Invoke")]
+    // Worker schema 1.37.0+ uses "function <FunctionName>".
+    [InlineData("function MySBFuncTest")]
+    [InlineData("function SomeOtherFunction")]
     public void IsInterestingRequest_KnownRequestNames_ReturnsTrue(string requestName)
     {
         Assert.True(RequestActivityRelay.IsInterestingRequest(requestName));
@@ -38,6 +42,10 @@ public class RequestActivityRelayTests
     // Case sensitivity: matching is ordinal.
     [InlineData("invoke")]
     [InlineData("servicebusprocessor.processmessage")]
+    // "function " prefix boundary: no trailing space / different word must not match.
+    [InlineData("function")]
+    [InlineData("functional.Thing")]
+    [InlineData("Function MyFunc")]
     // Unrelated / empty.
     [InlineData("")]
     [InlineData("SomeOther.Activity")]


### PR DESCRIPTION
## Summary

Fixes #147.

Makes the OpenTelemetry profiler capture and correctly correlate **Azure Functions isolated worker** invocations (the scenario that surfaced this was a Service Bus trigger), and fixes a sample-loss race and a Service Bus capture-scope bug found along the way.

In the isolated model the Service Bus SDK runs in the Functions **host** process, so the only request-like activity visible to the in-worker profiler is the worker's per-invocation span from ActivitySource `Microsoft.Azure.Functions.Worker`. That span is `ActivityKind.Internal` → Azure Monitor records it as a **dependency**, a child of the **request** the host emits (e.g. `ServiceBusProcessor.ProcessMessage`). This PR captures that worker span and anchors the profiler sample on its **parent** (the host request) so the profile correlates.

## Changes

- **Capture the Functions worker source** — add `[AS]Microsoft.Azure.Functions.Worker/` to `FilterAndPayloadSpecs`, and match the invocation in `IsInterestingRequest`. The worker operation name is schema-dependent: `"Invoke"` (schema ≤ 1.17.0, `ActivityKind.Server`) and `"function <FunctionName>"` (schema 1.37.0+, `ActivityKind.Internal`); both are matched.

- **Correlate isolated-worker samples to the host request** — for the worker `function <name>` (Internal) activity, remap the sample's `RequestId`/`OperationId` to the activity's **parent** span id (the host-emitted request) instead of its own (dependency) span id. The remap is gated to `SourceName == Microsoft.Azure.Functions.Worker` **and** name starting with `"function "`, so the `"Invoke"` (Server = request) span keeps its own id, as do ASP.NET Core and Service Bus processor activities. Uses a non-throwing `TryExtractKeyIds` with a safe fallback to the own id.

- **Fix empty-sample upload failure** — `SampleCollector` now enables the internal data-adapter `EventSource` **eagerly and synchronously** in its constructor. Previously the async `OnEventSourceCreated → Task.Run → EnableEvents` path lost a race when a concurrent burst of requests started the instant the source was first created (e.g. a Service Bus batch trigger), dropping the `Start` events and producing zero samples — which made the uploader fail with `[ActivityListValidator] No sample activities to match.`

- **Stop capturing Service Bus receiver activities** — `ServiceBusReceiver.Receive` (and `Peek`/`Complete`/…) are `ActivityKind.Client` (dependencies), not requests, so they can never correlate to a request and also fire inside the processor's own receive loop. Removed the receiver/session-receiver sources from the spec and `ServiceBusReceiver.Receive` from `IsInterestingRequest`.

- **`Both`-mode consistency** — the `OpenTelemetry-Sdk` handler returns early for `"function "`-prefixed worker activities (its events carry no `ParentId`, so it cannot do the parent remap), leaving them to the DiagnosticSource handler so the shared relay doesn't emit a Start/Stop pair with mismatched ids.

- **ActivityId reset** — extend the bridge `ActivityId` reset listener (renamed `ServiceBusActivityIdResetListener` → `RequestActivityIdResetListener`) to the worker source, mirroring the Service Bus processor handling.

## Verification

- New/updated unit tests for `IsInterestingRequest`, `FilterAndPayloadSpecs`, `ShouldRemapToParentRequest`, and `ExtractKeyIds`/`TryExtractKeyIds`. All **70** OTel profiler tests pass.
- Each behavior validated against the Azure SDK / Functions worker SDK source (ActivityKinds, activity names) and against live App Insights telemetry (the worker dependency's `operation_ParentId` equals the host request id; the remap targets that id).
- Iterative code review with GPT‑5.5 and Opus 4.7 to **two consecutive clean rounds** (three genuine defects caught and fixed during review).