### PR TITLE
Fix #151: customer notable Start/Stop traces dropped (iKey-only connection string)

### DIFF
--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Azure.Monitor.Diagnostics.Profiler;
+using Azure.Core;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Profiler.Core.Auth;
 using Microsoft.ApplicationInsights.Profiler.Core.Contracts;
@@ -16,6 +17,7 @@ using Microsoft.ApplicationInsights.Profiler.Shared.Services;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions.Auth;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions.IPC;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Auth;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.IPC;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.RoleNames;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.TraceScavenger;
@@ -87,8 +89,7 @@ internal static class ServiceCollectionExtensions
 
         // Telemetry - TODO:
         // 1. Have a dedicated application insights resource
-        // 2. Use the connection string
-        // 3. Support multiple endpoints / multiple clouds
+        // 2. Support multiple endpoints / multiple clouds
 
         // AI for Microsoft depends on user settings.
         services.AddSingleton<IAppInsightsLogger>(provider =>
@@ -110,9 +111,10 @@ internal static class ServiceCollectionExtensions
         });
 
         // AI for the customer.
-        // TODO: Use connection string instead.
-        services.AddSingleton<IAppInsightsLogger>(p =>
-            ActivatorUtilities.CreateInstance<EventPipeAppInsightsLogger>(p, p.GetRequiredService<IServiceProfilerContext>().AppInsightsInstrumentationKey));
+        // Build the customer telemetry client from the full connection string (so the regional
+        // IngestionEndpoint is honored) and the configured AAD token credential (so it works when
+        // local auth is disabled). This is the same mechanism used by AgentStatusSender.
+        services.AddSingleton<IAppInsightsLogger>(CreateCustomerAppInsightsLogger);
 
         // Heartbeats
         services.TryAddSingleton<IEventPipeTelemetryTracker, TelemetryTracker>();
@@ -241,6 +243,48 @@ internal static class ServiceCollectionExtensions
             .AddUploaderCallerServices()
             .AddTraceScavengerServices()
             .AddTraceControl();
+    }
+
+    /// <summary>
+    /// Creates the customer-facing Application Insights logger used for the profiler's notable
+    /// Start/Stop traces. Unlike the Microsoft anonymous-telemetry logger, this uses the full
+    /// connection string (so the regional IngestionEndpoint is honored) and the configured AAD
+    /// token credential (so it works when local auth is disabled).
+    /// </summary>
+    private static IAppInsightsLogger CreateCustomerAppInsightsLogger(IServiceProvider provider)
+    {
+        ILoggerFactory loggerFactory = provider.GetRequiredService<ILoggerFactory>();
+        ILogger logger = loggerFactory.CreateLogger("Microsoft.ApplicationInsights.Profiler.Core.Logging.CustomerAppInsightsLogger");
+
+        ConnectionString? connectionString = provider.GetRequiredService<IServiceProfilerContext>().ConnectionString;
+        if (connectionString is null)
+        {
+            logger.LogDebug("No Application Insights connection string is available. Customer notable-trace telemetry is disabled.");
+            return new NullAppInsightsLogger();
+        }
+
+        IAuthTokenProvider authTokenProvider = provider.GetRequiredService<IAuthTokenProvider>();
+        TokenCredential? tokenCredential = authTokenProvider.IsAADAuthenticateEnabled
+            ? new AADAuthTokenCredential(authTokenProvider, loggerFactory.CreateLogger<AADAuthTokenCredential>())
+            : null;
+
+        // Hardening: surface a warning when there is no ingestion endpoint to route to. Without it,
+        // telemetry falls back to the global endpoint and is silently dropped by workspace-based resources.
+        if (connectionString.GetFeatureEndpoint("Ingestion") is null)
+        {
+            logger.LogWarning(
+                "The Application Insights connection string does not specify an IngestionEndpoint. Profiler Start/Stop traces are " +
+                "sent to the global ingestion endpoint and may be dropped by workspace-based resources. Provide a full connection " +
+                "string (including IngestionEndpoint) to ensure these traces are ingested.");
+        }
+
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfigurationBuilder(
+            connectionString,
+            tokenCredential,
+            telemetryInitializers: [],
+            loggerFactory.CreateLogger<TelemetryConfigurationBuilder>()).Build();
+
+        return new EventPipeAppInsightsLogger(telemetryConfiguration);
     }
 
     // Register services related to Application Insights AAD Auth

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Logging/EventPipeAppInsightsLogger.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Logging/EventPipeAppInsightsLogger.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.ServiceProfiler.Utilities;
 using ServiceProfiler.Common.Utilities;
 
@@ -20,34 +19,37 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Logging
         private readonly TelemetryClient _telemetryClient;
         private readonly TelemetryConfiguration _telemetryConfiguration;
         private bool _isDisposed = false;
-        private readonly ServiceProvider _standaloneServiceProvider;
 
-        public EventPipeAppInsightsLogger(
-            Guid instrumentationKey)
+        /// <summary>
+        /// Creates a logger that sends telemetry using an instrumentation-key-only connection string.
+        /// This routes telemetry to the global ingestion endpoint without AAD authentication and is
+        /// intended only for Microsoft's anonymous-usage telemetry, not customer telemetry.
+        /// </summary>
+        public EventPipeAppInsightsLogger(Guid instrumentationKey)
+            : this(CreateInstrumentationKeyOnlyConfiguration(instrumentationKey))
         {
-            // Build the AI client and hook it up with ILogger according to the code here:
-            // https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/3dcab5b92ebddc92e9010fc707cc7062d03f92e4/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
-            // and here: https://github.com/aspnet/Logging/blob/c821494678a30c323174bea8056f43b93a3ca6f4/src/Microsoft.Extensions.Logging/LoggingServiceCollectionExtensions.cs
-            ServiceCollection services = new ServiceCollection();
-            string instrumentationKeyString = instrumentationKey.ToString();
-            _telemetryConfiguration = new TelemetryConfiguration();
-            _telemetryConfiguration.ConnectionString = $"InstrumentationKey={instrumentationKeyString}";
-            _telemetryClient = new TelemetryClient(_telemetryConfiguration);
-            services.AddApplicationInsightsTelemetry(options =>
-            {
-                options.ConnectionString = _telemetryConfiguration.ConnectionString;
-            });
+        }
 
-            // Hack: remove the existing telemetryClient that uses default iKey. Replace it with the one using MS iKey
-            services.Remove(new ServiceDescriptor(typeof(TelemetryClient), typeof(TelemetryClient), ServiceLifetime.Singleton));
-            services.AddSingleton(_telemetryClient);
-            // ~
-            _standaloneServiceProvider = services.BuildServiceProvider();
+        /// <summary>
+        /// Creates a logger that sends telemetry using a fully configured <see cref="TelemetryConfiguration"/>.
+        /// Use this overload for customer telemetry so the regional IngestionEndpoint and AAD token credential
+        /// (when configured) are honored. Build the configuration with TelemetryConfigurationBuilder.
+        /// </summary>
+        public EventPipeAppInsightsLogger(TelemetryConfiguration telemetryConfiguration)
+        {
+            _telemetryConfiguration = telemetryConfiguration ?? throw new ArgumentNullException(nameof(telemetryConfiguration));
+            _telemetryClient = new TelemetryClient(_telemetryConfiguration);
 
             // Reference https://github.com/Microsoft/ApplicationInsights-Home/blob/master/EndpointSpecs/SDK-VERSIONS.md for SDK Name.
             string sdkVersion = EnvironmentUtilities.GetApplicationInsightsSdkVersion("l_ap:");
             SetCommonProperty(Constants.SdkVersion, sdkVersion);
         }
+
+        private static TelemetryConfiguration CreateInstrumentationKeyOnlyConfiguration(Guid instrumentationKey)
+            => new TelemetryConfiguration
+            {
+                ConnectionString = $"InstrumentationKey={instrumentationKey}",
+            };
 
         /// <summary>
         /// Get and set the instrumentation key. By setting it to 'null' you can disable the logger.
@@ -187,7 +189,6 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Logging
             {
                 Flush();
                 _telemetryConfiguration.Dispose();
-                _standaloneServiceProvider.Dispose();
             }
 
             _isDisposed = true;

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/EventPipeAppInsightsLoggerTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/EventPipeAppInsightsLoggerTests.cs
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+using System;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Profiler.Core.Logging;
+using ServiceProfiler.Common.Utilities;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Client.Tests
+{
+    public class EventPipeAppInsightsLoggerTests
+    {
+        private static readonly Guid TestIKey = Guid.Parse("8e321e78-834f-4397-96fd-297fa844d140");
+        private const string RegionalIngestionEndpoint = "https://westus2-2.in.applicationinsights.azure.com/";
+
+        [Fact]
+        public void ShouldExposeConnectionStringWhenBuiltFromFullConfiguration()
+        {
+            Assert.True(ConnectionString.TryParse(
+                $"InstrumentationKey={TestIKey};IngestionEndpoint={RegionalIngestionEndpoint}",
+                out ConnectionString connectionString));
+
+            using TelemetryConfiguration telemetryConfiguration = new()
+            {
+                ConnectionString = connectionString.ToString(),
+            };
+
+            using EventPipeAppInsightsLogger logger = new(telemetryConfiguration);
+
+            Assert.NotNull(logger.ConnectionString);
+            Assert.Equal(TestIKey, logger.ConnectionString!.InstrumentationKeyGuid);
+        }
+
+        [Fact]
+        public void ShouldBuildInstrumentationKeyOnlyConfigurationFromGuid()
+        {
+            using EventPipeAppInsightsLogger logger = new(TestIKey);
+
+            Assert.NotNull(logger.ConnectionString);
+            Assert.Equal(TestIKey, logger.ConnectionString!.InstrumentationKeyGuid);
+        }
+
+        [Fact]
+        public void ShouldThrowWhenConfigurationIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new EventPipeAppInsightsLogger((TelemetryConfiguration)null!));
+        }
+    }
+}

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/TelemetryConfigurationBuilderTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/TelemetryConfigurationBuilderTests.cs
@@ -1,0 +1,81 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Profiler.Core.Utilities;
+using Microsoft.Extensions.Logging.Abstractions;
+using ServiceProfiler.Common.Utilities;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Client.Tests
+{
+    public class TelemetryConfigurationBuilderTests
+    {
+        private const string TestIKey = "8e321e78-834f-4397-96fd-297fa844d140";
+        private const string RegionalIngestionEndpoint = "https://westus2-2.in.applicationinsights.azure.com/";
+
+        [Fact]
+        public void ShouldApplyRegionalIngestionEndpointFromFullConnectionString()
+        {
+            Assert.True(ConnectionString.TryParse(
+                $"InstrumentationKey={TestIKey};IngestionEndpoint={RegionalIngestionEndpoint}",
+                out ConnectionString connectionString));
+
+            using TelemetryConfiguration telemetryConfiguration = BuildWith(connectionString, tokenCredential: null);
+
+            Assert.Contains("westus2-2.in.applicationinsights.azure.com", telemetryConfiguration.TelemetryChannel.EndpointAddress);
+        }
+
+        [Fact]
+        public void ShouldApplyTokenCredentialWhenProvided()
+        {
+            Assert.True(ConnectionString.TryParse(
+                $"InstrumentationKey={TestIKey};IngestionEndpoint={RegionalIngestionEndpoint}",
+                out ConnectionString connectionString));
+
+            using TelemetryConfiguration telemetryConfiguration = BuildWith(connectionString, new StubTokenCredential());
+
+            Assert.NotNull(GetCredentialEnvelope(telemetryConfiguration));
+        }
+
+        [Fact]
+        public void ShouldNotApplyTokenCredentialWhenNull()
+        {
+            Assert.True(ConnectionString.TryParse(
+                $"InstrumentationKey={TestIKey};IngestionEndpoint={RegionalIngestionEndpoint}",
+                out ConnectionString connectionString));
+
+            using TelemetryConfiguration telemetryConfiguration = BuildWith(connectionString, tokenCredential: null);
+
+            Assert.Null(GetCredentialEnvelope(telemetryConfiguration));
+        }
+
+        private static TelemetryConfiguration BuildWith(ConnectionString connectionString, TokenCredential? tokenCredential)
+            => new TelemetryConfigurationBuilder(
+                connectionString,
+                tokenCredential,
+                telemetryInitializers: [],
+                NullLogger<TelemetryConfigurationBuilder>.Instance).Build();
+
+        private static object? GetCredentialEnvelope(TelemetryConfiguration telemetryConfiguration)
+            => typeof(TelemetryConfiguration)
+                .GetTypeInfo()
+                .GetDeclaredProperty("CredentialEnvelope")?
+                .GetValue(telemetryConfiguration);
+
+        private sealed class StubTokenCredential : TokenCredential
+        {
+            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+                => new AccessToken("stub-token", DateTimeOffset.UtcNow.AddHours(1));
+
+            public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+                => new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #151. The classic profiler's customer-facing `EventPipeAppInsightsLogger` was registered with an **instrumentation-key-only** connection string. That dropped the regional `IngestionEndpoint` (so telemetry went to the global `dc.services.visualstudio.com` default) and never applied the configured AAD `TokenCredential`. As a result the profiler's notable lifecycle traces — `StartProfilerTriggered`, `StartProfilerSucceeded`, `StopProfilerTriggered`, `StopProfilerSucceeded` — were **silently dropped** on workspace-based Application Insights resources and on resources with local auth disabled (`DisableLocalAuth: true`).

These notable traces are emitted via `IAppInsightsSinks` → `EventPipeAppInsightsLogger.TrackTrace`, which is a separate `TelemetryClient` from the `ILogger`/agent-status pipeline. That is why agent-status traces were ingested correctly while the Start/Stop traces never appeared.

## Changes

- **`EventPipeAppInsightsLogger`** now accepts a fully-built `TelemetryConfiguration`. A `Guid` convenience constructor is kept for the Microsoft anonymous-telemetry loggers (unchanged, still iKey-only). Removed a dead standalone `ServiceProvider` / `AddApplicationInsightsTelemetry` block that was constructed but never resolved.
- **`ServiceCollectionExtensions.CreateCustomerAppInsightsLogger`** builds the customer logger's `TelemetryConfiguration` via the existing `TelemetryConfigurationBuilder`, using `IServiceProfilerContext.ConnectionString` (full connection string, with regional `IngestionEndpoint`) and an `AADAuthTokenCredential` when `IAuthTokenProvider.IsAADAuthenticateEnabled`. This is the same mechanism `AgentStatusSender` already uses successfully.
- **Hardening:** logs a one-time warning when the connection string would fall back to the global default endpoint (`GetFeatureEndpoint("Ingestion") is null`), so silent drops become diagnosable.
- Removed the now-obsolete "use the connection string" TODOs.

## Why this is correct / scope

- **OTel profiler is unaffected** — it emits these traces through `ILogger`, not `IAppInsightsSinks`. This change is scoped to the classic in-process profiler only.
- **Microsoft anonymous-telemetry path is unchanged** — it still uses the `Guid` (iKey-only) constructor on its own endpoint.
- The warning predicate was verified empirically: `GetFeatureEndpoint("Ingestion")` is null **only** for a bare-iKey connection string, which the AI SDK routes to the global default endpoint. `EndpointSuffix` (sovereign cloud) and explicit `IngestionEndpoint` both yield non-null and route to non-global endpoints, so no false-positive warning is raised.

## Tests

- `TelemetryConfigurationBuilderTests` — asserts a full connection string applies the regional ingestion endpoint to the channel, and that the AAD token credential is applied (`CredentialEnvelope` populated) when provided and absent otherwise.
- `EventPipeAppInsightsLoggerTests` — asserts the logger surfaces the connection string when built from a full configuration, the `Guid` ctor still produces an iKey-only logger, and the null-config guard.

All 35 tests in `ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests` pass; the full `EventPipe.Profilers.All.sln` builds clean.

## Review

Iterative code review with GPT-5.5 and Opus 4.7 to **two consecutive clean rounds**. One round-1 finding (a suspected gap in the missing-endpoint warning predicate) was investigated, empirically disproved, and confirmed correct by both reviewers.