### PR TITLE
Introduce lease-based concurrency control for profiler trace collection (#94)

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Orchestrations/OrchestratorEventPipe.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Orchestrations/OrchestratorEventPipe.cs
@@ -27,6 +27,7 @@ internal abstract class OrchestratorEventPipe : Orchestrator
     private readonly IServiceProfilerProvider _profilerProvider;
     private readonly IAgentStatusService _agentStatusService;
     private readonly IResourceUsageSource _resourceUsageSource;
+    private readonly IProfilerConcurrencyControlClient? _concurrencyControlClient;
     private ILogger _logger;
     private TimeSpan _initialDelay;
 
@@ -37,6 +38,14 @@ internal abstract class OrchestratorEventPipe : Orchestrator
     private readonly ConcurrentDictionary<Task, byte> _semaphoreTasks = new();
 
     private SchedulingPolicy? _currentProfilingPolicy = null;
+
+    // The concurrency lease held for the in-flight profiling session, if any.
+    // Guarded by _policyChangeHandler alongside _currentProfilingPolicy.
+    private IAsyncDisposable? _currentLease = null;
+
+    // Set during disposal so an in-flight StartProfilingAsync releases its lease instead of
+    // retaining it (the normal stop path won't run during shutdown). Volatile for visibility.
+    private volatile bool _disposed = false;
 
     private CancellationTokenSource _cancellationTokenSource = new();
 
@@ -52,7 +61,8 @@ internal abstract class OrchestratorEventPipe : Orchestrator
         IDelaySource delaySource,
         IAgentStatusService agentStatusService,
         IResourceUsageSource resourceUsageSource,
-        ILogger<OrchestratorEventPipe> logger) : base(delaySource)
+        ILogger<OrchestratorEventPipe> logger,
+        IProfilerConcurrencyControlClient? concurrencyControlClient = null) : base(delaySource)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _policyCollection = (policyCollection ?? throw new ArgumentNullException(nameof(policyCollection)))
@@ -60,6 +70,7 @@ internal abstract class OrchestratorEventPipe : Orchestrator
         _profilerProvider = profilerProvider ?? throw new ArgumentNullException(nameof(profilerProvider));
         _agentStatusService = agentStatusService ?? throw new ArgumentNullException(nameof(agentStatusService));
         _resourceUsageSource = resourceUsageSource ?? throw new ArgumentNullException(nameof(resourceUsageSource));
+        _concurrencyControlClient = concurrencyControlClient;
         _initialDelay = config.Value.InitialDelay;
     }
 
@@ -173,6 +184,11 @@ internal abstract class OrchestratorEventPipe : Orchestrator
                         _cancellationTokenSource.Cancel();
                         _logger.LogInformation("Agent status is {status}, stopping all scheduling policies.", status);
                     }
+
+                    // Cancelled schedules may exit without going through the normal stop path (e.g. a policy
+                    // cancelled during its profiling-duration delay), leaving an active session and its lease
+                    // dangling. Explicitly stop the session and release the lease here.
+                    await StopActiveSessionAndReleaseLeaseAsync("Agent deactivated").ConfigureAwait(false);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(status));
@@ -207,11 +223,73 @@ internal abstract class OrchestratorEventPipe : Orchestrator
                 {
                     if (_currentProfilingPolicy == null)
                     {
-                        bool result = await _profilerProvider.StartServiceProfilerAsync(policy, cancellationToken).ConfigureAwait(false);
+                        if (_disposed)
+                        {
+                            // Shutting down; don't acquire a lease or start a session.
+                            return false;
+                        }
+
+                        IAsyncDisposable? lease = null;
+                        if (_concurrencyControlClient is not null)
+                        {
+                            lease = await _concurrencyControlClient.TryAcquireLeaseAsync(cancellationToken).ConfigureAwait(false);
+                            if (lease is null)
+                            {
+                                _logger.LogDebug("Profiling requested by {source} skipped: concurrency lease unavailable.", policy.Source);
+                                return false;
+                            }
+
+                            _logger.LogTrace("Concurrency lease acquired for {source}; starting profiler session.", policy.Source);
+                        }
+
+                        bool result;
+                        try
+                        {
+                            result = await _profilerProvider.StartServiceProfilerAsync(policy, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch
+                        {
+                            // The start failed. The provider may have started (or partially started) before
+                            // throwing, and for some providers IsProfilerRunning reflects only that the
+                            // provider semaphore is held rather than that a session is truly active. To avoid
+                            // ever retaining/leaking a lease on a failed start, we do NOT keep the lease here:
+                            // best-effort stop the profiler if it reports running, then release the lease.
+                            if (_profilerProvider.IsProfilerRunning)
+                            {
+                                await StopProfilerBestEffortAsync(policy).ConfigureAwait(false);
+                            }
+
+                            await DisposeLeaseAsync(lease).ConfigureAwait(false);
+
+                            throw;
+                        }
+
                         if (result)
                         {
-                            _logger.LogDebug("Profiling is started. Source: {source}", policy.Source);
-                            _currentProfilingPolicy = policy;
+                            // If we are terminating while the provider was starting -- the orchestrator is
+                            // being disposed, or the schedule token was cancelled (e.g. agent deactivation) --
+                            // the normal stop path will not run to release the lease. Stop the just-started
+                            // session best-effort and release the lease here instead of retaining it, so we
+                            // never leave a profiler running without a concurrency lease, and never strand a
+                            // renewing lease. This runs under the policy-change semaphore, which Dispose and the
+                            // deactivation cleanup also acquire before reading _currentLease.
+                            if (_disposed || cancellationToken.IsCancellationRequested)
+                            {
+                                _logger.LogDebug("Orchestrator terminating during profiler start; stopping the just-started session and releasing the concurrency lease for {source}.", policy.Source);
+                                await StopProfilerBestEffortAsync(policy).ConfigureAwait(false);
+                                await DisposeLeaseAsync(lease).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                _logger.LogDebug("Profiling is started. Source: {source}", policy.Source);
+                                _currentProfilingPolicy = policy;
+                                _currentLease = lease;
+                            }
+                        }
+                        else
+                        {
+                            // Profiler did not start; release the lease so another instance can use it.
+                            await DisposeLeaseAsync(lease).ConfigureAwait(false);
                         }
 
                         return result;
@@ -282,6 +360,15 @@ internal abstract class OrchestratorEventPipe : Orchestrator
                             // StopServiceProfilerAsync guarantees the semaphore is released before returning,
                             // so the profiler is no longer running regardless of the result value.
                             _currentProfilingPolicy = null;
+
+                            // The profiler is no longer running; release the concurrency lease.
+                            IAsyncDisposable? leaseToRelease = _currentLease;
+                            _currentLease = null;
+                            if (leaseToRelease is not null)
+                            {
+                                _logger.LogTrace("Releasing concurrency lease for {source}.", policy.Source);
+                                await DisposeLeaseAsync(leaseToRelease).ConfigureAwait(false);
+                            }
                         }
                         else
                         {
@@ -291,11 +378,29 @@ internal abstract class OrchestratorEventPipe : Orchestrator
                     }
                     catch
                     {
-                        // Stop profiling can fail for various reasons. Check the current status to decide 
-                        // whether to give back the current profiling handler.
-                        if (_currentProfilingPolicy == policy && !_profilerProvider.IsProfilerRunning)
+                        // Stop profiling can fail for various reasons. Decide whether to release the lease now
+                        // or keep it for a retry. Release it when the profiler is no longer running, or when we
+                        // are terminating (the orchestrator is being disposed, or this stop was cancelled e.g.
+                        // by agent deactivation / shutdown) — because in those cases the scheduling loop will
+                        // not run again to retry the stop and release the lease. Otherwise keep the lease so the
+                        // still-active schedule can retry the stop.
+                        bool terminating = _disposed || cancellationToken.IsCancellationRequested;
+                        if (_currentProfilingPolicy == policy && (!_profilerProvider.IsProfilerRunning || terminating))
                         {
                             _currentProfilingPolicy = null;
+
+                            IAsyncDisposable? leaseToRelease = _currentLease;
+                            _currentLease = null;
+
+                            // If terminating while the profiler still reports running (e.g. the stop above was
+                            // cancelled), best-effort stop it before releasing the lease so we do not free a
+                            // concurrency slot while still profiling.
+                            if (terminating && _profilerProvider.IsProfilerRunning)
+                            {
+                                await StopProfilerBestEffortAsync(policy).ConfigureAwait(false);
+                            }
+
+                            await DisposeLeaseAsync(leaseToRelease).ConfigureAwait(false);
                         }
 
                         throw;
@@ -327,13 +432,169 @@ internal abstract class OrchestratorEventPipe : Orchestrator
         {
             _agentStatusService.StatusChanged -= OnAgentStatusChanged;
 
+            // Signal disposal first so any in-flight StartProfilingAsync (running while holding
+            // _policyChangeHandler) releases its own lease instead of retaining it.
+            _disposed = true;
+
+            // Cancel next so in-flight start/stop operations return promptly.
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource.Dispose();
 
             _statusChangeSemaphore.Dispose();
 
-            Task.WhenAll(_semaphoreTasks.Keys);
-            _policyChangeHandler.Dispose();
+            // Acquire the policy-change gate before reading _currentLease so we observe the final value
+            // assigned by any in-flight start/stop instead of racing it. Only mutate/dispose the semaphore
+            // when we actually acquired it; on timeout the in-flight holder still owns the gate and will
+            // release its own lease (because _disposed is set), so we avoid both a lease leak and a
+            // Release()/Dispose() against a semaphore another thread still holds.
+            IAsyncDisposable? leaseToRelease = null;
+            SchedulingPolicy? policyToStop = null;
+            bool acquired = false;
+            try
+            {
+                acquired = _policyChangeHandler.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+
+            if (acquired)
+            {
+                leaseToRelease = _currentLease;
+                policyToStop = _currentProfilingPolicy;
+                _currentLease = null;
+                _currentProfilingPolicy = null;
+
+                // Release so any queued start/stop waiter can drain cleanly; it will observe _disposed
+                // and return without acquiring a lease. _policyChangeHandler is intentionally NOT disposed:
+                // it is never used via AvailableWaitHandle (so Dispose would free nothing), and disposing it
+                // while in-flight/queued callers may still call Release() in their finally blocks would throw
+                // ObjectDisposedException.
+                _policyChangeHandler.Release();
+            }
+
+            // Best-effort teardown of any session still active during disposal: stop the profiler first
+            // (so we never release a concurrency slot while still profiling), then release the lease.
+            if (leaseToRelease is not null)
+            {
+                _logger.LogDebug("Cleaning up active profiling session and concurrency lease during disposal.");
+                _ = CleanupActiveSessionAsync(policyToStop, leaseToRelease);
+            }
+        }
+    }
+
+    private async Task DisposeLeaseAsync(IAsyncDisposable? lease)
+    {
+        if (lease is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await lease.DisposeAsync().ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Releasing a lease must never throw to the caller.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogDebug(ex, "Error releasing concurrency lease.");
+        }
+    }
+
+    /// <summary>
+    /// Best-effort stop of a profiling session during termination (disposal, agent deactivation, or a
+    /// cancelled stop), where the normal stop path will not run. Callers stop the profiler with this and
+    /// then release the lease.
+    /// </summary>
+    /// <remarks>
+    /// Deliberate termination tradeoff: callers release the concurrency lease after this returns even if
+    /// the stop failed and the provider still reports running. This is intentional. Holding the lease
+    /// instead would leave it auto-renewing forever (a permanent fleet-slot leak), which is strictly worse
+    /// than briefly overlapping during teardown — and note <c>IsProfilerRunning</c> reflects that the
+    /// provider's session semaphore is held, not necessarily that a trace is actively being captured, so a
+    /// failed stop here is frequently a stuck-semaphore false positive with no real session to keep a slot
+    /// for. The server-side lease also expires on its own within its short duration. Never throws.
+    /// </remarks>
+    private async Task StopProfilerBestEffortAsync(IProfilerSource policy)
+    {
+        try
+        {
+            await _profilerProvider.StopServiceProfilerAsync(policy, CancellationToken.None).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Best-effort shutdown cleanup must not throw.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogDebug(ex, "Best-effort stop during termination failed for {source}.", policy.Source);
+        }
+    }
+
+    /// <summary>
+    /// Cleans up an active profiling session during disposal: stops the profiler best-effort first (so a
+    /// concurrency slot is never released while still profiling), then releases the lease. Never throws.
+    /// </summary>
+    private async Task CleanupActiveSessionAsync(IProfilerSource? policy, IAsyncDisposable lease)
+    {
+        if (policy is not null && _profilerProvider.IsProfilerRunning)
+        {
+            await StopProfilerBestEffortAsync(policy).ConfigureAwait(false);
+        }
+
+        await DisposeLeaseAsync(lease).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Acquires the policy-change gate and, if a profiling session is active, best-effort stops it and
+    /// releases its concurrency lease. Used when schedules are torn down outside the normal stop path
+    /// (e.g. agent deactivation), where the cancelled policy loop may exit without releasing the lease.
+    /// Never throws.
+    /// </summary>
+    private async Task StopActiveSessionAndReleaseLeaseAsync(string reason)
+    {
+        bool acquired;
+        try
+        {
+            acquired = await _policyChangeHandler.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        if (!acquired)
+        {
+            _logger.LogWarning("Timed out acquiring the policy gate to clean up the active session ({reason}).", reason);
+            return;
+        }
+
+        try
+        {
+            SchedulingPolicy? policy = _currentProfilingPolicy;
+            IAsyncDisposable? lease = _currentLease;
+            if (policy is null && lease is null)
+            {
+                return;
+            }
+
+            _currentProfilingPolicy = null;
+            _currentLease = null;
+
+            _logger.LogDebug("Cleaning up active profiling session and concurrency lease ({reason}).", reason);
+            if (policy is not null && _profilerProvider.IsProfilerRunning)
+            {
+                await StopProfilerBestEffortAsync(policy).ConfigureAwait(false);
+            }
+
+            await DisposeLeaseAsync(lease).ConfigureAwait(false);
+        }
+        finally
+        {
+            _policyChangeHandler.Release();
         }
     }
 

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IProfilerConcurrencyControlClient.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IProfilerConcurrencyControlClient.cs
@@ -1,0 +1,35 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+
+/// <summary>
+/// Coordinates profiling concurrency across many instances of the same application by
+/// acquiring a shared, server-enforced lease before a profiling session starts.
+/// </summary>
+/// <remarks>
+/// The backend enforces the maximum number of instances that may profile concurrently.
+/// Implementations are expected to be <b>fail-open</b>: only an explicit "cap reached"
+/// response from the service should prevent profiling. Any other failure (service down,
+/// network error, missing endpoint, timeout) must allow profiling to proceed.
+/// </remarks>
+internal interface IProfilerConcurrencyControlClient
+{
+    /// <summary>
+    /// Attempts to acquire a concurrency lease for a profiling session.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>
+    /// A non-null <see cref="IAsyncDisposable"/> lease handle when profiling may proceed
+    /// (either the lease was acquired, or acquisition failed-open). Dispose the handle
+    /// when the profiling session ends to release the lease. Returns <see langword="null"/>
+    /// only when the service explicitly denied the lease because the concurrency cap has
+    /// been reached; in that case the caller should skip this profiling cycle.
+    /// </returns>
+    Task<IAsyncDisposable?> TryAcquireLeaseAsync(CancellationToken cancellationToken);
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IProfilerLeaseClient.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IProfilerLeaseClient.cs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+
+/// <summary>
+/// Thin seam over the raw backend lease operations used for profiler concurrency
+/// control. The default implementation wraps the public Azure Monitor diagnostics lease
+/// API; abstracting it keeps the higher-level concurrency logic unit-testable.
+/// </summary>
+internal interface IProfilerLeaseClient
+{
+    /// <summary>
+    /// Acquires a lease for the configured instrumentation key and profiler lease namespace.
+    /// </summary>
+    /// <param name="duration">The requested lease duration (15-60 seconds).</param>
+    /// <param name="metadata">Diagnostic metadata for the request.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The acquired lease ID.</returns>
+    /// <exception cref="Azure.Monitor.Diagnostics.LeaseUnavailableException">
+    /// The concurrency cap has been reached.
+    /// </exception>
+    Task<Guid> AcquireAsync(TimeSpan duration, IReadOnlyDictionary<string, string> metadata, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Renews a previously acquired lease.
+    /// </summary>
+    Task RenewAsync(Guid leaseId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Releases a previously acquired lease.
+    /// </summary>
+    Task ReleaseAsync(Guid leaseId, CancellationToken cancellationToken);
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/AutoRenewingProfilerLease.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/AutoRenewingProfilerLease.cs
@@ -1,0 +1,115 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Monitor.Diagnostics;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services;
+
+/// <summary>
+/// Holds a profiler concurrency lease alive by periodically renewing it, and releases it
+/// when disposed. Renewal failures are swallowed (logged) so they never disrupt the
+/// in-flight profiling session; the lease will simply expire server-side.
+/// </summary>
+internal sealed class AutoRenewingProfilerLease : IAsyncDisposable
+{
+    private readonly IProfilerLeaseClient _leaseClient;
+    private readonly Guid _leaseId;
+    private readonly TimeSpan _renewInterval;
+    private readonly ILogger _logger;
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private readonly Task _renewTask;
+    private readonly Stopwatch _heldStopwatch = Stopwatch.StartNew();
+
+    public AutoRenewingProfilerLease(
+        IProfilerLeaseClient leaseClient,
+        Guid leaseId,
+        TimeSpan renewInterval,
+        ILogger logger)
+    {
+        _leaseClient = leaseClient ?? throw new ArgumentNullException(nameof(leaseClient));
+        _leaseId = leaseId;
+        _renewInterval = renewInterval;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _renewTask = Task.Run(RenewLoopAsync);
+    }
+
+    private async Task RenewLoopAsync()
+    {
+        CancellationToken cancellationToken = _cancellationTokenSource.Token;
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(_renewInterval, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await _leaseClient.RenewAsync(_leaseId, cancellationToken).ConfigureAwait(false);
+                    _logger.LogTrace("Renewed profiler concurrency lease {LeaseId}.", _leaseId);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // Disposing; stop renewing.
+                    throw;
+                }
+                catch (LeaseUnavailableException ex)
+                {
+                    _logger.LogDebug(
+                        "Profiler concurrency lease {LeaseId} lost or expired during renewal; stopping renewal. " +
+                        "The current session will finish; the lease will expire server-side. {Reason}",
+                        _leaseId, ex.Message);
+                    _logger.LogTrace(ex, "Lease renewal failure detail for {LeaseId}.", _leaseId);
+                    return;
+                }
+#pragma warning disable CA1031 // Fail-open: a transient renew error must not disrupt profiling.
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    // Transient error: log and keep trying on the next interval.
+                    _logger.LogDebug("Transient error renewing profiler concurrency lease {LeaseId}: {Reason}", _leaseId, ex.Message);
+                    _logger.LogTrace(ex, "Lease renewal error detail for {LeaseId}.", _leaseId);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on dispose.
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cancellationTokenSource.Cancel();
+        try
+        {
+            await _renewTask.ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Best-effort cleanup; never throw from dispose.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogTrace(ex, "Profiler concurrency lease renewal task ended with an error for {LeaseId}.", _leaseId);
+        }
+
+        _cancellationTokenSource.Dispose();
+
+        try
+        {
+            await _leaseClient.ReleaseAsync(_leaseId, CancellationToken.None).ConfigureAwait(false);
+            _logger.LogDebug("Released profiler concurrency lease {LeaseId} after {HeldMs}ms.", _leaseId, _heldStopwatch.ElapsedMilliseconds);
+        }
+#pragma warning disable CA1031 // Release failures are non-fatal; the lease expires server-side.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogDebug("Failed to release profiler concurrency lease {LeaseId}; it will expire server-side. {Reason}", _leaseId, ex.Message);
+            _logger.LogTrace(ex, "Lease release error detail for {LeaseId}.", _leaseId);
+        }
+    }
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/DiagnosticsProfilerLeaseClient.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/DiagnosticsProfilerLeaseClient.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Shared.Services;
 /// <see cref="DiagnosticsClient"/> lease API. The underlying client is created lazily so
 /// the instrumentation key / endpoint are resolved at first use.
 /// </summary>
-internal sealed class DiagnosticsProfilerLeaseClient : IProfilerLeaseClient
+internal class DiagnosticsProfilerLeaseClient : IProfilerLeaseClient
 {
     private const string LeaseNamespace = LeaseNamespaces.Profiler;
 
@@ -59,19 +59,46 @@ internal sealed class DiagnosticsProfilerLeaseClient : IProfilerLeaseClient
     }
 
     public Task<Guid> AcquireAsync(TimeSpan duration, IReadOnlyDictionary<string, string> metadata, CancellationToken cancellationToken)
-        => _diagnosticsClient.Value.AcquireLeaseAsync(_iKey.Value, LeaseNamespace, duration, metadata, cancellationToken);
+        => TranslateLeaseLostAsync(AcquireCoreAsync(duration, metadata, cancellationToken));
 
     public Task RenewAsync(Guid leaseId, CancellationToken cancellationToken)
-        => TranslateLeaseLostAsync(_diagnosticsClient.Value.RenewLeaseAsync(_iKey.Value, LeaseNamespace, leaseId, cancellationToken));
+        => TranslateLeaseLostAsync(RenewCoreAsync(leaseId, cancellationToken));
 
     public Task ReleaseAsync(Guid leaseId, CancellationToken cancellationToken)
-        => TranslateLeaseLostAsync(_diagnosticsClient.Value.ReleaseLeaseAsync(_iKey.Value, LeaseNamespace, leaseId, cancellationToken));
+        => TranslateLeaseLostAsync(ReleaseCoreAsync(leaseId, cancellationToken));
+
+    // Raw calls into the underlying SDK, isolated as an overridable seam so the 409 -> typed-exception
+    // translation can be unit-tested without a live backend.
+    internal virtual Task<Guid> AcquireCoreAsync(TimeSpan duration, IReadOnlyDictionary<string, string> metadata, CancellationToken cancellationToken)
+        => _diagnosticsClient.Value.AcquireLeaseAsync(_iKey.Value, LeaseNamespace, duration, metadata, cancellationToken);
+
+    internal virtual Task RenewCoreAsync(Guid leaseId, CancellationToken cancellationToken)
+        => _diagnosticsClient.Value.RenewLeaseAsync(_iKey.Value, LeaseNamespace, leaseId, cancellationToken);
+
+    internal virtual Task ReleaseCoreAsync(Guid leaseId, CancellationToken cancellationToken)
+        => _diagnosticsClient.Value.ReleaseLeaseAsync(_iKey.Value, LeaseNamespace, leaseId, cancellationToken);
 
     /// <summary>
-    /// Unlike acquire, the underlying client surfaces a lost/expired lease (HTTP 409) on renew/release
-    /// as a generic <see cref="RequestFailedException"/>. Translate it to <see cref="LeaseUnavailableException"/>
-    /// so callers can distinguish "lease lost" from transient errors.
+    /// Translates a cap-reached / lost-lease response (HTTP 409) surfaced as a generic
+    /// <see cref="RequestFailedException"/> into a typed <see cref="LeaseUnavailableException"/> so callers
+    /// can distinguish "cap reached / lease lost" from transient errors.
+    /// The underlying client already throws <see cref="LeaseUnavailableException"/> directly for a 409 on
+    /// acquire, but surfaces it as a generic <see cref="RequestFailedException"/> on renew/release; acquire
+    /// is routed through here too so a single, symmetric contract holds regardless of that asymmetry (and is
+    /// a no-op when the SDK already throws the typed exception).
     /// </summary>
+    private static async Task<T> TranslateLeaseLostAsync<T>(Task<T> operation)
+    {
+        try
+        {
+            return await operation.ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex) when (ex.Status == (int)System.Net.HttpStatusCode.Conflict)
+        {
+            throw new LeaseUnavailableException("The lease is unavailable.", ex);
+        }
+    }
+
     private static async Task TranslateLeaseLostAsync(Task operation)
     {
         try

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/DiagnosticsProfilerLeaseClient.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/DiagnosticsProfilerLeaseClient.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Core;
+using Azure.Monitor.Diagnostics;
+using Azure.Monitor.Diagnostics.Models;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions.Auth;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services;
+
+/// <summary>
+/// Default <see cref="IProfilerLeaseClient"/> that wraps the public
+/// <see cref="DiagnosticsClient"/> lease API. The underlying client is created lazily so
+/// the instrumentation key / endpoint are resolved at first use.
+/// </summary>
+internal sealed class DiagnosticsProfilerLeaseClient : IProfilerLeaseClient
+{
+    private const string LeaseNamespace = LeaseNamespaces.Profiler;
+
+    private readonly IServiceProfilerContext _serviceProfilerContext;
+    private readonly IAuthTokenProvider _authTokenProvider;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly Lazy<DiagnosticsClient> _diagnosticsClient;
+    private readonly Lazy<string> _iKey;
+
+    public DiagnosticsProfilerLeaseClient(
+        IServiceProfilerContext serviceProfilerContext,
+        IAuthTokenProvider authTokenProvider,
+        ILoggerFactory loggerFactory)
+    {
+        _serviceProfilerContext = serviceProfilerContext ?? throw new ArgumentNullException(nameof(serviceProfilerContext));
+        _authTokenProvider = authTokenProvider ?? throw new ArgumentNullException(nameof(authTokenProvider));
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        _diagnosticsClient = new Lazy<DiagnosticsClient>(CreateDiagnosticsClient);
+        _iKey = new Lazy<string>(() => _serviceProfilerContext.AppInsightsInstrumentationKey.ToString("D"));
+    }
+
+    private DiagnosticsClient CreateDiagnosticsClient()
+    {
+        TokenCredential? credential = _authTokenProvider.IsAADAuthenticateEnabled
+            ? new AADAuthTokenCredential(_authTokenProvider, _loggerFactory.CreateLogger<AADAuthTokenCredential>())
+            : null;
+
+        DiagnosticsClientOptions options = new()
+        {
+            Endpoint = _serviceProfilerContext.StampFrontendEndpointUrl,
+        };
+
+        return new DiagnosticsClient(options, credential);
+    }
+
+    public Task<Guid> AcquireAsync(TimeSpan duration, IReadOnlyDictionary<string, string> metadata, CancellationToken cancellationToken)
+        => _diagnosticsClient.Value.AcquireLeaseAsync(_iKey.Value, LeaseNamespace, duration, metadata, cancellationToken);
+
+    public Task RenewAsync(Guid leaseId, CancellationToken cancellationToken)
+        => TranslateLeaseLostAsync(_diagnosticsClient.Value.RenewLeaseAsync(_iKey.Value, LeaseNamespace, leaseId, cancellationToken));
+
+    public Task ReleaseAsync(Guid leaseId, CancellationToken cancellationToken)
+        => TranslateLeaseLostAsync(_diagnosticsClient.Value.ReleaseLeaseAsync(_iKey.Value, LeaseNamespace, leaseId, cancellationToken));
+
+    /// <summary>
+    /// Unlike acquire, the underlying client surfaces a lost/expired lease (HTTP 409) on renew/release
+    /// as a generic <see cref="RequestFailedException"/>. Translate it to <see cref="LeaseUnavailableException"/>
+    /// so callers can distinguish "lease lost" from transient errors.
+    /// </summary>
+    private static async Task TranslateLeaseLostAsync(Task operation)
+    {
+        try
+        {
+            await operation.ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex) when (ex.Status == (int)System.Net.HttpStatusCode.Conflict)
+        {
+            throw new LeaseUnavailableException("The lease is unavailable.", ex);
+        }
+    }
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/NoOpProfilerConcurrencyControlClient.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/NoOpProfilerConcurrencyControlClient.cs
@@ -1,0 +1,30 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services;
+
+/// <summary>
+/// A no-op concurrency control client that always grants. Used when there is no backend
+/// to lease from (for example, standalone mode).
+/// </summary>
+internal sealed class NoOpProfilerConcurrencyControlClient : IProfilerConcurrencyControlClient
+{
+    /// <summary>
+    /// A shared no-op lease handle. Disposing it does nothing.
+    /// </summary>
+    internal static readonly IAsyncDisposable GrantedLease = new NoOpLease();
+
+    public Task<IAsyncDisposable?> TryAcquireLeaseAsync(CancellationToken cancellationToken)
+        => Task.FromResult<IAsyncDisposable?>(GrantedLease);
+
+    private sealed class NoOpLease : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => default;
+    }
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerConcurrencyControlClient.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerConcurrencyControlClient.cs
@@ -1,0 +1,106 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Monitor.Diagnostics;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services;
+
+/// <summary>
+/// Acquires server-enforced concurrency leases so that not all instances of the same
+/// application profile at once. Fail-open: only an explicit cap-reached response prevents
+/// profiling; any other failure allows profiling to proceed.
+/// </summary>
+internal sealed class ProfilerConcurrencyControlClient : IProfilerConcurrencyControlClient
+{
+    /// <summary>
+    /// Initial lease duration. The backend accepts values between 15 and 60 seconds.
+    /// </summary>
+    internal static readonly TimeSpan LeaseDuration = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// How often to renew the lease while a profiling session runs.
+    /// </summary>
+    internal static readonly TimeSpan RenewInterval = TimeSpan.FromSeconds(5);
+
+    private readonly IProfilerLeaseClient _leaseClient;
+    private readonly IServiceProfilerContext _serviceProfilerContext;
+    private readonly IRoleNameSource _roleNameSource;
+    private readonly IRoleInstanceSource _roleInstanceSource;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger _logger;
+
+    public ProfilerConcurrencyControlClient(
+        IProfilerLeaseClient leaseClient,
+        IServiceProfilerContext serviceProfilerContext,
+        IRoleNameSource roleNameSource,
+        IRoleInstanceSource roleInstanceSource,
+        ILoggerFactory loggerFactory,
+        ILogger<ProfilerConcurrencyControlClient> logger)
+    {
+        _leaseClient = leaseClient ?? throw new ArgumentNullException(nameof(leaseClient));
+        _serviceProfilerContext = serviceProfilerContext ?? throw new ArgumentNullException(nameof(serviceProfilerContext));
+        _roleNameSource = roleNameSource ?? throw new ArgumentNullException(nameof(roleNameSource));
+        _roleInstanceSource = roleInstanceSource ?? throw new ArgumentNullException(nameof(roleInstanceSource));
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IAsyncDisposable?> TryAcquireLeaseAsync(CancellationToken cancellationToken)
+    {
+        string roleName = _roleNameSource.CloudRoleName;
+        string roleInstance = _roleInstanceSource.CloudRoleInstance;
+
+        IReadOnlyDictionary<string, string> metadata = new Dictionary<string, string>
+        {
+            ["RoleName"] = roleName,
+            ["RoleInstance"] = roleInstance,
+        };
+
+        _logger.LogTrace(
+            "Acquiring profiler concurrency lease for {RoleName}/{RoleInstance} (requested duration {DurationSeconds}s). Metadata: {@Metadata}",
+            roleName, roleInstance, (int)LeaseDuration.TotalSeconds, metadata);
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        try
+        {
+            Guid leaseId = await _leaseClient.AcquireAsync(LeaseDuration, metadata, cancellationToken).ConfigureAwait(false);
+
+            _logger.LogDebug(
+                "Acquired profiler concurrency lease {LeaseId} for {RoleName}/{RoleInstance} in {ElapsedMs}ms.",
+                leaseId, roleName, roleInstance, stopwatch.ElapsedMilliseconds);
+
+            return new AutoRenewingProfilerLease(
+                _leaseClient, leaseId, RenewInterval,
+                _loggerFactory.CreateLogger<AutoRenewingProfilerLease>());
+        }
+        catch (LeaseUnavailableException)
+        {
+            _logger.LogInformation(
+                "Profiler concurrency lease unavailable - fleet concurrency cap reached for {RoleName}/{RoleInstance}. Skipping this profiling cycle.",
+                roleName, roleInstance);
+            return null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+#pragma warning disable CA1031 // Fail-open: never block profiling because of an infrastructure error.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogWarning(
+                "Failed to acquire profiler concurrency lease ({Reason}); proceeding with profiling anyway (fail-open). Endpoint {Endpoint}.",
+                ex.Message, _serviceProfilerContext.StampFrontendEndpointUrl.Host);
+            _logger.LogTrace(ex, "Lease acquisition error detail for {RoleName}/{RoleInstance}.", roleName, roleInstance);
+            return NoOpProfilerConcurrencyControlClient.GrantedLease;
+        }
+    }
+}

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/OrchestrationImp.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/OrchestrationImp.cs
@@ -13,6 +13,7 @@ internal class OrchestrationImp(
     IDelaySource delaySource,
     IAgentStatusService agentStatusService,
     IResourceUsageSource resourceUsageSource,
-    ILogger<OrchestrationImp> logger) : OrchestratorEventPipe(profilerProvider, config, policyCollection, delaySource, agentStatusService, resourceUsageSource, logger)
+    ILogger<OrchestrationImp> logger,
+    IProfilerConcurrencyControlClient concurrencyControlClient) : OrchestratorEventPipe(profilerProvider, config, policyCollection, delaySource, agentStatusService, resourceUsageSource, logger, concurrencyControlClient)
 {
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/ServiceCollectionExtensions.cs
@@ -116,6 +116,19 @@ internal static class ServiceCollectionExtensions
         // Client
         services.AddSingleton<IProfilerClient>(p => ActivatorUtilities.CreateInstance<ProfilerClientFactory>(p).CreateProfilerClient());
 
+        // Concurrency control (lease-based). No-op in standalone mode (no backend to lease from).
+        services.AddSingleton<IProfilerLeaseClient, DiagnosticsProfilerLeaseClient>();
+        services.AddSingleton<IProfilerConcurrencyControlClient>(p =>
+        {
+            ServiceProfilerOptions options = p.GetRequiredService<IOptions<ServiceProfilerOptions>>().Value;
+            if (options.StandaloneMode)
+            {
+                return new NoOpProfilerConcurrencyControlClient();
+            }
+
+            return ActivatorUtilities.CreateInstance<ProfilerConcurrencyControlClient>(p);
+        });
+
         // Token
         services.AddSingleton<IAuthTokenProvider, AuthTokenProvider>();
 

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/OrchestrationImp.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/OrchestrationImp.cs
@@ -17,7 +17,8 @@ internal class OrchestrationImp : OrchestratorEventPipe
         IDelaySource delaySource,
         IAgentStatusService agentStatusService,
         IResourceUsageSource resourceUsageSource,
-        ILogger<OrchestrationImp> logger) : base(profilerProvider, config, policyCollection, delaySource, agentStatusService, resourceUsageSource, logger)
+        ILogger<OrchestrationImp> logger,
+        IProfilerConcurrencyControlClient concurrencyControlClient) : base(profilerProvider, config, policyCollection, delaySource, agentStatusService, resourceUsageSource, logger, concurrencyControlClient)
     {
     }
 }

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
@@ -365,6 +365,20 @@ internal static class ServiceCollectionExtensions
     private static IServiceCollection AddFrontendClient(this IServiceCollection services)
     {
         services.AddSingleton<IProfilerClient>(p => ActivatorUtilities.CreateInstance<ProfilerClientFactory>(p).CreateProfilerClient());
+
+        // Concurrency control (lease-based). No-op in standalone mode (no backend to lease from).
+        services.AddSingleton<IProfilerLeaseClient, DiagnosticsProfilerLeaseClient>();
+        services.AddSingleton<IProfilerConcurrencyControlClient>(p =>
+        {
+            UserConfiguration options = p.GetRequiredService<IOptions<UserConfiguration>>().Value;
+            if (options.StandaloneMode)
+            {
+                return new NoOpProfilerConcurrencyControlClient();
+            }
+
+            return ActivatorUtilities.CreateInstance<ProfilerConcurrencyControlClient>(p);
+        });
+
         return services;
     }
 

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/AutoRenewingProfilerLeaseTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/AutoRenewingProfilerLeaseTests.cs
@@ -1,0 +1,110 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Tests;
+
+public class AutoRenewingProfilerLeaseTests
+{
+    [Fact]
+    public async Task Lease_RenewsPeriodically_AndReleasesOnDispose()
+    {
+        Guid leaseId = Guid.NewGuid();
+        using ManualResetEventSlim renewed = new(false);
+
+        Mock<IProfilerLeaseClient> lease = new();
+        lease.Setup(l => l.RenewAsync(leaseId, It.IsAny<CancellationToken>()))
+            .Callback(() => renewed.Set())
+            .Returns(Task.CompletedTask);
+        lease.Setup(l => l.ReleaseAsync(leaseId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        AutoRenewingProfilerLease auto = new(lease.Object, leaseId, TimeSpan.FromMilliseconds(20), NullLogger.Instance);
+
+        Assert.True(renewed.Wait(TimeSpan.FromSeconds(5)), "Expected the lease to be renewed at least once.");
+
+        await auto.DisposeAsync();
+
+        lease.Verify(l => l.ReleaseAsync(leaseId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Lease_RenewFailure_IsSwallowed_AndStillReleases()
+    {
+        Guid leaseId = Guid.NewGuid();
+        using ManualResetEventSlim attempted = new(false);
+
+        Mock<IProfilerLeaseClient> lease = new();
+        lease.Setup(l => l.RenewAsync(leaseId, It.IsAny<CancellationToken>()))
+            .Callback(() => attempted.Set())
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        lease.Setup(l => l.ReleaseAsync(leaseId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        AutoRenewingProfilerLease auto = new(lease.Object, leaseId, TimeSpan.FromMilliseconds(20), NullLogger.Instance);
+
+        Assert.True(attempted.Wait(TimeSpan.FromSeconds(5)), "Expected a renew attempt.");
+
+        // Dispose must not throw even though renewal kept failing.
+        await auto.DisposeAsync();
+
+        lease.Verify(l => l.ReleaseAsync(leaseId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Lease_ReleaseFailure_DoesNotThrow()
+    {
+        Guid leaseId = Guid.NewGuid();
+
+        Mock<IProfilerLeaseClient> lease = new();
+        lease.Setup(l => l.RenewAsync(leaseId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        lease.Setup(l => l.ReleaseAsync(leaseId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("release failed"));
+
+        AutoRenewingProfilerLease auto = new(lease.Object, leaseId, TimeSpan.FromSeconds(30), NullLogger.Instance);
+
+        // Should complete without throwing.
+        await auto.DisposeAsync();
+
+        lease.Verify(l => l.ReleaseAsync(leaseId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Lease_WhenLeaseLostDuringRenew_StopsRenewing()
+    {
+        Guid leaseId = Guid.NewGuid();
+        int renewCalls = 0;
+        using ManualResetEventSlim lost = new(false);
+
+        Mock<IProfilerLeaseClient> lease = new();
+        lease.Setup(l => l.RenewAsync(leaseId, It.IsAny<CancellationToken>()))
+            .Callback(() =>
+            {
+                Interlocked.Increment(ref renewCalls);
+                lost.Set();
+            })
+            .ThrowsAsync(new Azure.Monitor.Diagnostics.LeaseUnavailableException("lease lost"));
+        lease.Setup(l => l.ReleaseAsync(leaseId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        AutoRenewingProfilerLease auto = new(lease.Object, leaseId, TimeSpan.FromMilliseconds(20), NullLogger.Instance);
+
+        Assert.True(lost.Wait(TimeSpan.FromSeconds(5)), "Expected a renew attempt.");
+
+        // Give the loop ample time to (incorrectly) retry; it must not after a lost lease.
+        await Task.Delay(200);
+        Assert.Equal(1, Volatile.Read(ref renewCalls));
+
+        await auto.DisposeAsync();
+        lease.Verify(l => l.ReleaseAsync(leaseId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/DiagnosticsProfilerLeaseClientTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/DiagnosticsProfilerLeaseClientTests.cs
@@ -1,0 +1,126 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Monitor.Diagnostics;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions.Auth;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Tests;
+
+/// <summary>
+/// Seam-level tests for <see cref="DiagnosticsProfilerLeaseClient"/>. These exercise the real
+/// translation logic against the raw SDK call, unlike <see cref="ProfilerConcurrencyControlClientTests"/>
+/// which mock <see cref="IProfilerLeaseClient"/> to throw the typed exception directly. They pin the
+/// contract the whole fail-open feature depends on: a cap-reached response on <c>acquire</c> must surface
+/// as <see cref="LeaseUnavailableException"/> (so a cycle is skipped) rather than a generic exception
+/// (which would fail open and silently defeat the concurrency cap).
+/// </summary>
+public class DiagnosticsProfilerLeaseClientTests
+{
+    private static readonly IReadOnlyDictionary<string, string> EmptyMetadata = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Test seam: overrides the raw SDK acquire call so we can drive its outcome without a live backend.
+    /// </summary>
+    private sealed class FakeAcquireLeaseClient : DiagnosticsProfilerLeaseClient
+    {
+        private readonly Func<Task<Guid>> _acquire;
+
+        public FakeAcquireLeaseClient(Func<Task<Guid>> acquire)
+            : base(Mock.Of<IServiceProfilerContext>(), Mock.Of<IAuthTokenProvider>(), NullLoggerFactory.Instance)
+        {
+            _acquire = acquire;
+        }
+
+        internal override Task<Guid> AcquireCoreAsync(TimeSpan duration, IReadOnlyDictionary<string, string> metadata, CancellationToken cancellationToken)
+            => _acquire();
+    }
+
+    [Fact]
+    public async Task AcquireAsync_WhenCapReached409_ThrowsLeaseUnavailable()
+    {
+        // A 409 surfaced as a generic RequestFailedException on acquire must be translated.
+        DiagnosticsProfilerLeaseClient client = new FakeAcquireLeaseClient(
+            () => Task.FromException<Guid>(new RequestFailedException((int)System.Net.HttpStatusCode.Conflict, "cap reached")));
+
+        await Assert.ThrowsAsync<LeaseUnavailableException>(
+            () => client.AcquireAsync(TimeSpan.FromSeconds(60), EmptyMetadata, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task AcquireAsync_WhenTypedLeaseUnavailable_Propagates()
+    {
+        // The current SDK throws LeaseUnavailableException directly on a 409 acquire; it must pass through.
+        DiagnosticsProfilerLeaseClient client = new FakeAcquireLeaseClient(
+            () => Task.FromException<Guid>(new LeaseUnavailableException("cap reached")));
+
+        await Assert.ThrowsAsync<LeaseUnavailableException>(
+            () => client.AcquireAsync(TimeSpan.FromSeconds(60), EmptyMetadata, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task AcquireAsync_WhenNon409Error_IsNotTranslated()
+    {
+        // A non-cap error must remain a generic RequestFailedException so the caller fails open.
+        DiagnosticsProfilerLeaseClient client = new FakeAcquireLeaseClient(
+            () => Task.FromException<Guid>(new RequestFailedException((int)System.Net.HttpStatusCode.InternalServerError, "server down")));
+
+        await Assert.ThrowsAsync<RequestFailedException>(
+            () => client.AcquireAsync(TimeSpan.FromSeconds(60), EmptyMetadata, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task AcquireAsync_WhenGranted_ReturnsLeaseId()
+    {
+        Guid expected = Guid.NewGuid();
+        DiagnosticsProfilerLeaseClient client = new FakeAcquireLeaseClient(() => Task.FromResult(expected));
+
+        Guid actual = await client.AcquireAsync(TimeSpan.FromSeconds(60), EmptyMetadata, CancellationToken.None);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async Task TryAcquireLeaseAsync_WhenSeamReturns409_ReturnsNull()
+    {
+        // End-to-end through the real lease seam: a cap-reached 409 on acquire must skip the cycle
+        // (return null), not fail open. Guards against the acquire path silently no-op'ing the cap.
+        DiagnosticsProfilerLeaseClient leaseClient = new FakeAcquireLeaseClient(
+            () => Task.FromException<Guid>(new RequestFailedException((int)System.Net.HttpStatusCode.Conflict, "cap reached")));
+
+        ProfilerConcurrencyControlClient controlClient = CreateConcurrencyControlClient(leaseClient);
+
+        IAsyncDisposable? result = await controlClient.TryAcquireLeaseAsync(CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    private static ProfilerConcurrencyControlClient CreateConcurrencyControlClient(IProfilerLeaseClient leaseClient)
+    {
+        Mock<IServiceProfilerContext> context = new();
+        context.SetupGet(c => c.StampFrontendEndpointUrl).Returns(new Uri("https://example.com/"));
+
+        Mock<IRoleNameSource> roleName = new();
+        roleName.SetupGet(r => r.CloudRoleName).Returns("role");
+
+        Mock<IRoleInstanceSource> roleInstance = new();
+        roleInstance.SetupGet(r => r.CloudRoleInstance).Returns("instance");
+
+        return new ProfilerConcurrencyControlClient(
+            leaseClient,
+            context.Object,
+            roleName.Object,
+            roleInstance.Object,
+            NullLoggerFactory.Instance,
+            NullLogger<ProfilerConcurrencyControlClient>.Instance);
+    }
+}

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/ProfilerConcurrencyControlClientTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/ProfilerConcurrencyControlClientTests.cs
@@ -1,0 +1,100 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Monitor.Diagnostics;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Tests;
+
+public class ProfilerConcurrencyControlClientTests
+{
+    private static ProfilerConcurrencyControlClient CreateClient(IProfilerLeaseClient leaseClient)
+    {
+        Mock<IServiceProfilerContext> context = new();
+        context.SetupGet(c => c.StampFrontendEndpointUrl).Returns(new Uri("https://example.com/"));
+
+        Mock<IRoleNameSource> roleName = new();
+        roleName.SetupGet(r => r.CloudRoleName).Returns("role");
+
+        Mock<IRoleInstanceSource> roleInstance = new();
+        roleInstance.SetupGet(r => r.CloudRoleInstance).Returns("instance");
+
+        return new ProfilerConcurrencyControlClient(
+            leaseClient,
+            context.Object,
+            roleName.Object,
+            roleInstance.Object,
+            NullLoggerFactory.Instance,
+            NullLogger<ProfilerConcurrencyControlClient>.Instance);
+    }
+
+    [Fact]
+    public async Task TryAcquireLeaseAsync_WhenAcquired_ReturnsLease()
+    {
+        Mock<IProfilerLeaseClient> lease = new();
+        lease.Setup(l => l.AcquireAsync(It.IsAny<TimeSpan>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+
+        ProfilerConcurrencyControlClient client = CreateClient(lease.Object);
+
+        IAsyncDisposable? result = await client.TryAcquireLeaseAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        await result!.DisposeAsync();
+        lease.Verify(
+            l => l.AcquireAsync(It.IsAny<TimeSpan>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TryAcquireLeaseAsync_WhenCapReached_ReturnsNull()
+    {
+        Mock<IProfilerLeaseClient> lease = new();
+        lease.Setup(l => l.AcquireAsync(It.IsAny<TimeSpan>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new LeaseUnavailableException("cap reached"));
+
+        ProfilerConcurrencyControlClient client = CreateClient(lease.Object);
+
+        IAsyncDisposable? result = await client.TryAcquireLeaseAsync(CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task TryAcquireLeaseAsync_WhenTransientError_FailsOpen()
+    {
+        Mock<IProfilerLeaseClient> lease = new();
+        lease.Setup(l => l.AcquireAsync(It.IsAny<TimeSpan>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("server down"));
+
+        ProfilerConcurrencyControlClient client = CreateClient(lease.Object);
+
+        IAsyncDisposable? result = await client.TryAcquireLeaseAsync(CancellationToken.None);
+
+        // Fail-open: a non-cap error must not block profiling.
+        Assert.Same(NoOpProfilerConcurrencyControlClient.GrantedLease, result);
+    }
+
+    [Fact]
+    public async Task TryAcquireLeaseAsync_WhenCancelled_Propagates()
+    {
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        Mock<IProfilerLeaseClient> lease = new();
+        lease.Setup(l => l.AcquireAsync(It.IsAny<TimeSpan>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        ProfilerConcurrencyControlClient client = CreateClient(lease.Object);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => client.TryAcquireLeaseAsync(cts.Token));
+    }
+}

--- a/tests/ServiceProfiler.EventPipe.Client.Tests/OrchestratorEventPipeConcurrencyTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Client.Tests/OrchestratorEventPipeConcurrencyTests.cs
@@ -1,0 +1,233 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
+using Microsoft.ApplicationInsights.Profiler.Shared.Orchestrations;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.ServiceProfiler.Orchestration;
+using Moq;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Client.Tests;
+
+public class OrchestratorEventPipeConcurrencyTests
+{
+    [Fact]
+    public async Task StartProfilingAsync_WhenLeaseUnavailable_DoesNotStartProfiler()
+    {
+        Mock<IServiceProfilerProvider> provider = new();
+        Mock<IProfilerConcurrencyControlClient> concurrency = new();
+        concurrency.Setup(c => c.TryAcquireLeaseAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IAsyncDisposable)null);
+
+        TestOrchestrator orchestrator = CreateOrchestrator(provider, concurrency);
+        TestPolicy policy = new();
+
+        bool result = await orchestrator.StartProfilingAsync(policy, CancellationToken.None);
+
+        Assert.False(result);
+        provider.Verify(
+            p => p.StartServiceProfilerAsync(It.IsAny<IProfilerSource>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task StartProfilingAsync_WhenLeaseGranted_StartsProfiler()
+    {
+        Mock<IServiceProfilerProvider> provider = new();
+        provider.Setup(p => p.StartServiceProfilerAsync(It.IsAny<IProfilerSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        Mock<IAsyncDisposable> leaseHandle = new();
+        leaseHandle.Setup(l => l.DisposeAsync()).Returns(default(ValueTask));
+
+        Mock<IProfilerConcurrencyControlClient> concurrency = new();
+        concurrency.Setup(c => c.TryAcquireLeaseAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(leaseHandle.Object);
+
+        TestOrchestrator orchestrator = CreateOrchestrator(provider, concurrency);
+        TestPolicy policy = new();
+
+        bool result = await orchestrator.StartProfilingAsync(policy, CancellationToken.None);
+
+        Assert.True(result);
+        provider.Verify(
+            p => p.StartServiceProfilerAsync(policy, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task StopProfilingAsync_ReleasesLease()
+    {
+        Mock<IServiceProfilerProvider> provider = new();
+        provider.Setup(p => p.StartServiceProfilerAsync(It.IsAny<IProfilerSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        provider.Setup(p => p.StopServiceProfilerAsync(It.IsAny<IProfilerSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        Mock<IAsyncDisposable> leaseHandle = new();
+        leaseHandle.Setup(l => l.DisposeAsync()).Returns(default(ValueTask));
+
+        Mock<IProfilerConcurrencyControlClient> concurrency = new();
+        concurrency.Setup(c => c.TryAcquireLeaseAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(leaseHandle.Object);
+
+        TestOrchestrator orchestrator = CreateOrchestrator(provider, concurrency);
+        TestPolicy policy = new();
+
+        Assert.True(await orchestrator.StartProfilingAsync(policy, CancellationToken.None));
+        Assert.True(await orchestrator.StopProfilingAsync(policy, CancellationToken.None));
+
+        leaseHandle.Verify(l => l.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartProfilingAsync_WhenProfilerFailsToStart_ReleasesLease()
+    {
+        Mock<IServiceProfilerProvider> provider = new();
+        provider.Setup(p => p.StartServiceProfilerAsync(It.IsAny<IProfilerSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        Mock<IAsyncDisposable> leaseHandle = new();
+        leaseHandle.Setup(l => l.DisposeAsync()).Returns(default(ValueTask));
+
+        Mock<IProfilerConcurrencyControlClient> concurrency = new();
+        concurrency.Setup(c => c.TryAcquireLeaseAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(leaseHandle.Object);
+
+        TestOrchestrator orchestrator = CreateOrchestrator(provider, concurrency);
+        TestPolicy policy = new();
+
+        bool result = await orchestrator.StartProfilingAsync(policy, CancellationToken.None);
+
+        Assert.False(result);
+        leaseHandle.Verify(l => l.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartProfilingAsync_WhenProviderThrowsWhileRunning_StopsAndReleasesLease()
+    {
+        Mock<IServiceProfilerProvider> provider = new();
+        provider.Setup(p => p.StartServiceProfilerAsync(It.IsAny<IProfilerSource>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("threw after starting"));
+        // The provider reports running (e.g. its semaphore is held) despite throwing.
+        provider.SetupGet(p => p.IsProfilerRunning).Returns(true);
+        provider.Setup(p => p.StopServiceProfilerAsync(It.IsAny<IProfilerSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        Mock<IAsyncDisposable> leaseHandle = new();
+        leaseHandle.Setup(l => l.DisposeAsync()).Returns(default(ValueTask));
+
+        Mock<IProfilerConcurrencyControlClient> concurrency = new();
+        concurrency.Setup(c => c.TryAcquireLeaseAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(leaseHandle.Object);
+
+        TestOrchestrator orchestrator = CreateOrchestrator(provider, concurrency);
+        TestPolicy policy = new();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => orchestrator.StartProfilingAsync(policy, CancellationToken.None));
+
+        // A failed start must never retain the lease: the profiler is best-effort stopped and the
+        // lease released immediately, so it cannot be leaked regardless of provider state.
+        provider.Verify(
+            p => p.StopServiceProfilerAsync(It.IsAny<IProfilerSource>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        leaseHandle.Verify(l => l.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task StopProfilingAsync_WhenStopFailsDuringCancellation_ReleasesLease()
+    {
+        using CancellationTokenSource cts = new();
+
+        Mock<IServiceProfilerProvider> provider = new();
+        provider.Setup(p => p.StartServiceProfilerAsync(It.IsAny<IProfilerSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        // The stop is cancelled mid-flight (e.g. agent deactivation/shutdown) and throws while the
+        // profiler still reports running. The token is cancelled as part of the call.
+        provider.Setup(p => p.StopServiceProfilerAsync(It.IsAny<IProfilerSource>(), It.IsAny<CancellationToken>()))
+            .Callback(() => cts.Cancel())
+            .ThrowsAsync(new OperationCanceledException());
+        provider.SetupGet(p => p.IsProfilerRunning).Returns(true);
+
+        Mock<IAsyncDisposable> leaseHandle = new();
+        leaseHandle.Setup(l => l.DisposeAsync()).Returns(default(ValueTask));
+
+        Mock<IProfilerConcurrencyControlClient> concurrency = new();
+        concurrency.Setup(c => c.TryAcquireLeaseAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(leaseHandle.Object);
+
+        TestOrchestrator orchestrator = CreateOrchestrator(provider, concurrency);
+        TestPolicy policy = new();
+
+        Assert.True(await orchestrator.StartProfilingAsync(policy, CancellationToken.None));
+
+        // The stop is cancelled and throws; because it was cancelled (terminal), the lease must be
+        // released (best-effort stop first) instead of retained, so it cannot renew forever.
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => orchestrator.StopProfilingAsync(policy, cts.Token));
+
+        leaseHandle.Verify(l => l.DisposeAsync(), Times.Once);
+    }
+
+    private static TestOrchestrator CreateOrchestrator(
+        Mock<IServiceProfilerProvider> provider,
+        Mock<IProfilerConcurrencyControlClient> concurrency)
+    {
+        IOptions<UserConfigurationBase> options = Options.Create<UserConfigurationBase>(new TestUserConfiguration());
+        return new TestOrchestrator(
+            provider.Object,
+            options,
+            Mock.Of<IDelaySource>(),
+            Mock.Of<IAgentStatusService>(),
+            Mock.Of<IResourceUsageSource>(),
+            concurrency.Object);
+    }
+
+    private sealed class TestUserConfiguration : UserConfigurationBase
+    {
+    }
+
+    private sealed class TestOrchestrator : OrchestratorEventPipe
+    {
+        public TestOrchestrator(
+            IServiceProfilerProvider profilerProvider,
+            IOptions<UserConfigurationBase> config,
+            IDelaySource delaySource,
+            IAgentStatusService agentStatusService,
+            IResourceUsageSource resourceUsageSource,
+            IProfilerConcurrencyControlClient concurrencyControlClient)
+            : base(
+                profilerProvider,
+                config,
+                Array.Empty<SchedulingPolicy>(),
+                delaySource,
+                agentStatusService,
+                resourceUsageSource,
+                NullLogger<OrchestratorEventPipe>.Instance,
+                concurrencyControlClient)
+        {
+        }
+    }
+
+    private sealed class TestPolicy : SchedulingPolicy
+    {
+        public TestPolicy()
+            : base(TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, Mock.Of<IDelaySource>(), Mock.Of<IExpirationPolicy>(), NullLogger<SchedulingPolicy>.Instance)
+        {
+        }
+
+        public override string Source => nameof(TestPolicy);
+
+        public override IAsyncEnumerable<(TimeSpan duration, ProfilerAction action)> GetScheduleAsync(CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary
When a user runs a large number of instances of the same application, it does not make
sense for all instances to concurrently capture and submit profiler traces. This PR adds
a **coordinated, server-enforced concurrency cap**: an instance must acquire a shared
**lease** from the backend before it starts a profiling session. The backend
(`AppsLeasesController`) enforces the maximum concurrency per app; the client simply
attempts to acquire a lease and skips the cycle if the server says the cap is full.

Applies to **both** profilers in this repo — the OpenTelemetry profiler
(`Azure.Monitor.OpenTelemetry.Profiler`) and the classic EventPipe profiler
(`Microsoft.ApplicationInsights.Profiler.AspNetCore`), which share `OrchestratorEventPipe`
and the `Microsoft.ApplicationInsights.Profiler.Shared` services.

Fixes #94.

## Design
The lease primitive already exists and is **public** on
`Azure.Monitor.Diagnostics.DiagnosticsClient` (`AcquireLease` / `RenewLease` /
`ReleaseLease`, namespace `profiler`). We wrap it behind a small internal seam, so **no
submodule changes** were needed and the logic is fully unit-testable.

```
SchedulingPolicy ─▶ OrchestratorEventPipe.StartProfilingAsync
                        │  (single choke point for every scheduling policy)
                        ├─ TryAcquireLeaseAsync()
                        │      ├─ granted → start profiler, hold auto-renewing lease
                        │      ├─ 409 cap reached → skip this cycle
                        │      └─ error → fail-open, profile anyway
                        └─ StopProfilingAsync → release lease
```

### Key behaviors
- **Always on, no config flag** — fail-open semantics make it safe to enable unconditionally.
- **Fail-open** — only an explicit **HTTP 409** (`LeaseUnavailableException`) skips a cycle
  (cap reached). Server-down / network / timeout / missing endpoint → log and **profile
  anyway**. The orchestrator gate never throws because of concurrency control.
- **Lease lifecycle** — acquire 60s, auto-renew every 5s for the session, release on stop.
  A failed renew stops renewing but lets the in-flight session finish (the lease expires
  server-side). On renew/release the SDK surfaces a lost lease (409) as a generic
  `RequestFailedException`, which is translated to `LeaseUnavailableException`.
- **Standalone mode** → no-op (nothing to lease from).
- **Disposal safety** — leases are guarded by the same semaphore as the active policy; an
  in-flight start observes disposal and self-releases (and best-effort stops) its session,
  so no lease is leaked and no profiler is left running without a lease, even under the
  disposal timeout.

## Changes
New (internal, `Microsoft.ApplicationInsights.Profiler.Shared`):
- `IProfilerConcurrencyControlClient` / `ProfilerConcurrencyControlClient`
- `IProfilerLeaseClient` / `DiagnosticsProfilerLeaseClient` (seam over `DiagnosticsClient`)
- `AutoRenewingProfilerLease`
- `NoOpProfilerConcurrencyControlClient`

Modified:
- `OrchestratorEventPipe` — acquires a lease before `StartServiceProfilerAsync`, releases
  on stop, with disposal-safe lease handling.
- Both profilers' `OrchestrationImp` ctors + `ServiceCollectionExtensions` (real client, or
  no-op when standalone).

## Logging / troubleshooting
One correlatable `{LeaseId}` across acquire → renew → release; every line carries
`{RoleName}` / `{RoleInstance}` / `{LeaseNamespace}`. `Information` on the cap-reached skip
(explains an otherwise-silent cycle), `Warning`+`Trace` on fail-open, `Debug` for
acquire/release/renew-stop. No secrets / SAS / tokens are logged.

## Testing
14 new unit tests covering acquire success / 409 / transient error / cancellation; lease
renew + release + failure-swallowing + lease-lost-stops-renewing; orchestrator
denied-vs-granted, release-on-stop, fail-to-start, provider-throws-while-running, and
stop-cancelled-during-termination. Full suites green: **OTel 78**, **classic Client 64**,
**classic AppInsights 48**. No public API surface added (all new types internal).

## Review
The implementation was iterated through 17 rounds of automated code review with two
independent models (GPT-5.5 and Claude Opus 4.8) to **two consecutive clean rounds**,
hardening the disposal/lease lifecycle against concurrency races across start, stop,
disposal, agent-deactivation, and cancellation interleavings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>