### PR TITLE
Distinguish connection string error messages (null vs empty vs malformed)

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/ConnectionStringValidationResult.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/ConnectionStringValidationResult.cs
@@ -1,0 +1,37 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+
+/// <summary>
+/// Describes the outcome of validating the configured connection string, without
+/// exposing the raw connection string value itself.
+/// </summary>
+internal enum ConnectionStringValidationResult
+{
+    /// <summary>
+    /// The connection string is present and parsed into a usable instrumentation key.
+    /// </summary>
+    Valid,
+
+    /// <summary>
+    /// No connection string was provided (the raw value is <see langword="null"/>).
+    /// </summary>
+    NotConfigured,
+
+    /// <summary>
+    /// A connection string was provided but is empty or whitespace.
+    /// </summary>
+    Empty,
+
+    /// <summary>
+    /// The connection string is present but its instrumentation key is missing or malformed.
+    /// </summary>
+    InvalidInstrumentationKey,
+
+    /// <summary>
+    /// The connection string is present but could not be parsed for some other reason.
+    /// </summary>
+    Malformed,
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IServiceProfilerContext.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IServiceProfilerContext.cs
@@ -11,6 +11,13 @@ internal interface IServiceProfilerContext
 {
     ConnectionString? ConnectionString { get; }
 
+    /// <summary>
+    /// Gets the raw connection string value as provided by the user, before parsing.
+    /// This is null when no connection string was provided, and may be a non-empty but
+    /// unparsable value when the connection string is malformed.
+    /// </summary>
+    string? ConnectionStringValue { get; }
+
     Guid AppInsightsInstrumentationKey { get; }
 
     string MachineName { get; }

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IServiceProfilerContext.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IServiceProfilerContext.cs
@@ -12,11 +12,10 @@ internal interface IServiceProfilerContext
     ConnectionString? ConnectionString { get; }
 
     /// <summary>
-    /// Gets the raw connection string value as provided by the user, before parsing.
-    /// This is null when no connection string was provided, and may be a non-empty but
-    /// unparsable value when the connection string is malformed.
+    /// Gets the result of validating the configured connection string. This intentionally does
+    /// not expose the raw connection string value, so callers cannot misuse or leak it.
     /// </summary>
-    string? ConnectionStringValue { get; }
+    ConnectionStringValidationResult ConnectionStringValidation { get; }
 
     Guid AppInsightsInstrumentationKey { get; }
 

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerAgentBootstrap.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerAgentBootstrap.cs
@@ -48,8 +48,6 @@ internal class ServiceProfilerAgentBootstrap : IServiceProfilerAgentBootstrap
 
     public async Task ActivateAsync(CancellationToken cancellationToken)
     {
-        string noConnectionStringMessage = "No connection string is set. Application Insights Profiler won't start.";
-
         if (_serializer.TrySerialize(_userConfiguration, out string? serializedUserConfiguration))
         {
             _logger.LogDebug("User Settings:{eol} {details}", Environment.NewLine, serializedUserConfiguration);
@@ -84,18 +82,11 @@ internal class ServiceProfilerAgentBootstrap : IServiceProfilerAgentBootstrap
 
         try
         {
-            // Connection string exists.
-            if (string.IsNullOrEmpty(_serviceProfilerContext.ConnectionString?.ToString()))
+            // Diagnose the connection string state to provide an actionable error message.
+            string? connectionStringError = GetConnectionStringConfigurationError();
+            if (connectionStringError is not null)
             {
-                _logger.LogError(noConnectionStringMessage);
-                Activated(false);
-                return;
-            }
-
-            // Instrumentation key is well-formed.
-            if (_serviceProfilerContext.AppInsightsInstrumentationKey == Guid.Empty)
-            {
-                _logger.LogError("Instrumentation key is not set or malformed in the connection string. Application Insights Profiler won't start.");
+                _logger.LogError(connectionStringError + ProfilerWontStartSuffix);
                 Activated(false);
                 return;
             }
@@ -115,7 +106,7 @@ internal class ServiceProfilerAgentBootstrap : IServiceProfilerAgentBootstrap
         catch (ArgumentNullException ex) when (string.Equals(ex.ParamName, "instrumentationKey", StringComparison.OrdinalIgnoreCase))
         {
             Debug.Fail("You hit the safety net! How could it escape the instrumentation key check?");
-            _logger.LogError(noConnectionStringMessage);
+            _logger.LogError(NoConnectionStringMessage + ProfilerWontStartSuffix);
             Activated(false);
             return;
         }
@@ -134,5 +125,71 @@ internal class ServiceProfilerAgentBootstrap : IServiceProfilerAgentBootstrap
     private void Activated(bool isRunning)
     {
         _bootstrapState.SetProfilerRunning(isRunning);
+    }
+
+    private const string ProfilerWontStartSuffix = " Application Insights Profiler won't start.";
+    private const string NoConnectionStringMessage = "No connection string is set.";
+    private const string InstrumentationKeyMessage = "Instrumentation key is not set or malformed in the connection string.";
+
+    /// <summary>
+    /// Inspects the connection string configuration and returns an actionable error message
+    /// describing why the profiler cannot start, or <see langword="null"/> when it is valid.
+    /// </summary>
+    private string? GetConnectionStringConfigurationError()
+    {
+        string? connectionStringValue = _serviceProfilerContext.ConnectionStringValue;
+
+        if (connectionStringValue is null)
+        {
+            return NoConnectionStringMessage;
+        }
+
+        if (string.IsNullOrWhiteSpace(connectionStringValue))
+        {
+            return "The connection string is empty.";
+        }
+
+        // Connection string is present but could not be parsed.
+        if (_serviceProfilerContext.ConnectionString is null)
+        {
+            // Surface the more specific instrumentation-key error when the connection string
+            // explicitly contains an empty instrumentation key (e.g. "InstrumentationKey=").
+            return ContainsEmptyInstrumentationKey(connectionStringValue)
+                ? InstrumentationKeyMessage
+                : "The connection string is malformed and could not be parsed. Verify the connection string and that it contains a valid instrumentation key.";
+        }
+
+        // Connection string parsed, but the instrumentation key is missing or malformed.
+        if (_serviceProfilerContext.AppInsightsInstrumentationKey == Guid.Empty)
+        {
+            return InstrumentationKeyMessage;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Determines whether the raw connection string declares any
+    /// <c>InstrumentationKey</c> token whose value is empty or whitespace.
+    /// </summary>
+    private static bool ContainsEmptyInstrumentationKey(string connectionStringValue)
+    {
+        foreach (string token in connectionStringValue.Split(';'))
+        {
+            int separatorIndex = token.IndexOf('=');
+            if (separatorIndex < 0)
+            {
+                continue;
+            }
+
+            string key = token.Substring(0, separatorIndex).Trim();
+            if (key.Equals("InstrumentationKey", StringComparison.OrdinalIgnoreCase)
+                && string.IsNullOrWhiteSpace(token.Substring(separatorIndex + 1)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerAgentBootstrap.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerAgentBootstrap.cs
@@ -132,64 +132,16 @@ internal class ServiceProfilerAgentBootstrap : IServiceProfilerAgentBootstrap
     private const string InstrumentationKeyMessage = "Instrumentation key is not set or malformed in the connection string.";
 
     /// <summary>
-    /// Inspects the connection string configuration and returns an actionable error message
+    /// Maps the connection string validation result to an actionable error message
     /// describing why the profiler cannot start, or <see langword="null"/> when it is valid.
     /// </summary>
-    private string? GetConnectionStringConfigurationError()
+    private string? GetConnectionStringConfigurationError() => _serviceProfilerContext.ConnectionStringValidation switch
     {
-        string? connectionStringValue = _serviceProfilerContext.ConnectionStringValue;
-
-        if (connectionStringValue is null)
-        {
-            return NoConnectionStringMessage;
-        }
-
-        if (string.IsNullOrWhiteSpace(connectionStringValue))
-        {
-            return "The connection string is empty.";
-        }
-
-        // Connection string is present but could not be parsed.
-        if (_serviceProfilerContext.ConnectionString is null)
-        {
-            // Surface the more specific instrumentation-key error when the connection string
-            // explicitly contains an empty instrumentation key (e.g. "InstrumentationKey=").
-            return ContainsEmptyInstrumentationKey(connectionStringValue)
-                ? InstrumentationKeyMessage
-                : "The connection string is malformed and could not be parsed. Verify the connection string and that it contains a valid instrumentation key.";
-        }
-
-        // Connection string parsed, but the instrumentation key is missing or malformed.
-        if (_serviceProfilerContext.AppInsightsInstrumentationKey == Guid.Empty)
-        {
-            return InstrumentationKeyMessage;
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Determines whether the raw connection string declares any
-    /// <c>InstrumentationKey</c> token whose value is empty or whitespace.
-    /// </summary>
-    private static bool ContainsEmptyInstrumentationKey(string connectionStringValue)
-    {
-        foreach (string token in connectionStringValue.Split(';'))
-        {
-            int separatorIndex = token.IndexOf('=');
-            if (separatorIndex < 0)
-            {
-                continue;
-            }
-
-            string key = token.Substring(0, separatorIndex).Trim();
-            if (key.Equals("InstrumentationKey", StringComparison.OrdinalIgnoreCase)
-                && string.IsNullOrWhiteSpace(token.Substring(separatorIndex + 1)))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+        ConnectionStringValidationResult.Valid => null,
+        ConnectionStringValidationResult.NotConfigured => NoConnectionStringMessage,
+        ConnectionStringValidationResult.Empty => "The connection string is empty.",
+        ConnectionStringValidationResult.InvalidInstrumentationKey => InstrumentationKeyMessage,
+        ConnectionStringValidationResult.Malformed => "The connection string is malformed and could not be parsed. Verify the connection string and that it contains a valid instrumentation key.",
+        _ => "The connection string is invalid.",
+    };
 }

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerContext.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerContext.cs
@@ -14,6 +14,7 @@ internal class ServiceProfilerContext : IServiceProfilerContext
 
     public ServiceProfilerContext(
         ConnectionString? connectionString,
+        string? connectionStringValue,
         IEndpointProvider endpointProvider,
         ILogger<ServiceProfilerContext> logger)
     {
@@ -21,6 +22,7 @@ internal class ServiceProfilerContext : IServiceProfilerContext
         
         // Allow null connection string for local development scenarios.
         ConnectionString = connectionString;
+        ConnectionStringValue = connectionStringValue;
         
         _endpointProvider = endpointProvider ?? throw new ArgumentNullException(nameof(endpointProvider));
 
@@ -38,4 +40,6 @@ internal class ServiceProfilerContext : IServiceProfilerContext
     public Guid AppInsightsInstrumentationKey => ConnectionString is null ? Guid.Empty : ConnectionString.InstrumentationKeyGuid;
 
     public ConnectionString? ConnectionString { get; }
+
+    public string? ConnectionStringValue { get; }
 }

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerContext.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerContext.cs
@@ -11,6 +11,7 @@ internal class ServiceProfilerContext : IServiceProfilerContext
 {
     private readonly IEndpointProvider _endpointProvider;
     private readonly ILogger _logger;
+    private readonly string? _connectionStringValue;
 
     public ServiceProfilerContext(
         ConnectionString? connectionString,
@@ -22,7 +23,8 @@ internal class ServiceProfilerContext : IServiceProfilerContext
         
         // Allow null connection string for local development scenarios.
         ConnectionString = connectionString;
-        ConnectionStringValue = connectionStringValue;
+        _connectionStringValue = connectionStringValue;
+        ConnectionStringValidation = ValidateConnectionString();
         
         _endpointProvider = endpointProvider ?? throw new ArgumentNullException(nameof(endpointProvider));
 
@@ -41,5 +43,61 @@ internal class ServiceProfilerContext : IServiceProfilerContext
 
     public ConnectionString? ConnectionString { get; }
 
-    public string? ConnectionStringValue { get; }
+    public ConnectionStringValidationResult ConnectionStringValidation { get; }
+
+    private ConnectionStringValidationResult ValidateConnectionString()
+    {
+        if (_connectionStringValue is null)
+        {
+            return ConnectionStringValidationResult.NotConfigured;
+        }
+
+        if (string.IsNullOrWhiteSpace(_connectionStringValue))
+        {
+            return ConnectionStringValidationResult.Empty;
+        }
+
+        // Connection string is present but could not be parsed.
+        if (ConnectionString is null)
+        {
+            // Distinguish an explicitly empty instrumentation key (e.g. "InstrumentationKey=")
+            // from an otherwise malformed connection string.
+            return ContainsEmptyInstrumentationKey(_connectionStringValue)
+                ? ConnectionStringValidationResult.InvalidInstrumentationKey
+                : ConnectionStringValidationResult.Malformed;
+        }
+
+        // Connection string parsed, but the instrumentation key is missing or malformed.
+        if (AppInsightsInstrumentationKey == Guid.Empty)
+        {
+            return ConnectionStringValidationResult.InvalidInstrumentationKey;
+        }
+
+        return ConnectionStringValidationResult.Valid;
+    }
+
+    /// <summary>
+    /// Determines whether the raw connection string declares any
+    /// <c>InstrumentationKey</c> token whose value is empty or whitespace.
+    /// </summary>
+    private static bool ContainsEmptyInstrumentationKey(string connectionStringValue)
+    {
+        foreach (string token in connectionStringValue.Split(';'))
+        {
+            int separatorIndex = token.IndexOf('=');
+            if (separatorIndex < 0)
+            {
+                continue;
+            }
+
+            string key = token.Substring(0, separatorIndex).Trim();
+            if (key.Equals("InstrumentationKey", StringComparison.OrdinalIgnoreCase)
+                && string.IsNullOrWhiteSpace(token.Substring(separatorIndex + 1)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/ServiceCollectionExtensions.cs
@@ -102,7 +102,15 @@ internal static class ServiceCollectionExtensions
         services.AddSingleton(_ => DiagnosticsClientProvider.Instance);
         services.AddSingleton<DiagnosticsClientTraceConfiguration>();
         services.AddSingleton<ITraceControl, DiagnosticsClientTrace>();
-        services.AddSingleton<IServiceProfilerContext, ServiceProfilerContext>();
+        services.AddSingleton<IServiceProfilerContext>(p =>
+        {
+            ServiceProfilerOptions options = p.GetRequiredService<IOptions<ServiceProfilerOptions>>().Value;
+            return new ServiceProfilerContext(
+                p.GetService<ConnectionString>(),
+                options.ConnectionString,
+                p.GetRequiredService<IEndpointProvider>(),
+                p.GetRequiredService<ILogger<ServiceProfilerContext>>());
+        });
         services.AddSingleton<IServiceProfilerProvider, OpenTelemetryProfilerProvider>();
 
         // Client

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
@@ -175,7 +175,15 @@ internal static class ServiceCollectionExtensions
         services.TryAddSingleton<IEndpointProvider, EndpointProviderMirror>();
 
         services.AddSingleton<IMetadataWriter, MetadataWriter>();
-        services.AddSingleton<IServiceProfilerContext, ServiceProfilerContext>();
+        services.AddSingleton<IServiceProfilerContext>(p =>
+        {
+            TelemetryConfiguration telemetryConfiguration = p.GetRequiredService<TelemetryConfiguration>();
+            return new ServiceProfilerContext(
+                p.GetService<ConnectionString>(),
+                telemetryConfiguration.ConnectionString,
+                p.GetRequiredService<IEndpointProvider>(),
+                p.GetRequiredService<ILogger<ServiceProfilerContext>>());
+        });
 
         services.AddSingleton<INamedPipeClientFactory, NamedPipeClientFactory>();
 

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerAgentBootstrapTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerAgentBootstrapTests.cs
@@ -20,55 +20,47 @@ namespace ServiceProfiler.EventPipe.Client.Tests;
 public class ServiceProfilerAgentBootstrapTests
 {
     [Fact]
-    public async Task ActivateAsync_NullConnectionString_LogsNotSetMessage()
+    public async Task ActivateAsync_NotConfigured_LogsNotSetMessage()
     {
-        (string? logged, bool running) = await RunBootstrapAsync(connectionStringValue: null);
+        (string? logged, bool running) = await RunBootstrapAsync(ConnectionStringValidationResult.NotConfigured);
 
         Assert.False(running);
         Assert.Contains("No connection string is set", logged);
     }
 
     [Fact]
-    public async Task ActivateAsync_EmptyConnectionString_LogsEmptyMessage()
+    public async Task ActivateAsync_Empty_LogsEmptyMessage()
     {
-        (string? logged, bool running) = await RunBootstrapAsync(connectionStringValue: "   ");
+        (string? logged, bool running) = await RunBootstrapAsync(ConnectionStringValidationResult.Empty);
 
         Assert.False(running);
         Assert.Contains("connection string is empty", logged);
     }
 
     [Fact]
-    public async Task ActivateAsync_MalformedConnectionString_LogsMalformedMessage()
+    public async Task ActivateAsync_Malformed_LogsMalformedMessage()
     {
-        // A non-empty value that fails to parse leaves the parsed ConnectionString null.
-        (string? logged, bool running) = await RunBootstrapAsync(connectionStringValue: "this-is-not-a-valid-connection-string");
+        (string? logged, bool running) = await RunBootstrapAsync(ConnectionStringValidationResult.Malformed);
 
         Assert.False(running);
         Assert.Contains("malformed", logged);
     }
 
-    [Theory]
-    [InlineData("InstrumentationKey=")]
-    [InlineData("InstrumentationKey=   ")]
-    [InlineData("IngestionEndpoint=https://example.com/;InstrumentationKey=")]
-    [InlineData("InstrumentationKey=00000000-0000-0000-0000-000000000001;InstrumentationKey=")]
-    public async Task ActivateAsync_EmptyInstrumentationKey_LogsInstrumentationKeyMessage(string connectionStringValue)
+    [Fact]
+    public async Task ActivateAsync_InvalidInstrumentationKey_LogsInstrumentationKeyMessage()
     {
-        // An explicitly empty instrumentation key fails to parse (ConnectionString stays null),
-        // but should surface the instrumentation-key-specific message rather than the generic one.
-        (string? logged, bool running) = await RunBootstrapAsync(connectionStringValue);
+        (string? logged, bool running) = await RunBootstrapAsync(ConnectionStringValidationResult.InvalidInstrumentationKey);
 
         Assert.False(running);
         Assert.Contains("Instrumentation key", logged);
     }
 
-    private static async Task<(string? loggedError, bool running)> RunBootstrapAsync(string? connectionStringValue)
+    private static async Task<(string? loggedError, bool running)> RunBootstrapAsync(ConnectionStringValidationResult validation)
     {
         using BootstrapState bootstrapState = new();
 
         Mock<IServiceProfilerContext> contextMock = new();
-        contextMock.SetupGet(c => c.ConnectionStringValue).Returns(connectionStringValue);
-        // ConnectionString is left at its default (null), simulating an unset or unparsable value.
+        contextMock.SetupGet(c => c.ConnectionStringValidation).Returns(validation);
 
         Mock<IOrchestrator> orchestratorMock = new();
 

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerAgentBootstrapTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerAgentBootstrapTests.cs
@@ -1,0 +1,136 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.Profiler.Shared;
+using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.ServiceProfiler.Orchestration;
+using Moq;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Client.Tests;
+
+public class ServiceProfilerAgentBootstrapTests
+{
+    [Fact]
+    public async Task ActivateAsync_NullConnectionString_LogsNotSetMessage()
+    {
+        (string? logged, bool running) = await RunBootstrapAsync(connectionStringValue: null);
+
+        Assert.False(running);
+        Assert.Contains("No connection string is set", logged);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_EmptyConnectionString_LogsEmptyMessage()
+    {
+        (string? logged, bool running) = await RunBootstrapAsync(connectionStringValue: "   ");
+
+        Assert.False(running);
+        Assert.Contains("connection string is empty", logged);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_MalformedConnectionString_LogsMalformedMessage()
+    {
+        // A non-empty value that fails to parse leaves the parsed ConnectionString null.
+        (string? logged, bool running) = await RunBootstrapAsync(connectionStringValue: "this-is-not-a-valid-connection-string");
+
+        Assert.False(running);
+        Assert.Contains("malformed", logged);
+    }
+
+    [Theory]
+    [InlineData("InstrumentationKey=")]
+    [InlineData("InstrumentationKey=   ")]
+    [InlineData("IngestionEndpoint=https://example.com/;InstrumentationKey=")]
+    [InlineData("InstrumentationKey=00000000-0000-0000-0000-000000000001;InstrumentationKey=")]
+    public async Task ActivateAsync_EmptyInstrumentationKey_LogsInstrumentationKeyMessage(string connectionStringValue)
+    {
+        // An explicitly empty instrumentation key fails to parse (ConnectionString stays null),
+        // but should surface the instrumentation-key-specific message rather than the generic one.
+        (string? logged, bool running) = await RunBootstrapAsync(connectionStringValue);
+
+        Assert.False(running);
+        Assert.Contains("Instrumentation key", logged);
+    }
+
+    private static async Task<(string? loggedError, bool running)> RunBootstrapAsync(string? connectionStringValue)
+    {
+        using BootstrapState bootstrapState = new();
+
+        Mock<IServiceProfilerContext> contextMock = new();
+        contextMock.SetupGet(c => c.ConnectionStringValue).Returns(connectionStringValue);
+        // ConnectionString is left at its default (null), simulating an unset or unparsable value.
+
+        Mock<IOrchestrator> orchestratorMock = new();
+
+        IOptions<UserConfigurationBase> options = Options.Create<UserConfigurationBase>(new TestUserConfiguration
+        {
+            IsDisabled = false,
+            IsSkipCompatibilityTest = true,
+        });
+
+        Mock<ICompatibilityUtilityFactory> compatibilityFactoryMock = new();
+
+        Mock<ISerializationProvider> serializerMock = new();
+        string? ignored;
+        serializerMock.Setup(s => s.TrySerialize(It.IsAny<UserConfigurationBase>(), out ignored)).Returns(false);
+
+        Mock<IEventPipeEnvironmentCheckService> environmentCheckMock = new();
+        environmentCheckMock.Setup(e => e.IsEnvironmentSuitable()).Returns(true);
+
+        TestLogger logger = new();
+
+        ServiceProfilerAgentBootstrap bootstrap = new(
+            bootstrapState,
+            contextMock.Object,
+            orchestratorMock.Object,
+            options,
+            compatibilityFactoryMock.Object,
+            serializerMock.Object,
+            environmentCheckMock.Object,
+            logger);
+
+        await bootstrap.ActivateAsync(CancellationToken.None);
+
+        orchestratorMock.Verify(o => o.StartAsync(It.IsAny<CancellationToken>()), Times.Never);
+
+        bool running = bootstrapState.IsProfilerRunning(CancellationToken.None);
+        return (logger.LastError, running);
+    }
+
+    private sealed class TestUserConfiguration : UserConfigurationBase
+    {
+    }
+
+    private sealed class TestLogger : ILogger<ServiceProfilerAgentBootstrap>
+    {
+        public string? LastError { get; private set; }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Error)
+            {
+                LastError = formatter(state, exception);
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerContextValidationTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerContextValidationTests.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Client.Tests;
+
+public class ServiceProfilerContextValidationTests
+{
+    [Fact]
+    public void Validation_NullValue_ReturnsNotConfigured()
+        => Assert.Equal(ConnectionStringValidationResult.NotConfigured, Validate(null));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validation_EmptyOrWhitespace_ReturnsEmpty(string connectionStringValue)
+        => Assert.Equal(ConnectionStringValidationResult.Empty, Validate(connectionStringValue));
+
+    [Theory]
+    [InlineData("this-is-not-a-valid-connection-string")]
+    [InlineData("Foo=bar;Baz=qux")]
+    public void Validation_Unparsable_ReturnsMalformed(string connectionStringValue)
+        => Assert.Equal(ConnectionStringValidationResult.Malformed, Validate(connectionStringValue));
+
+    [Theory]
+    [InlineData("InstrumentationKey=")]
+    [InlineData("InstrumentationKey=   ")]
+    [InlineData("IngestionEndpoint=https://example.com/;InstrumentationKey=")]
+    [InlineData("InstrumentationKey=00000000-0000-0000-0000-000000000001;InstrumentationKey=")]
+    public void Validation_EmptyInstrumentationKey_ReturnsInvalidInstrumentationKey(string connectionStringValue)
+        => Assert.Equal(ConnectionStringValidationResult.InvalidInstrumentationKey, Validate(connectionStringValue));
+
+    private static ConnectionStringValidationResult Validate(string? connectionStringValue)
+    {
+        Mock<IEndpointProvider> endpointProviderMock = new();
+        endpointProviderMock.Setup(e => e.GetEndpoint()).Returns(new Uri("https://localhost"));
+
+        // Every case under test is one the connection string parser rejects, so the parsed
+        // ConnectionString is null. The context classifies it from the raw value internally.
+        ServiceProfilerContext context = new(
+            connectionString: null,
+            connectionStringValue: connectionStringValue,
+            endpointProviderMock.Object,
+            NullLogger<ServiceProfilerContext>.Instance);
+
+        return context.ConnectionStringValidation;
+    }
+}


### PR DESCRIPTION
Fixes #146

## Problem

When the connection string was malformed, empty, or not set, the profiler bootstrap always logged the same message:

```
fail: Microsoft.ApplicationInsights.Profiler.Shared.ServiceProfilerAgentBootstrap[0]
      No connection string is set. Application Insights Profiler won't start.
```

This was unhelpful: a user who provided a *malformed* connection string was told it was *not set*. The root cause is that null, empty, and malformed connection strings all parse to a `null` `ConnectionString` object, so the bootstrap could not tell them apart.

## Fix

- Added a raw, unparsed `ConnectionStringValue` to `IServiceProfilerContext` / `ServiceProfilerContext`, fed by the DI factories in both the OTel core and classic client registrations (from `ServiceProfilerOptions.ConnectionString` and `TelemetryConfiguration.ConnectionString` respectively — the same sources the existing `ConnectionString` singleton already consumes, so the raw and parsed views stay consistent).
- `ServiceProfilerAgentBootstrap` now diagnoses the connection string via a single `GetConnectionStringConfigurationError()` helper and emits a distinct, actionable message for each state:
  - **not set** (null) → `No connection string is set.`
  - **empty/whitespace** → `The connection string is empty.`
  - **empty instrumentation key** (e.g. `InstrumentationKey=`) → `Instrumentation key is not set or malformed in the connection string.`
  - **malformed** (present but unparsable) → `The connection string is malformed and could not be parsed. Verify the connection string and that it contains a valid instrumentation key.`
  - **zero-GUID instrumentation key** → instrumentation-key message
- Refactored the repeated `LogError(...); Activated(false); return;` branches and deduplicated the shared message suffix.

## Tests

Added `ServiceProfilerAgentBootstrapTests` covering the null, empty/whitespace, malformed, and empty-instrumentation-key (including duplicate-token) cases. All affected test suites pass (70 OTel + 36 classic).

## Notes

The unconfigured OTel scenario still reports `No connection string is set.` — the options pipeline's env-var fallback normalizes an unset value to `null` before it reaches the bootstrap, so there is no behavior regression for the common case.

## Review

Iteratively reviewed with GPT-5.5 and Opus 4.7 to **two consecutive clean rounds**. Findings that led to real improvements: empty-instrumentation-key now maps to the instrumentation-key message, and the detection helper scans all tokens to handle duplicate keys. One reported "dead null branch / regression" finding was investigated and disproved (env-var fallback yields `null` for unconfigured), and both reviewers retracted it.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>