### PR TITLE
Remove CommandLineParser dependency from the profiler libraries (#18)

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/UploadContextModel.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/UploadContextModel.cs
@@ -1,26 +1,11 @@
 using System;
+using System.Text;
 using Microsoft.ServiceProfiler.Contract.Agent;
 
 namespace Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
 
 internal class UploadContextModel
 {
-    private const char InstrumentationKeyShortKeyName = 'i';
-    private const string EndpointKeyName = "host";
-    private const string SessionIdKeyName = "sessionId";
-    private const char StampIdShortKeyName = 's';
-    private const char TraceFilePathShortKeyName = 't';
-    private const string MetadataFilePathKeyName = "metadata";
-    private const string PreserveTraceFileKeyName = "preserve";
-    private const string SkipEndpointCertificateValidationKeyName = "insecure";
-    private const string UploadModeKeyName = "uploadMode";
-    private const string SampleActivityFilePathKeyName = "sampleActivityFilePath";
-    private const string PipeNameKeyName = "pipeName";
-    private const string RoleNameKeyName = "roleName";
-    private const string TriggerTypeKeyName = "trigger";
-    private const string TraceFileFormatKeyName = "traceFileFormat";
-
-
     public Guid AIInstrumentationKey { get; init; }
 
     public Uri HostUrl { get; init; } = null!;
@@ -51,38 +36,48 @@ internal class UploadContextModel
 
     public override string ToString()
     {
-        // TODO: Treat this as a method to serialize the parameters before passing it on to the uploader.
-        // The issue is: The uploader uses CommandOptions to sort of deserializing the parameters.
-        // This is somewhat awkward because of the mismatch between the serializer and the deserializer.
-        string argumentLine = $@"-{TraceFilePathShortKeyName} ""{TraceFilePath}"" -{InstrumentationKeyShortKeyName} {AIInstrumentationKey} --{SessionIdKeyName} ""{TimestampContract.TimestampToString(SessionId)}"" -{StampIdShortKeyName} ""{StampId}"" --{EndpointKeyName} {HostUrl} --{MetadataFilePathKeyName} ""{MetadataFilePath}"" --{UploadModeKeyName} ""{UploadMode}"" --{SampleActivityFilePathKeyName} ""{SerializedSampleFilePath}""";
+        // Serializes the parameters into a command line that the Uploader binds back
+        // into its own context via Microsoft.Extensions.Configuration.CommandLine.
+        // Keys intentionally match the Uploader's UploadContext property names so the
+        // configuration binder can map them directly (no third-party parser needed).
+        StringBuilder builder = new();
+
+        builder.Append($@"--{nameof(TraceFilePath)} ""{TraceFilePath}""");
+        builder.Append($@" --{nameof(AIInstrumentationKey)} ""{AIInstrumentationKey}""");
+        builder.Append($@" --{nameof(SessionId)} ""{TimestampContract.TimestampToString(SessionId)}""");
+        builder.Append($@" --{nameof(StampId)} ""{StampId}""");
+        builder.Append($@" --{nameof(HostUrl)} ""{HostUrl}""");
+        builder.Append($@" --{nameof(MetadataFilePath)} ""{MetadataFilePath}""");
+        builder.Append($@" --{nameof(UploadMode)} ""{UploadMode}""");
+        builder.Append($@" --{nameof(SerializedSampleFilePath)} ""{SerializedSampleFilePath}""");
 
         if (!string.IsNullOrEmpty(PipeName))
         {
-            argumentLine += $@" --{PipeNameKeyName} ""{PipeName}""";
+            builder.Append($@" --{nameof(PipeName)} ""{PipeName}""");
         }
 
         if (PreserveTraceFile)
         {
-            argumentLine += $" --{PreserveTraceFileKeyName}";
+            builder.Append($" --{nameof(PreserveTraceFile)} true");
         }
 
         if (SkipEndpointCertificateValidation)
         {
-            argumentLine += $" --{SkipEndpointCertificateValidationKeyName}";
+            builder.Append($" --{nameof(SkipEndpointCertificateValidation)} true");
         }
 
         if (!string.IsNullOrEmpty(RoleName))
         {
-            argumentLine += $@" --{RoleNameKeyName} ""{RoleName}""";
+            builder.Append($@" --{nameof(RoleName)} ""{RoleName}""");
         }
 
         if (!string.IsNullOrEmpty(TriggerType))
         {
-            argumentLine += $@" --{TriggerTypeKeyName} ""{TriggerType}""";
+            builder.Append($@" --{nameof(TriggerType)} ""{TriggerType}""");
         }
 
-        argumentLine += $@" --{TraceFileFormatKeyName} ""{TraceFileFormat}""";
+        builder.Append($@" --{nameof(TraceFileFormat)} ""{TraceFileFormat}""");
 
-        return argumentLine;
+        return builder.ToString();
     }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/Azure.Monitor.OpenTelemetry.Profiler.Core.csproj
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/Azure.Monitor.OpenTelemetry.Profiler.Core.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
-    <PackageReference Include="CommandLineParser" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
   </ItemGroup>

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/Azure.Monitor.OpenTelemetry.Profiler.csproj
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler/Azure.Monitor.OpenTelemetry.Profiler.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
-    <PackageReference Include="CommandLineParser" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />

--- a/src/ServiceProfiler.EventPipe.Upload/Program.cs
+++ b/src/ServiceProfiler.EventPipe.Upload/Program.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //-----------------------------------------------------------------------------
 
-using CommandLine;
 using Microsoft.ApplicationInsights.Profiler.Core.Contracts;
 using Microsoft.ApplicationInsights.Profiler.Core.Logging;
 using Microsoft.ApplicationInsights.Profiler.Core.Utilities;
@@ -28,13 +27,33 @@ namespace Microsoft.ApplicationInsights.Profiler.Uploader
 {
     class Program
     {
-        static void Main(string[] args)
+        static int Main(string[] args)
         {
-            Parser.Default.ParseArguments<UploadContext>(args).WithParsed<UploadContext>(options =>
+            UploadContext options;
+            try
             {
-                using IHost host = CreateHostBuilder(args, options).Build();
-                host.Run();
-            });
+                IConfiguration configuration = new ConfigurationBuilder()
+                    .AddCommandLine(args)
+                    .Build();
+
+                options = configuration.Get<UploadContext>() ?? new UploadContext();
+            }
+            catch (Exception ex)
+            {
+                // Mirror the previous CommandLineParser behavior of failing fast on
+                // malformed arguments (e.g. an unparseable Guid/Uri/DateTimeOffset)
+                // instead of letting the exception escape as an unhandled crash.
+                Console.Error.WriteLine($"fail: Failed to parse uploader arguments. {ex.Message}");
+                return 1;
+            }
+
+            using IHost host = CreateHostBuilder(args, options).Build();
+            host.Run();
+
+            // Preserve the exit code set by HostedUploaderService via Environment.ExitCode.
+            // Returning a literal 0 here would override it and mask upload failures from the
+            // parent process, which only inspects the process exit code.
+            return Environment.ExitCode;
         }
 
         private static IHostBuilder CreateHostBuilder(string[] args, UploadContext options) =>

--- a/src/ServiceProfiler.EventPipe.Upload/ServiceProfiler.EventPipe.Upload.csproj
+++ b/src/ServiceProfiler.EventPipe.Upload/ServiceProfiler.EventPipe.Upload.csproj
@@ -17,7 +17,6 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(CastleCorePublicKey)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Memory.Data" />
     <!--
@@ -29,6 +28,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Core" />

--- a/src/ServiceProfiler.EventPipe.Upload/UploadContext.cs
+++ b/src/ServiceProfiler.EventPipe.Upload/UploadContext.cs
@@ -2,116 +2,40 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //-----------------------------------------------------------------------------
 
-using CommandLine;
 using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
-using Microsoft.ServiceProfiler.Contract.Agent;
 using System;
 
 namespace Microsoft.ApplicationInsights.Profiler.Core.Contracts
 {
     internal class UploadContext
     {
-        private const char InstrumentationKeyShortKeyName = 'i';
-        private const string InstrumentationKeyKeyName = "iKey";
-        private const string EndpointKeyName = "host";
-        private const string SessionIdKeyName = "sessionId";
-        private const string StampIdKeyName = "stampId";
-        private const char StampIdShortKeyName = 's';
-        private const char TraceFilePathShortKeyName = 't';
-        private const string TraceFilePathKeyName = "trace";
-        private const string MetadataFilePathKeyName = "metadata";
-        private const string PreserveTraceFileKeyName = "preserve";
-        private const string SkipEndpointCertificateValidationKeyName = "insecure";
-        private const string UploadModeKeyName = "uploadMode";
-        private const string SampleActivityFilePathKeyName = "sampleActivityFilePath";
-        private const string PipeNameKeyName = "pipeName";
-        private const char PipeNameShortKeyName = 'p';
-        private const char RoleNameShortKeyName = 'r';
-        private const string RoleNameKeyName = "roleName";
-        private const char TriggerTypeShortKeyName = 'u';
-        private const string TriggerTypeKeyName = "trigger";
-
-        private const char TraceFileFormatShortKeyName = 'f';
-        private const string TraceFileFormatKeyName = "traceFileFormat";
-
-        [Option(InstrumentationKeyShortKeyName, InstrumentationKeyKeyName, Required = true, HelpText = "Application Insights instrumentation key.")]
         public Guid AIInstrumentationKey { get; set; }
 
-        [Option(EndpointKeyName, Required = true, HelpText = "Microsoft Application Insights Profiler endpoint.")]
         public Uri HostUrl { get; set; } = null!;
 
-        [Option(SessionIdKeyName, Required = true, HelpText = "Trace session id.")]
         public DateTimeOffset SessionId { get; set; }
 
-        [Option(StampIdShortKeyName, StampIdKeyName, Required = true, HelpText = "StampId used to upload the trace file.")]
         public string StampId { get; set; } = null!;
 
-        [Option(TraceFilePathShortKeyName, TraceFilePathKeyName, Required = true, HelpText = "File path to trace file.")]
         public string TraceFilePath { get; set; } = null!;
 
-        [Option(MetadataFilePathKeyName, Required = false, HelpText = "File path to the metadata file.")]
         public string MetadataFilePath { get; set; } = null!;
 
-        [Option(PreserveTraceFileKeyName, Required = false, Default = false, HelpText = "Preserve the trace file locally.")]
         public bool PreserveTraceFile { get; set; }
 
-        [Option(SkipEndpointCertificateValidationKeyName, Required = false, Default = false, HelpText = "Allow insecure profile endpoint connections when using SSL.")]
         public bool SkipEndpointCertificateValidation { get; set; }
 
-        [Option(UploadModeKeyName, Required = false, Default = UploadMode.OnSuccess, HelpText = "The mode for uploading behavior. Valid values are: Never, OnSuccess and Always.")]
-        public UploadMode UploadMode { get; set; }
+        public UploadMode UploadMode { get; set; } = UploadMode.OnSuccess;
 
-        [Option(SampleActivityFilePathKeyName, Required = true, HelpText = "Path to the file which contains all serialized activity samples.")]
         public string SerializedSampleFilePath { get; set; } = null!;
 
-        [Option(PipeNameShortKeyName, PipeNameKeyName, Required = false, HelpText = "Named pipe name for client and uploader communication. NamedPipe is preferred when the value is provided.")]
         public string? PipeName { get; set; }
 
-        [Option(RoleNameShortKeyName, RoleNameKeyName, Required = false, HelpText = "Cloud role name of the customer app recorded in the telemetry.")]
         public string? RoleName { get; set; }
 
-        [Option(TriggerTypeShortKeyName, TriggerTypeKeyName, Required = false, HelpText = "Type of trigger that caused the collection of the trace.")]
         public string? TriggerType { get; set; }
 
-        [Option(TraceFileFormatShortKeyName, TraceFileFormatKeyName, Required = true, HelpText = "The trace file format.", Default = ServiceProfiler.Contract.Agent.Profiler.TraceFileFormat.Netperf)]
         public string TraceFileFormat { get; set; } = ServiceProfiler.Contract.Agent.Profiler.TraceFileFormat.Netperf;
-
-        public override string ToString()
-        {
-            // TODO: Treat this as a method to serialize the parameters before passing it on to the uploader.
-            // The issue is: The uploader uses CommandOptions to sort of deserializing the parameters.
-            // This is somewhat awkward because of the mismatch between the serializer and the deserializer.
-            string argumentLine = $@"-{TraceFilePathShortKeyName} ""{TraceFilePath}"" -{InstrumentationKeyShortKeyName} {AIInstrumentationKey} --{SessionIdKeyName} ""{TimestampContract.TimestampToString(SessionId)}"" -{StampIdShortKeyName} ""{StampId}"" --{EndpointKeyName} {HostUrl} --{MetadataFilePathKeyName} ""{MetadataFilePath}"" --{UploadModeKeyName} ""{UploadMode}"" --{SampleActivityFilePathKeyName} ""{SerializedSampleFilePath}""";
-
-            if (!string.IsNullOrEmpty(PipeName))
-            {
-                argumentLine += $@" --{PipeNameKeyName} ""{PipeName}""";
-            }
-
-            if (PreserveTraceFile)
-            {
-                argumentLine += $" --{PreserveTraceFileKeyName}";
-            }
-
-            if (SkipEndpointCertificateValidation)
-            {
-                argumentLine += $" --{SkipEndpointCertificateValidationKeyName}";
-            }
-
-            if (!string.IsNullOrEmpty(RoleName))
-            {
-                argumentLine += $@" --{RoleNameKeyName} ""{RoleName}""";
-            }
-
-            if (!string.IsNullOrEmpty(TriggerType))
-            {
-                argumentLine += $@" --{TriggerTypeKeyName} ""{TriggerType}""";
-            }
-
-            argumentLine += $@" --{TraceFileFormatKeyName} ""{TraceFileFormat}""";
-
-            return argumentLine;
-        }
 
         public bool UseNamedPipe => !string.IsNullOrEmpty(PipeName);
     }

--- a/src/ServiceProfiler.EventPipe.Upload/UploadContextValidator.cs
+++ b/src/ServiceProfiler.EventPipe.Upload/UploadContextValidator.cs
@@ -43,6 +43,15 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Utilities
                 errorMessageBuilder.AppendLine($"{nameof(uploadContext.SessionId)} is required.");
             }
 
+            // TraceFilePath was previously enforced by the command-line parser's [Option(Required = true)]
+            // attribute. Now that arguments are bound via Microsoft.Extensions.Configuration, re-assert it
+            // here so a missing trace path fails fast with a clear message instead of an obscure downstream
+            // file error.
+            if (string.IsNullOrEmpty(uploadContext.TraceFilePath))
+            {
+                errorMessageBuilder.AppendLine($"{nameof(uploadContext.TraceFilePath)} is required.");
+            }
+
             if (string.IsNullOrEmpty(uploadContext.SerializedSampleFilePath) && string.IsNullOrEmpty(uploadContext.PipeName))
             {
                 errorMessageBuilder.AppendLine($"{nameof(uploadContext.SerializedSampleFilePath)} and {nameof(uploadContext.PipeName)} can't be null at the same time.");

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfiler.EventPipe.Client.csproj
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfiler.EventPipe.Client.csproj
@@ -38,7 +38,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="CommandLineParser" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" VersionOverride="[2.23.0, 3.0.0)" />
     <PackageReference Include="Microsoft.ApplicationInsights" VersionOverride="[2.23.0, 3.0.0)" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" VersionOverride="[2.23.0, 3.0.0)" />

--- a/tests/ServiceProfiler.EventPipe.Client.Tests/UploadContextModelTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Client.Tests/UploadContextModelTests.cs
@@ -8,11 +8,15 @@ namespace ServiceProfiler.EventPipe.Client.Tests
 
     public class UploadContextModelTests
     {
+        private const string IKey = "ed63033b-cd63-4df6-848e-f00772de729f";
+
+        private static string CommonPrefix(DateTimeOffset utcNow) =>
+            $@"--TraceFilePath ""c:\tracefilePath.etl.zip"" --AIInstrumentationKey ""{IKey}"" --SessionId ""{TimestampContract.TimestampToString(utcNow)}"" --StampId ""stampId"" --HostUrl ""https://endpoint/"" --MetadataFilePath ""c:\metadataFilePath.metadata"" --UploadMode ""OnSuccess"" --SerializedSampleFilePath ""c:\sample""";
+
         [Fact]
         public void ShouldOverwriteToStringForCommandLine()
         {
-            Guid iKey = Guid.Parse("ed63033b-cd63-4df6-848e-f00772de729f");
-            Guid dataCube = Guid.Parse("33a5a798-8489-4467-97d3-b35870fed1b3");
+            Guid iKey = Guid.Parse(IKey);
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
 
             var validUploadContext = new UploadContextModel()
@@ -31,7 +35,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = CommonPrefix(utcNow) + @" --TraceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -39,8 +43,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
         [Fact]
         public void ShouldSetPreserveTraceFile()
         {
-            Guid iKey = Guid.Parse("ed63033b-cd63-4df6-848e-f00772de729f");
-            Guid dataCube = Guid.Parse("33a5a798-8489-4467-97d3-b35870fed1b3");
+            Guid iKey = Guid.Parse(IKey);
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
 
             var validUploadContext = new UploadContextModel()
@@ -59,7 +62,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --traceFileFormat ""Netperf""";
+            string expectedCommandLine = CommonPrefix(utcNow) + @" --PreserveTraceFile true --TraceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -67,8 +70,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
         [Fact]
         public void ShouldAllowInsecureSSLCommunication()
         {
-            Guid iKey = Guid.Parse("ed63033b-cd63-4df6-848e-f00772de729f");
-            Guid dataCube = Guid.Parse("33a5a798-8489-4467-97d3-b35870fed1b3");
+            Guid iKey = Guid.Parse(IKey);
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
 
             var validUploadContext = new UploadContextModel()
@@ -87,7 +89,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --traceFileFormat ""Netperf""";
+            string expectedCommandLine = CommonPrefix(utcNow) + @" --PreserveTraceFile true --SkipEndpointCertificateValidation true --TraceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -95,8 +97,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
         [Fact]
         public void ShouldPassOnRoleNameWhenExists()
         {
-            Guid iKey = Guid.Parse("ed63033b-cd63-4df6-848e-f00772de729f");
-            Guid dataCube = Guid.Parse("33a5a798-8489-4467-97d3-b35870fed1b3");
+            Guid iKey = Guid.Parse(IKey);
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             const string roleName = "testRoleName";
             UploadContextModel validUploadContext = new()
@@ -116,7 +117,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --roleName ""{roleName}"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = CommonPrefix(utcNow) + $@" --PreserveTraceFile true --SkipEndpointCertificateValidation true --RoleName ""{roleName}"" --TraceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -124,8 +125,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
         [Fact]
         public void ShouldNotPassOnRoleNameWhenNull()
         {
-            Guid iKey = Guid.Parse("ed63033b-cd63-4df6-848e-f00772de729f");
-            Guid dataCube = Guid.Parse("33a5a798-8489-4467-97d3-b35870fed1b3");
+            Guid iKey = Guid.Parse(IKey);
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             UploadContextModel validUploadContext = new()
             {
@@ -144,7 +144,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --traceFileFormat ""Netperf""";
+            string expectedCommandLine = CommonPrefix(utcNow) + @" --PreserveTraceFile true --SkipEndpointCertificateValidation true --TraceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -152,8 +152,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
         [Fact]
         public void ShouldNotPassOnRoleNameWhenEmpty()
         {
-            Guid iKey = Guid.Parse("ed63033b-cd63-4df6-848e-f00772de729f");
-            Guid dataCube = Guid.Parse("33a5a798-8489-4467-97d3-b35870fed1b3");
+            Guid iKey = Guid.Parse(IKey);
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             UploadContextModel validUploadContext = new()
             {
@@ -172,7 +171,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --traceFileFormat ""Netperf""";
+            string expectedCommandLine = CommonPrefix(utcNow) + @" --PreserveTraceFile true --SkipEndpointCertificateValidation true --TraceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -180,8 +179,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
         [Fact]
         public void ShouldPassOnTriggerTypeWhenExists()
         {
-            Guid iKey = Guid.Parse("ed63033b-cd63-4df6-848e-f00772de729f");
-            Guid dataCube = Guid.Parse("33a5a798-8489-4467-97d3-b35870fed1b3");
+            Guid iKey = Guid.Parse(IKey);
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             const string trigger = "HighCPU";
             UploadContextModel validUploadContext = new UploadContextModel()
@@ -201,7 +199,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --trigger ""{trigger}"" --traceFileFormat ""Netperf""";
+            string expectedCommandLine = CommonPrefix(utcNow) + $@" --PreserveTraceFile true --SkipEndpointCertificateValidation true --TriggerType ""{trigger}"" --TraceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -209,8 +207,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
         [Fact]
         public void ShouldNotPassOnTriggerTypeWhenNull()
         {
-            Guid iKey = Guid.Parse("ed63033b-cd63-4df6-848e-f00772de729f");
-            Guid dataCube = Guid.Parse("33a5a798-8489-4467-97d3-b35870fed1b3");
+            Guid iKey = Guid.Parse(IKey);
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             UploadContextModel validUploadContext = new UploadContextModel()
             {
@@ -229,7 +226,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --traceFileFormat ""Netperf""";
+            string expectedCommandLine = CommonPrefix(utcNow) + @" --PreserveTraceFile true --SkipEndpointCertificateValidation true --TraceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }
@@ -237,8 +234,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
         [Fact]
         public void ShouldNotPassOnTriggerTypeWhenEmpty()
         {
-            Guid iKey = Guid.Parse("ed63033b-cd63-4df6-848e-f00772de729f");
-            Guid dataCube = Guid.Parse("33a5a798-8489-4467-97d3-b35870fed1b3");
+            Guid iKey = Guid.Parse(IKey);
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             UploadContextModel validUploadContext = new()
             {
@@ -257,7 +253,7 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             };
             string commandLine = validUploadContext.ToString();
 
-            string expectedCommandLine = $@"-t ""c:\tracefilePath.etl.zip"" -i ed63033b-cd63-4df6-848e-f00772de729f --sessionId ""{TimestampContract.TimestampToString(utcNow)}"" -s ""stampId"" --host https://endpoint/ --metadata ""c:\metadataFilePath.metadata"" --uploadMode ""OnSuccess"" --sampleActivityFilePath ""c:\sample"" --preserve --insecure --traceFileFormat ""Netperf""";
+            string expectedCommandLine = CommonPrefix(utcNow) + @" --PreserveTraceFile true --SkipEndpointCertificateValidation true --TraceFileFormat ""Netperf""";
 
             Assert.Equal(expectedCommandLine, commandLine);
         }

--- a/tests/ServiceProfiler.EventPipe.Upload.Tests/ServiceProfiler.EventPipe.Upload.Tests.csproj
+++ b/tests/ServiceProfiler.EventPipe.Upload.Tests/ServiceProfiler.EventPipe.Upload.Tests.csproj
@@ -23,6 +23,16 @@
     <ProjectReference Include="..\..\src\ServiceProfiler.EventPipe.Upload\ServiceProfiler.EventPipe.Upload.csproj" />
   </ItemGroup>
 
+  <!--
+    Compile the real agent-side producer (UploadContextModel) into the test assembly so the round-trip
+    test drives the actual UploadContextModel.ToString() rather than a hand-built command line. The
+    uploader assembly deliberately does not reference it (it is a producer-only type), so it is linked
+    here the same way the uploader links other shared source files.
+  -->
+  <ItemGroup>
+    <Compile Include="..\..\src\Microsoft.ApplicationInsights.Profiler.Shared\Contracts\UploadContextModel.cs" Link="Contracts\UploadContextModel.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/tests/ServiceProfiler.EventPipe.Upload.Tests/UploadContextRoundTripTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Upload.Tests/UploadContextRoundTripTests.cs
@@ -1,0 +1,140 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.ApplicationInsights.Profiler.Core.Contracts;
+using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Upload.Tests
+{
+    /// <summary>
+    /// Verifies the uploader argument contract is honored without any third-party command
+    /// line parser: a command line whose keys match the UploadContext property names binds
+    /// back into an UploadContext via Microsoft.Extensions.Configuration. The exact wire
+    /// format produced by UploadContextModel.ToString() is locked by UploadContextModelTests.
+    /// </summary>
+    public class UploadContextRoundTripTests
+    {
+        [Fact]
+        public void CommandLine_BindsToUploadContext_AllFields()
+        {
+            Guid iKey = Guid.NewGuid();
+            DateTimeOffset sessionId = new(2024, 6, 29, 13, 45, 30, TimeSpan.Zero);
+
+            string commandLine =
+                $@"--{nameof(UploadContext.TraceFilePath)} ""C:\traces\my trace.nettrace""" +
+                $@" --{nameof(UploadContext.AIInstrumentationKey)} ""{iKey}""" +
+                $@" --{nameof(UploadContext.SessionId)} ""{sessionId.UtcDateTime:o}""" +
+                $@" --{nameof(UploadContext.StampId)} ""my-stamp""" +
+                $@" --{nameof(UploadContext.HostUrl)} ""https://example.endpoint.com/""" +
+                $@" --{nameof(UploadContext.MetadataFilePath)} ""C:\traces\meta data.json""" +
+                $@" --{nameof(UploadContext.UploadMode)} ""{UploadMode.Always}""" +
+                $@" --{nameof(UploadContext.SerializedSampleFilePath)} ""C:\traces\samples file.json""" +
+                $@" --{nameof(UploadContext.PipeName)} ""pipe-name-123""" +
+                $@" --{nameof(UploadContext.PreserveTraceFile)} true" +
+                $@" --{nameof(UploadContext.SkipEndpointCertificateValidation)} true" +
+                $@" --{nameof(UploadContext.RoleName)} ""my role name""" +
+                $@" --{nameof(UploadContext.TriggerType)} ""my trigger""" +
+                $@" --{nameof(UploadContext.TraceFileFormat)} ""Nettrace""";
+
+            UploadContext bound = Bind(commandLine);
+
+            Assert.Equal(iKey, bound.AIInstrumentationKey);
+            Assert.Equal(new Uri("https://example.endpoint.com/"), bound.HostUrl);
+            Assert.Equal(sessionId, bound.SessionId);
+            Assert.Equal("my-stamp", bound.StampId);
+            Assert.Equal(@"C:\traces\my trace.nettrace", bound.TraceFilePath);
+            Assert.Equal(@"C:\traces\meta data.json", bound.MetadataFilePath);
+            Assert.True(bound.PreserveTraceFile);
+            Assert.True(bound.SkipEndpointCertificateValidation);
+            Assert.Equal(UploadMode.Always, bound.UploadMode);
+            Assert.Equal(@"C:\traces\samples file.json", bound.SerializedSampleFilePath);
+            Assert.Equal("pipe-name-123", bound.PipeName);
+            Assert.Equal("my role name", bound.RoleName);
+            Assert.Equal("my trigger", bound.TriggerType);
+            Assert.Equal("Nettrace", bound.TraceFileFormat);
+            Assert.True(bound.UseNamedPipe);
+        }
+
+        [Fact]
+        public void CommandLine_OmitsOptionalFields_BindsToDefaults()
+        {
+            Guid iKey = Guid.NewGuid();
+            DateTimeOffset sessionId = new(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
+
+            string commandLine =
+                $@"--{nameof(UploadContext.TraceFilePath)} ""/tmp/trace.nettrace""" +
+                $@" --{nameof(UploadContext.AIInstrumentationKey)} ""{iKey}""" +
+                $@" --{nameof(UploadContext.SessionId)} ""{sessionId.UtcDateTime:o}""" +
+                $@" --{nameof(UploadContext.StampId)} ""stamp""" +
+                $@" --{nameof(UploadContext.HostUrl)} ""https://example.endpoint.com/""" +
+                $@" --{nameof(UploadContext.MetadataFilePath)} ""/tmp/meta.json""" +
+                $@" --{nameof(UploadContext.UploadMode)} ""{UploadMode.OnSuccess}""" +
+                $@" --{nameof(UploadContext.SerializedSampleFilePath)} ""/tmp/samples.json""" +
+                $@" --{nameof(UploadContext.TraceFileFormat)} ""Netperf""";
+
+            UploadContext bound = Bind(commandLine);
+
+            Assert.Equal(UploadMode.OnSuccess, bound.UploadMode);
+            Assert.False(bound.PreserveTraceFile);
+            Assert.False(bound.SkipEndpointCertificateValidation);
+            Assert.Null(bound.PipeName);
+            Assert.Null(bound.RoleName);
+            Assert.Null(bound.TriggerType);
+            Assert.False(bound.UseNamedPipe);
+        }
+
+        private static UploadContext Bind(string commandLine)
+        {
+            string[] args = Tokenize(commandLine);
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddCommandLine(args)
+                .Build();
+
+            UploadContext? context = configuration.Get<UploadContext>();
+            Assert.NotNull(context);
+            return context!;
+        }
+
+        [DllImport("shell32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern IntPtr CommandLineToArgvW([MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine, out int pNumArgs);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr LocalFree(IntPtr hMem);
+
+        /// <summary>
+        /// Splits a command line into argument tokens exactly the way the OS does when the
+        /// uploader process is launched. <c>OutOfProcCaller</c> passes the string built
+        /// by <c>UploadContextModel.ToString()</c> to <c>ProcessStartInfo.Arguments</c>, so on
+        /// Windows the child parses it via the CRT / <c>CommandLineToArgvW</c> rules. We invoke
+        /// that same API here (prefixing a dummy argv[0] for the executable name, then dropping
+        /// it) so the test exercises real tokenization rather than an approximation.
+        /// </summary>
+        private static string[] Tokenize(string commandLine)
+        {
+            IntPtr argv = CommandLineToArgvW("uploader.exe " + commandLine, out int count);
+            Assert.NotEqual(IntPtr.Zero, argv);
+
+            try
+            {
+                // Skip index 0 (the synthetic executable name).
+                string[] args = new string[count - 1];
+                for (int i = 1; i < count; i++)
+                {
+                    IntPtr argPtr = Marshal.ReadIntPtr(argv, i * IntPtr.Size);
+                    args[i - 1] = Marshal.PtrToStringUni(argPtr)!;
+                }
+
+                return args;
+            }
+            finally
+            {
+                LocalFree(argv);
+            }
+        }
+    }
+}

--- a/tests/ServiceProfiler.EventPipe.Upload.Tests/UploadContextRoundTripTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Upload.Tests/UploadContextRoundTripTests.cs
@@ -12,73 +12,90 @@ using Xunit;
 namespace ServiceProfiler.EventPipe.Upload.Tests
 {
     /// <summary>
-    /// Verifies the uploader argument contract is honored without any third-party command
-    /// line parser: a command line whose keys match the UploadContext property names binds
-    /// back into an UploadContext via Microsoft.Extensions.Configuration. The exact wire
-    /// format produced by UploadContextModel.ToString() is locked by UploadContextModelTests.
+    /// Genuine producer-to-consumer round trip: constructs the real <see cref="UploadContextModel"/>
+    /// (the agent-side producer), serializes it with <see cref="UploadContextModel.ToString()"/>,
+    /// tokenizes exactly the way the launched uploader process would (Windows
+    /// <c>CommandLineToArgvW</c>), and binds the result back into the uploader's <see cref="UploadContext"/>
+    /// via Microsoft.Extensions.Configuration. This verifies the actual wire contract this package changed -
+    /// if the producer and consumer ever drift (key names, quoting, bool emission, defaults, timestamp
+    /// format), these tests fail. The exact string emitted by the producer is additionally locked by
+    /// UploadContextModelTests.
     /// </summary>
     public class UploadContextRoundTripTests
     {
         [Fact]
-        public void CommandLine_BindsToUploadContext_AllFields()
+        public void ProducerOutput_RoundTripsToUploadContext_AllFields()
         {
-            Guid iKey = Guid.NewGuid();
-            DateTimeOffset sessionId = new(2024, 6, 29, 13, 45, 30, TimeSpan.Zero);
+            // Use a session id with sub-second precision so a lossy timestamp format would be caught.
+            DateTimeOffset sessionId = new DateTimeOffset(2024, 6, 29, 13, 45, 30, TimeSpan.Zero).AddTicks(1234567);
 
-            string commandLine =
-                $@"--{nameof(UploadContext.TraceFilePath)} ""C:\traces\my trace.nettrace""" +
-                $@" --{nameof(UploadContext.AIInstrumentationKey)} ""{iKey}""" +
-                $@" --{nameof(UploadContext.SessionId)} ""{sessionId.UtcDateTime:o}""" +
-                $@" --{nameof(UploadContext.StampId)} ""my-stamp""" +
-                $@" --{nameof(UploadContext.HostUrl)} ""https://example.endpoint.com/""" +
-                $@" --{nameof(UploadContext.MetadataFilePath)} ""C:\traces\meta data.json""" +
-                $@" --{nameof(UploadContext.UploadMode)} ""{UploadMode.Always}""" +
-                $@" --{nameof(UploadContext.SerializedSampleFilePath)} ""C:\traces\samples file.json""" +
-                $@" --{nameof(UploadContext.PipeName)} ""pipe-name-123""" +
-                $@" --{nameof(UploadContext.PreserveTraceFile)} true" +
-                $@" --{nameof(UploadContext.SkipEndpointCertificateValidation)} true" +
-                $@" --{nameof(UploadContext.RoleName)} ""my role name""" +
-                $@" --{nameof(UploadContext.TriggerType)} ""my trigger""" +
-                $@" --{nameof(UploadContext.TraceFileFormat)} ""Nettrace""";
+            UploadContextModel model = new()
+            {
+                AIInstrumentationKey = Guid.NewGuid(),
+                HostUrl = new Uri("https://example.endpoint.com/"),
+                SessionId = sessionId,
+                StampId = "my-stamp",
+                TraceFilePath = @"C:\traces\my trace.nettrace",
+                MetadataFilePath = @"C:\traces\meta data.json",
+                PreserveTraceFile = true,
+                SkipEndpointCertificateValidation = true,
+                UploadMode = UploadMode.Always,
+                SerializedSampleFilePath = @"C:\traces\samples file.json",
+                PipeName = "pipe-name-123",
+                RoleName = "my role name",
+                TriggerType = "my trigger",
+                TraceFileFormat = "Nettrace",
+            };
 
-            UploadContext bound = Bind(commandLine);
+            UploadContext bound = RoundTrip(model);
 
-            Assert.Equal(iKey, bound.AIInstrumentationKey);
-            Assert.Equal(new Uri("https://example.endpoint.com/"), bound.HostUrl);
-            Assert.Equal(sessionId, bound.SessionId);
-            Assert.Equal("my-stamp", bound.StampId);
-            Assert.Equal(@"C:\traces\my trace.nettrace", bound.TraceFilePath);
-            Assert.Equal(@"C:\traces\meta data.json", bound.MetadataFilePath);
-            Assert.True(bound.PreserveTraceFile);
-            Assert.True(bound.SkipEndpointCertificateValidation);
-            Assert.Equal(UploadMode.Always, bound.UploadMode);
-            Assert.Equal(@"C:\traces\samples file.json", bound.SerializedSampleFilePath);
-            Assert.Equal("pipe-name-123", bound.PipeName);
-            Assert.Equal("my role name", bound.RoleName);
-            Assert.Equal("my trigger", bound.TriggerType);
-            Assert.Equal("Nettrace", bound.TraceFileFormat);
+            Assert.Equal(model.AIInstrumentationKey, bound.AIInstrumentationKey);
+            Assert.Equal(model.HostUrl, bound.HostUrl);
+            // Pins the timestamp format: the producer serializes via TimestampContract and the binder must
+            // parse back the exact same instant (guards against an offset-less form shifting the value).
+            Assert.Equal(model.SessionId, bound.SessionId);
+            Assert.Equal(model.StampId, bound.StampId);
+            Assert.Equal(model.TraceFilePath, bound.TraceFilePath);
+            Assert.Equal(model.MetadataFilePath, bound.MetadataFilePath);
+            Assert.Equal(model.PreserveTraceFile, bound.PreserveTraceFile);
+            Assert.Equal(model.SkipEndpointCertificateValidation, bound.SkipEndpointCertificateValidation);
+            Assert.Equal(model.UploadMode, bound.UploadMode);
+            Assert.Equal(model.SerializedSampleFilePath, bound.SerializedSampleFilePath);
+            Assert.Equal(model.PipeName, bound.PipeName);
+            Assert.Equal(model.RoleName, bound.RoleName);
+            Assert.Equal(model.TriggerType, bound.TriggerType);
+            Assert.Equal(model.TraceFileFormat, bound.TraceFileFormat);
             Assert.True(bound.UseNamedPipe);
         }
 
         [Fact]
-        public void CommandLine_OmitsOptionalFields_BindsToDefaults()
+        public void ProducerOutput_WithOptionalFieldsOmitted_RoundTrips()
         {
-            Guid iKey = Guid.NewGuid();
-            DateTimeOffset sessionId = new(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
+            DateTimeOffset sessionId = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero).AddTicks(7654321);
 
-            string commandLine =
-                $@"--{nameof(UploadContext.TraceFilePath)} ""/tmp/trace.nettrace""" +
-                $@" --{nameof(UploadContext.AIInstrumentationKey)} ""{iKey}""" +
-                $@" --{nameof(UploadContext.SessionId)} ""{sessionId.UtcDateTime:o}""" +
-                $@" --{nameof(UploadContext.StampId)} ""stamp""" +
-                $@" --{nameof(UploadContext.HostUrl)} ""https://example.endpoint.com/""" +
-                $@" --{nameof(UploadContext.MetadataFilePath)} ""/tmp/meta.json""" +
-                $@" --{nameof(UploadContext.UploadMode)} ""{UploadMode.OnSuccess}""" +
-                $@" --{nameof(UploadContext.SerializedSampleFilePath)} ""/tmp/samples.json""" +
-                $@" --{nameof(UploadContext.TraceFileFormat)} ""Netperf""";
+            // PipeName / RoleName / TriggerType null and the bool flags false: the producer omits these
+            // entirely, so the consumer must fall back to its defaults rather than binding stale values.
+            UploadContextModel model = new()
+            {
+                AIInstrumentationKey = Guid.NewGuid(),
+                HostUrl = new Uri("https://example.endpoint.com/"),
+                SessionId = sessionId,
+                StampId = "stamp",
+                TraceFilePath = @"/tmp/trace.nettrace",
+                MetadataFilePath = @"/tmp/meta.json",
+                PreserveTraceFile = false,
+                SkipEndpointCertificateValidation = false,
+                UploadMode = UploadMode.OnSuccess,
+                SerializedSampleFilePath = @"/tmp/samples.json",
+                PipeName = null,
+                RoleName = null,
+                TriggerType = null,
+                TraceFileFormat = "Netperf",
+            };
 
-            UploadContext bound = Bind(commandLine);
+            UploadContext bound = RoundTrip(model);
 
+            Assert.Equal(model.SessionId, bound.SessionId);
             Assert.Equal(UploadMode.OnSuccess, bound.UploadMode);
             Assert.False(bound.PreserveTraceFile);
             Assert.False(bound.SkipEndpointCertificateValidation);
@@ -86,11 +103,12 @@ namespace ServiceProfiler.EventPipe.Upload.Tests
             Assert.Null(bound.RoleName);
             Assert.Null(bound.TriggerType);
             Assert.False(bound.UseNamedPipe);
+            Assert.Equal(model.TraceFileFormat, bound.TraceFileFormat);
         }
 
-        private static UploadContext Bind(string commandLine)
+        private static UploadContext RoundTrip(UploadContextModel model)
         {
-            string[] args = Tokenize(commandLine);
+            string[] args = Tokenize(model.ToString());
             IConfiguration configuration = new ConfigurationBuilder()
                 .AddCommandLine(args)
                 .Build();

--- a/tests/ServiceProfiler.EventPipe.Upload.Tests/UploadContextValidatorTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Upload.Tests/UploadContextValidatorTests.cs
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using Microsoft.ApplicationInsights.Profiler.Core.Contracts;
+using Microsoft.ApplicationInsights.Profiler.Core.Utilities;
+using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Upload.Tests
+{
+    /// <summary>
+    /// Validates the uploader-side <see cref="UploadContextValidator"/> that runs against the bound
+    /// <see cref="UploadContext"/>. Because the command-line parser's <c>[Option(Required = true)]</c>
+    /// attributes were removed in favor of configuration binding, required-field enforcement now lives
+    /// entirely in this validator.
+    /// </summary>
+    public class UploadContextValidatorTests
+    {
+        private static UploadContext CreateValidContext() => new()
+        {
+            AIInstrumentationKey = Guid.NewGuid(),
+            HostUrl = new Uri("https://endpoint/"),
+            SessionId = DateTimeOffset.UtcNow,
+            StampId = "stamp",
+            TraceFilePath = @"c:\trace.nettrace",
+            MetadataFilePath = @"c:\meta.json",
+            UploadMode = UploadMode.OnSuccess,
+            SerializedSampleFilePath = @"c:\sample",
+            TraceFileFormat = "Nettrace",
+        };
+
+        [Fact]
+        public void Validate_WhenComplete_ReturnsNoError()
+        {
+            UploadContextValidator validator = new(fileExists: _ => true);
+
+            string error = validator.Validate(CreateValidContext());
+
+            Assert.True(string.IsNullOrEmpty(error));
+        }
+
+        [Fact]
+        public void Validate_WhenTraceFilePathMissing_ReturnsError()
+        {
+            UploadContextValidator validator = new(fileExists: _ => true);
+            UploadContext context = CreateValidContext();
+            context.TraceFilePath = null!;
+
+            string error = validator.Validate(context);
+
+            Assert.Contains($"{nameof(UploadContext.TraceFilePath)} is required.", error);
+        }
+
+        [Fact]
+        public void Validate_WhenTraceFilePathEmpty_ReturnsError()
+        {
+            UploadContextValidator validator = new(fileExists: _ => true);
+            UploadContext context = CreateValidContext();
+            context.TraceFilePath = string.Empty;
+
+            string error = validator.Validate(context);
+
+            Assert.Contains($"{nameof(UploadContext.TraceFilePath)} is required.", error);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #18.

## Summary

The third-party [`CommandLineParser`](https://www.nuget.org/packages/CommandLineParser) package was only ever needed by the standalone uploader to **parse** its command line — yet it was referenced by the profiler libraries too. This PR removes the dependency entirely from the main repo and replaces the uploader's argument parsing with the already-referenced `Microsoft.Extensions.Configuration` command-line binding.

## What changed

- **Producer** (`UploadContextModel.ToString()`, in the Shared library): now emits `--<PropertyName> "value"` keys that match the uploader's `UploadContext` property names so the configuration binder maps them directly. Boolean flags are emitted as `--Flag true` only when set.
- **Consumer** (`ServiceProfiler.EventPipe.Upload`):
  - `UploadContext` drops the `[Option]` attributes and `using CommandLine`; it's now a plain bindable options class.
  - `Program.Main` binds via `ConfigurationBuilder().AddCommandLine(args).Get<UploadContext>()`. It **fails fast** with exit code `1` (and a clear `fail:` message) on malformed arguments, and returns `Environment.ExitCode` after the host completes so the uploader's success (`0`) / failure (`-1`) exit code is preserved for the parent process.
  - Added `Microsoft.Extensions.Configuration.Binder` (drives `Get<T>()`).
- **Removed** the dead `CommandLineParser` `<PackageReference>` from the Core library, the public `Azure.Monitor.OpenTelemetry.Profiler` package, and the classic `ServiceProfiler.EventPipe.Client` project (none of them used it).

## Tests

- Updated the producer-format assertions in `UploadContextModelTests`.
- Added `UploadContextRoundTripTests`, which serializes via `UploadContextModel.ToString()`, tokenizes using the **real Windows `CommandLineToArgvW`** parser (matching how `ProcessStartInfo.Arguments` is parsed by the launched uploader), then binds back into `UploadContext` — verifying every field (Guid, Uri, DateTimeOffset, enum, bool flags, optional/nullable strings).

## Verification

- Combined solution builds with 0 errors.
- Affected test suites pass: Uploader (24), classic Client (58), OTel (70).
- Clean build + pack of the OTel NuGet package confirms `CommandLineParser` is **no longer a dependency** in the generated `.nuspec`, with `Microsoft.Extensions.Configuration.Binder` correctly present.

## Review

Iteratively reviewed with GPT-5.5 and Opus 4.7 to **two consecutive clean rounds**. Findings that led to real improvements: the round-trip test now tokenizes via the real Windows `CommandLineToArgvW` (instead of an approximation), `Program.Main` fails fast on malformed args, and `Main` returns `Environment.ExitCode` so uploader failures are no longer masked by a literal `0`.

## Notes

- Producer and consumer ship together in the same package, so the internal command-line wire format can change freely; no cross-version compatibility contract exists for these args.
- The root `Directory.Packages.props` is a symlink into the `ServiceProfiler` submodule whose `CommandLineParser` version is still used by submodule projects, so the central `PackageVersion` entry is intentionally left in place (an unreferenced version never becomes a package dependency).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>