### PR TITLE
Improve shutdown/IPC diagnostics and fix StopServiceProfilerAsync races

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/IPC/DuplexNamedPipeService.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/IPC/DuplexNamedPipeService.cs
@@ -155,6 +155,20 @@ internal sealed class DuplexNamedPipeService : INamedPipeServerService, INamedPi
         VerifyModeIsSpecified();
         string payload = await ReadMessageAsync(timeout, cancellationToken).ConfigureAwait(false);
         _logger.LogTrace("Reading payload from named pipe: {payload}", payload);
+
+        // An empty payload means the stream reached end-of-file: the peer closed the pipe before
+        // sending a message (timeouts surface as TimeoutException, and outgoing empty messages are
+        // rejected on the send side). Surface this as a distinct, actionable error instead of a
+        // misleading deserialization failure so the real cause - the peer (e.g. the uploader)
+        // exiting early - is visible in the logs.
+        if (string.IsNullOrEmpty(payload))
+        {
+            string closedMessage = $"Named pipe was closed by the peer before a {typeof(T).FullName} message could be read. " +
+                "The other process (for example, the trace uploader) likely exited prematurely; check its logs for the underlying failure.";
+            _logger.LogError(closedMessage);
+            throw new NamedPipeClosedException(closedMessage);
+        }
+
         if (_payloadSerializer.TryDeserialize<T>(payload, out T? result))
         {
             return result;

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/IPC/NamedPipeClosedException.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/IPC/NamedPipeClosedException.cs
@@ -1,0 +1,13 @@
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.IPC;
+
+/// <summary>
+/// Exception thrown when the named pipe is closed by the peer before a message could be read.
+/// This typically means the other process (for example, the trace uploader) exited prematurely.
+/// Check that process's logs for the underlying failure.
+/// </summary>
+internal class NamedPipeClosedException : System.Exception
+{
+    public NamedPipeClosedException() { }
+    public NamedPipeClosedException(string message) : base(message) { }
+    public NamedPipeClosedException(string message, System.Exception inner) : base(message, inner) { }
+}

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/OpenTelemetryProfilerProvider.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/OpenTelemetryProfilerProvider.cs
@@ -123,6 +123,7 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
         _logger.LogTrace("Entering {StopServiceProfilerAsync}.", nameof(StopServiceProfilerAsync));
 
         bool profilerStopped = false;
+        bool semaphoreReleased = false;
 
         if (source is null)
         {
@@ -148,10 +149,11 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
 
         try
         {
-            // Copy resource usage values captured at session start before releasing the semaphore,
-            // to avoid a race where a new session could overwrite these fields.
+            // Copy values captured at session start before releasing the semaphore, to avoid a race
+            // where a new session could overwrite these fields once the semaphore is released below.
             float cpuUsage = _sessionCPUUsage;
             float memoryUsage = _sessionMemoryUsage;
+            string currentTraceFilePath = _currentTraceFilePath;
 
             // Notice: Stop trace session listener has to be happen before calling ITraceControl.Disable().
             // Trace control disabling will take a while. We shall not gathering anything events when disable is happening.
@@ -163,16 +165,44 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
             // Disable the EventPipe.
             await _traceControl.DisableAsync(cancellationToken).ConfigureAwait(false);
             profilerStopped = true;
-            ReleaseSemaphoreForProfiling();
+            // Release the semaphore as soon as the trace is disabled so a new session can start
+            // while the (potentially long) post-stop processing/upload runs. Mark it as released in
+            // a finally so that even if Release() throws (e.g. the semaphore was disposed during
+            // shutdown), the outer finally does not attempt a second release - that would throw
+            // again and mask the original outcome, or free a semaphore acquired by a newer session.
+            try
+            {
+                ReleaseSemaphoreForProfiling();
+            }
+            finally
+            {
+                semaphoreReleased = true;
+            }
 
-            await _postStopProcessorFactory.Create().PostStopProcessAsync(new PostStopOptions(
-                _currentTraceFilePath,
-                currentSessionId.Value,
-                stampFrontendHostUrl: _serviceProfilerContext.StampFrontendEndpointUrl,
-                sampleActivities ?? Enumerable.Empty<SampleActivity>(),
-                source,
-                averageCPUUsage: cpuUsage,
-                averageMemoryUsage: memoryUsage), cancellationToken).ConfigureAwait(false);
+            // Only the post-stop processing resolves services from the (possibly disposed during
+            // shutdown) root IServiceProvider, so scope the ObjectDisposedException handling to just
+            // this call. An ObjectDisposedException from anywhere else (e.g. DisableAsync) must still
+            // propagate so the caller learns the stop failed and the semaphore handling stays correct.
+            try
+            {
+                await _postStopProcessorFactory.Create().PostStopProcessAsync(new PostStopOptions(
+                    currentTraceFilePath,
+                    currentSessionId.Value,
+                    stampFrontendHostUrl: _serviceProfilerContext.StampFrontendEndpointUrl,
+                    sampleActivities ?? Enumerable.Empty<SampleActivity>(),
+                    source,
+                    averageCPUUsage: cpuUsage,
+                    averageMemoryUsage: memoryUsage), cancellationToken).ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException ex)
+            {
+                // The root IServiceProvider can be disposed while a profiling session is being stopped
+                // during host shutdown (the post-stop processor is resolved via the service provider).
+                // In that case there is nothing more we can do - the upload cannot proceed once the
+                // container is torn down - so log it and return gracefully instead of a noisy error.
+                _logger.LogWarning(ex, "Service provider was disposed (likely during host shutdown) before post-stop processing finished. Skipping trace upload.");
+                return false;
+            }
 
             _logger.LogInformation(StopProfilerSucceeded);
 
@@ -192,7 +222,7 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
         }
         finally
         {
-            if (profilerStopped)
+            if (profilerStopped && !semaphoreReleased)
             {
                 ReleaseSemaphoreForProfiling();
             }


### PR DESCRIPTION
## Summary

Fixes #150.

Two confusing profiler errors seen in testing turned out to be diagnostics gaps that hid the real cause. This PR makes both paths self-explanatory and hardens `StopServiceProfilerAsync` against shutdown/concurrency races found along the way.

## Changes

- **Gracefully handle a disposed `IServiceProvider` during shutdown** — on host shutdown the root `IServiceProvider` can be disposed while the final profiling cycle runs post-stop processing (`PostStopProcessorFactory.Create()` -> `ActivatorUtilities.CreateInstance`), throwing `ObjectDisposedException` and surfacing as a noisy unhandled error. `StopServiceProfilerAsync` now catches it **scoped to only the post-stop call** and logs a warning instead. An `ObjectDisposedException` from anywhere else (e.g. `DisableAsync`) still propagates so a genuine stop failure is not swallowed.

- **Distinguish named-pipe EOF from a deserialization failure** — when the uploader process exits early, the agent's `DuplexNamedPipeService.ReadAsync<T>` read returns an empty (EOF) payload, which was reported as a misleading `Failed to deserialize named pipe message as System.Guid`. It now detects the empty/closed-pipe payload and throws a new `NamedPipeClosedException` with an actionable message pointing at the uploader's own logs. (Timeouts already surface as `TimeoutException`, and the send path rejects empty messages, so an empty payload reliably means the peer closed the pipe.)

- **Fix semaphore/state races in the stop path** (found during review of the above):
  - Capture session-scoped fields (`_currentTraceFilePath`, `_sessionCPUUsage`, `_sessionMemoryUsage`) into locals **before** the early semaphore release, so a session that starts during the long post-stop upload cannot redirect this session's upload.
  - Guard the `finally` release with a `semaphoreReleased` flag (set inside a `finally` around the early release) so the stop never double-releases a semaphore re-acquired by a newer session, even if `Release()` itself throws.

## Context

The underlying trigger in our test run was a `403 Forbidden` from the ingestion service (`IngestionClient.GetAppProfileAsync`) because the AAD identity lacked the **Monitoring Metrics Publisher** role on the App Insights resource. That is an environment/permissions issue, not a code bug — but the old diagnostics made it look like a serialization defect. With this change the failure points at the right place.

## Verification

- Full solution builds clean (0 errors).
- Iterative code review with GPT-5.5 and Opus 4.7 to **two consecutive clean rounds**; four genuine defects (a semaphore double-release race, a trace-path race, a `Release()`-throws masking case, and an over-broad `ObjectDisposedException` catch that could leak the semaphore) were caught and fixed during review.