### PR TITLE
Remove dangling NuGetVersions.props symlink

### DIFF
--- a/NuGetVersions.props
+++ b/NuGetVersions.props
@@ -1,1 +1,0 @@
-ServiceProfiler/NuGetVersions.props


### PR DESCRIPTION
## Summary

Removes the tracked top-level symlink `NuGetVersions.props` → `ServiceProfiler/NuGetVersions.props`, which is **dangling** at the currently pinned submodule commit.

## Why

The `ServiceProfiler` submodule deleted `NuGetVersions.props` in `71640f3ff` ("Use nuget central package management") when it migrated to Central Package Management (`Directory.Packages.props`). That deletion is in the ancestry of the pinned submodule commit, so a fresh checkout has no target and the symlink dangles.

Nothing in this repo imports `NuGetVersions.props` (`git grep NuGetVersions` outside the submodule returns nothing), so builds are unaffected. However, any tooling that recursively walks the working tree and follows symlinks breaks on the stale link — e.g. the OneBranch signing task failed with `ENOENT ... stat 'NuGetVersions.props'`.

This removes the latent hazard at the source rather than papering over it.

## Verification

- `git ls-files -s NuGetVersions.props` → tracked symlink (mode `120000`) before removal.
- `Test-Path ServiceProfiler/NuGetVersions.props` → `False` (dangling).
- `git grep NuGetVersions` outside the submodule → no references.
- Committed as a clean symlink deletion (`delete mode 120000`).

Fixes #149