### PR TITLE
Docs: env-variable config examples and README cleanup (#156, #157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Choose the path that matches your project:
 
 The current `Microsoft.ApplicationInsights.AspNetCore` SDK is an OpenTelemetry-based wrapper. Since it already configures OpenTelemetry internally, you can enable the profiler **without** adding `Azure.Monitor.OpenTelemetry.AspNetCore` or calling `UseAzureMonitor()`.
 
+<details>
+<summary><strong>Show setup walkthrough</strong></summary>
+
 #### Prerequisites
 
 - **.NET 8.0 or later**: Install the latest .NET SDK from [here](https://dotnet.microsoft.com/download/dotnet).
@@ -98,9 +101,14 @@ The current `Microsoft.ApplicationInsights.AspNetCore` SDK is an OpenTelemetry-b
 
 📖 **Full example:** [aspnetcore-aisdk3](./examples/aspnetcore-aisdk3)
 
+</details>
+
 ---
 
 ### Option B: Azure Monitor OpenTelemetry Distro
+
+<details>
+<summary><strong>Show setup walkthrough</strong></summary>
 
 #### Prerequisites
 
@@ -185,6 +193,8 @@ Assuming you are building an **ASP.NET Core application**:
     ![sample trace](./images/sample-trace.png)
 
 📖 **Full example:** [aspnetcore-webapi](./examples/aspnetcore-webapi)
+
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Choose the path that matches your project:
 | SDK | Path |
 |-----|------|
 | **Azure Monitor OpenTelemetry distro** (`Azure.Monitor.OpenTelemetry.AspNetCore`) | [Option A](#option-a-azure-monitor-opentelemetry-distro) |
-| **Application Insights SDK for ASP.NET Core v3.x** (`Microsoft.ApplicationInsights.AspNetCore` package v3.x — an OpenTelemetry-based release) | [Option B](#option-b-application-insights-sdk-for-aspnet-core-v3x-experimental) |
-| **Application Insights SDK for ASP.NET Core v2.x** (classic, non-OpenTelemetry `Microsoft.ApplicationInsights.AspNetCore` package v2.x) | Use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead |
+| **Application Insights SDK for ASP.NET Core** (`Microsoft.ApplicationInsights.AspNetCore`, current OpenTelemetry-based release) | [Option B](#option-b-application-insights-sdk-for-aspnet-core-experimental) |
+| **Application Insights SDK for ASP.NET Core — classic 2.x** (legacy, non-OpenTelemetry release) | Use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead |
 
 ---
 
@@ -116,17 +116,17 @@ Assuming you are building an **ASP.NET Core application**:
 
 ---
 
-### Option B: Application Insights SDK for ASP.NET Core v3.x (Experimental)
+### Option B: Application Insights SDK for ASP.NET Core (Experimental)
 
 > ⚠️ **Experimental** — This integration is under active development. Please [report any issues](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net/issues/new) you encounter.
 
-The `Microsoft.ApplicationInsights.AspNetCore` **package v3.x** (the SDK version — not the ASP.NET Core framework version) is an OpenTelemetry-based wrapper. Since it already configures OpenTelemetry internally, you can enable the profiler **without** adding `Azure.Monitor.OpenTelemetry.AspNetCore` or calling `UseAzureMonitor()`.
+The current `Microsoft.ApplicationInsights.AspNetCore` SDK is an OpenTelemetry-based wrapper. Since it already configures OpenTelemetry internally, you can enable the profiler **without** adding `Azure.Monitor.OpenTelemetry.AspNetCore` or calling `UseAzureMonitor()`.
 
 #### Prerequisites
 
 - **.NET 8.0 or later**: Install the latest .NET SDK from [here](https://dotnet.microsoft.com/download/dotnet).
 - **Application Insights Resource**: Follow [this guide](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource) to create a new Application Insights resource.
-- **Application Insights SDK for ASP.NET Core v3.x**: Your project must reference the [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) package version **3.x or later** (this is the NuGet package version, not the .NET framework version).
+- **Application Insights SDK for ASP.NET Core**: Your project must reference the current OpenTelemetry-based [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) SDK. The legacy classic 2.x release is not supported by this profiler — use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead.
 
 #### Walkthrough
 
@@ -229,7 +229,7 @@ If you're still experiencing issues, please [open an issue](https://github.com/A
 Learn more by following the examples:
 
 - [Azure Monitor OpenTelemetry Distro + Profiler (ASP.NET Core WebAPI)](./examples/aspnetcore-webapi) — for [Option A](#option-a-azure-monitor-opentelemetry-distro)
-- [Application Insights SDK for ASP.NET Core v3.x + Profiler](./examples/aspnetcore-aisdk3) — for [Option B](#option-b-application-insights-sdk-for-aspnet-core-v3x-experimental)
+- [Application Insights SDK for ASP.NET Core + Profiler](./examples/aspnetcore-aisdk3) — for [Option B](#option-b-application-insights-sdk-for-aspnet-core-experimental)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,33 +4,53 @@
 
 ## Description
 
-The Azure Monitor OpenTelemetry Profiler captures detailed performance traces of your live .NET applications with minimal overhead — helping you find slow code paths, high-CPU methods, and bottlenecks, then surfacing fixes through [Code Optimizations](https://learn.microsoft.com/azure/azure-monitor/insights/code-optimizations-profiler-overview#code-optimizations) in Application Insights. It profiles on a schedule (random sampling) and can also trigger on high CPU or memory.
+The Azure Monitor OpenTelemetry Profiler captures detailed performance traces of your live .NET applications with minimal overhead. It helps you find slow code paths, high-CPU methods, and bottlenecks, then surfaces fixes through [Code Optimizations](https://learn.microsoft.com/azure/azure-monitor/insights/code-optimizations-profiler-overview#code-optimizations) in Application Insights. The profiler runs on a schedule (random sampling) and can also trigger on high CPU or memory.
 
 **Learn more:** [optix — Code Optimizations skills for Copilot](https://github.com/microsoft/code-optimizations-skills) · [Profiler Agent Selection Guide](./docs/ProfilerAgentSelectionGuide.md) · [CPU](./docs/CpuUsageMonitoring.md) & [Memory](./docs/MemoryUsageMonitoring.md) usage monitoring
 
 ## Get Started
 
-**Prerequisites:** [.NET 8.0+](https://dotnet.microsoft.com/download/dotnet), an [Application Insights resource](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource), and its connection string set as `APPLICATIONINSIGHTS_CONNECTION_STRING`.
+Using this profiler is two phases: **enable** it (once), then **analyze** the traces it collects (ongoing). Enabling takes three steps.
 
-**1. Add the profiler package:**
+### Before you begin
+
+You'll need:
+
+- [.NET 8.0 or later](https://dotnet.microsoft.com/download/dotnet)
+- An [Application Insights resource](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource)
+- Its connection string set as the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable
+
+### Step 1 — Add the profiler package
 
 ```sh
 dotnet add package Azure.Monitor.OpenTelemetry.Profiler --prerelease
 ```
 
-**2. Add one line where you configure telemetry** — pick the row that matches your SDK:
+### Step 2 — Enable the profiler in one line
 
-| Your SDK | Enable the profiler with | Full walkthrough |
+Find the row that matches the telemetry SDK you already use, and add the highlighted call where you configure telemetry:
+
+| Your SDK | Add this call | Detailed walkthrough |
 |---|---|---|
-| **Application Insights SDK for ASP.NET Core** (`Microsoft.ApplicationInsights.AspNetCore`) | `AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();` | [Option A steps](#option-a-application-insights-sdk-for-aspnet-core-experimental) |
-| **Azure Monitor OpenTelemetry distro** (`Azure.Monitor.OpenTelemetry.AspNetCore`) | `AddOpenTelemetry().UseAzureMonitor().AddAzureMonitorProfiler();` | [Option B steps](#option-b-azure-monitor-opentelemetry-distro) |
-| **Application Insights SDK for ASP.NET Core — classic 2.x** (legacy) | Not supported by this profiler | Use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) |
+| **Application Insights SDK for ASP.NET Core** (`Microsoft.ApplicationInsights.AspNetCore`) | `AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();` | [Option A](#option-a-application-insights-sdk-for-aspnet-core-experimental) |
+| **Azure Monitor OpenTelemetry distro** (`Azure.Monitor.OpenTelemetry.AspNetCore`) | `AddOpenTelemetry().UseAzureMonitor().AddAzureMonitorProfiler();` | [Option B](#option-b-azure-monitor-opentelemetry-distro) |
+| **Application Insights SDK for ASP.NET Core — classic 2.x** (legacy) | Not supported — use [Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead | — |
 
-**3. Run your app** — profiler traces appear in Application Insights after a few minutes.
+### Step 3 — Run your app
 
-> 🤖 Not sure which you use, or want zero config? Let **optix** do it — install the [Code Optimizations skills for Copilot CLI](https://github.com/microsoft/code-optimizations-skills) and run `copilot "Help me enable the Application Insights Profiler"`. See [Enable the Profiler with optix](./docs/AddAzureMonitorProfilerWithCoPilot.md).
+```sh
+dotnet run
+```
 
-Need the full step-by-step (packages, connection string, verification)? Expand the walkthrough for your SDK below.
+Profiler traces appear in Application Insights after a few minutes. [How to view them →](https://learn.microsoft.com/azure/azure-monitor/profiler/profiler-data)
+
+> 🤖 **Prefer zero config?** Let **optix** enable it for you. Install the [Code Optimizations skills for Copilot CLI](https://github.com/microsoft/code-optimizations-skills) and run:
+> ```sh
+> copilot "Help me enable the Application Insights Profiler"
+> ```
+> See [Enable the Profiler with optix](./docs/AddAzureMonitorProfilerWithCoPilot.md).
+
+**Next:** once traces are flowing, [analyze them with optix](#analyze-performance-with-optix) to turn bottlenecks into concrete code fixes. Need more detail on enabling? Expand the walkthrough for your SDK below.
 
 ---
 
@@ -187,8 +207,29 @@ Assuming you are building an **ASP.NET Core application**:
 
 ---
 
+## Analyze Performance with optix
+
+Enabling the profiler is a one-time step. The real, ongoing value is **analysis** — turning collected traces into fixes. [optix](https://github.com/microsoft/code-optimizations-skills) (Code Optimizations skills for Copilot) automates that end to end:
+
+1. **Ingest** — finds recent profiler traces on your Application Insights resource and downloads one.
+2. **Identify** — extracts the hot path and ranks the top CPU and latency contributors.
+3. **Correlate** — links hot frames to a specific operation or distributed trace, plus related errors and failed dependencies.
+4. **Recommend** — maps hot frames to your source code and proposes concrete changes.
+5. **Verify** — re-profiles after your change to confirm the bottleneck is gone.
+
+Install the [Code Optimizations skills for Copilot CLI](https://github.com/microsoft/code-optimizations-skills), then ask:
+
+```sh
+copilot "Analyze my Application Insights Profiler traces and show me the top CPU bottlenecks"
+```
+
+No profiler data yet? optix will guide you back to [enabling the profiler](#get-started).
+
+---
+
 ## Next
 
+- [Analyze performance with optix (Copilot CLI)](#analyze-performance-with-optix)
 - [Enable the Profiler with optix (Copilot CLI)](./docs/AddAzureMonitorProfilerWithCoPilot.md)
 - [Profiling Azure Service Bus Applications](./docs/ServiceBusSetup.md)
 - [Setup the Role name](./docs/SetupCloudRoleName.md)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | Continuous Integration | Status |
 | ----------- | ----------- |
 | Package | [![Nuget](https://img.shields.io/nuget/v/Azure.Monitor.OpenTelemetry.Profiler)](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.Profiler/) |
-| PR Build | [![Build Status](https://dev.azure.com/devdiv/OnlineServices/_apis/build/status%2FOneBranch%2FServiceProfiler%2FBuilds%2FEP-OTel-Profiler-PR?repoName=ServiceProfiler-EP-Profiler&branchName=refs%2Fpull%2F615631%2Fmerge)](https://dev.azure.com/devdiv/OnlineServices/_build/latest?definitionId=25440&repoName=ServiceProfiler-EP-Profiler&branchName=refs%2Fpull%2F615631%2Fmerge) |
+| PR Build | [![Build Status](https://dev.azure.com/devdiv/OnlineServices/_apis/build/status%2FOneBranch%2FServiceProfiler%2FBuilds%2FEP-OTel-Profiler-PR?repoName=ServiceProfiler-EP-Profiler)](https://dev.azure.com/devdiv/OnlineServices/_build/latest?definitionId=25440&repoName=ServiceProfiler-EP-Profiler) |
 | Official Build | [![Build Status](https://dev.azure.com/devdiv/OnlineServices/_apis/build/status%2FOneBranch%2FServiceProfiler%2FBuilds%2FEP-OTel-Profiler-Official?repoName=ServiceProfiler-EP-Profiler&branchName=main)](https://dev.azure.com/devdiv/OnlineServices/_build/latest?definitionId=25454&repoName=ServiceProfiler-EP-Profiler&branchName=main) |
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -22,13 +22,85 @@ Choose the path that matches your project:
 
 | SDK | Path |
 |-----|------|
-| **Azure Monitor OpenTelemetry distro** (`Azure.Monitor.OpenTelemetry.AspNetCore`) | [Option A](#option-a-azure-monitor-opentelemetry-distro) |
-| **Application Insights SDK for ASP.NET Core** (`Microsoft.ApplicationInsights.AspNetCore`, current OpenTelemetry-based release) | [Option B](#option-b-application-insights-sdk-for-aspnet-core-experimental) |
+| **Application Insights SDK for ASP.NET Core** (`Microsoft.ApplicationInsights.AspNetCore`, current OpenTelemetry-based release) | [Option A](#option-a-application-insights-sdk-for-aspnet-core-experimental) |
+| **Azure Monitor OpenTelemetry distro** (`Azure.Monitor.OpenTelemetry.AspNetCore`) | [Option B](#option-b-azure-monitor-opentelemetry-distro) |
 | **Application Insights SDK for ASP.NET Core — classic 2.x** (legacy, non-OpenTelemetry release) | Use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead |
 
 ---
 
-### Option A: Azure Monitor OpenTelemetry Distro
+### Option A: Application Insights SDK for ASP.NET Core (Experimental)
+
+> ⚠️ **Experimental** — This integration is under active development. Please [report any issues](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net/issues/new) you encounter.
+
+The current `Microsoft.ApplicationInsights.AspNetCore` SDK is an OpenTelemetry-based wrapper. Since it already configures OpenTelemetry internally, you can enable the profiler **without** adding `Azure.Monitor.OpenTelemetry.AspNetCore` or calling `UseAzureMonitor()`.
+
+#### Prerequisites
+
+- **.NET 8.0 or later**: Install the latest .NET SDK from [here](https://dotnet.microsoft.com/download/dotnet).
+- **Application Insights Resource**: Follow [this guide](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource) to create a new Application Insights resource.
+- **Application Insights SDK for ASP.NET Core**: Your project must reference the current OpenTelemetry-based [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) SDK. The legacy classic 2.x release is not supported by this profiler — use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead.
+
+#### Walkthrough
+
+1. **Add NuGet Packages**
+
+    ```sh
+    dotnet add package Microsoft.ApplicationInsights.AspNetCore --version "3.*-*"
+    dotnet add package Azure.Monitor.OpenTelemetry.Profiler --prerelease
+    ```
+
+    Or in your `.csproj`:
+
+    ```xml
+    <ItemGroup>
+        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="[3.*-*, 4.0.0)" />
+        <PackageReference Include="Azure.Monitor.OpenTelemetry.Profiler" Version="[1.*-*, 2.0.0)" />
+    </ItemGroup>
+    ```
+
+2. **Enable the Profiler**
+
+    Chain `AddAzureMonitorProfiler()` after `AddApplicationInsightsTelemetry()`:
+
+    ```csharp
+    using Azure.Monitor.OpenTelemetry.Profiler;
+
+    var builder = WebApplication.CreateBuilder(args);
+
+    builder.Services.AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();
+
+    var app = builder.Build();
+    app.Run();
+    ```
+
+3. **Set up the connection string**
+
+    Refer to the [connection string section](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore#paste-the-connection-string-in-your-environment) for all options. For local testing in PowerShell:
+
+    ```powershell
+    $env:APPLICATIONINSIGHTS_CONNECTION_STRING="InstrumentationKey=5d..."
+    ```
+
+4. **Run & Verify**
+
+    ```sh
+    dotnet run
+    ```
+
+    Look for profiler startup log messages like:
+
+    ```
+    info: Azure.Monitor.OpenTelemetry.Profiler.ServiceProfilerAgentBootstrap[0]
+        Starting application insights profiler with connection string: InstrumentationKey=5d…
+    ```
+
+    After a few minutes, traces will appear in Application Insights — see [how to view profiler data](https://learn.microsoft.com/azure/azure-monitor/profiler/profiler-data).
+
+📖 **Full example:** [aspnetcore-aisdk3](./examples/aspnetcore-aisdk3)
+
+---
+
+### Option B: Azure Monitor OpenTelemetry Distro
 
 #### Prerequisites
 
@@ -116,78 +188,6 @@ Assuming you are building an **ASP.NET Core application**:
 
 ---
 
-### Option B: Application Insights SDK for ASP.NET Core (Experimental)
-
-> ⚠️ **Experimental** — This integration is under active development. Please [report any issues](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net/issues/new) you encounter.
-
-The current `Microsoft.ApplicationInsights.AspNetCore` SDK is an OpenTelemetry-based wrapper. Since it already configures OpenTelemetry internally, you can enable the profiler **without** adding `Azure.Monitor.OpenTelemetry.AspNetCore` or calling `UseAzureMonitor()`.
-
-#### Prerequisites
-
-- **.NET 8.0 or later**: Install the latest .NET SDK from [here](https://dotnet.microsoft.com/download/dotnet).
-- **Application Insights Resource**: Follow [this guide](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource) to create a new Application Insights resource.
-- **Application Insights SDK for ASP.NET Core**: Your project must reference the current OpenTelemetry-based [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) SDK. The legacy classic 2.x release is not supported by this profiler — use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead.
-
-#### Walkthrough
-
-1. **Add NuGet Packages**
-
-    ```sh
-    dotnet add package Microsoft.ApplicationInsights.AspNetCore --version "3.*-*"
-    dotnet add package Azure.Monitor.OpenTelemetry.Profiler --prerelease
-    ```
-
-    Or in your `.csproj`:
-
-    ```xml
-    <ItemGroup>
-        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="[3.*-*, 4.0.0)" />
-        <PackageReference Include="Azure.Monitor.OpenTelemetry.Profiler" Version="[1.*-*, 2.0.0)" />
-    </ItemGroup>
-    ```
-
-2. **Enable the Profiler**
-
-    Chain `AddAzureMonitorProfiler()` after `AddApplicationInsightsTelemetry()`:
-
-    ```csharp
-    using Azure.Monitor.OpenTelemetry.Profiler;
-
-    var builder = WebApplication.CreateBuilder(args);
-
-    builder.Services.AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();
-
-    var app = builder.Build();
-    app.Run();
-    ```
-
-3. **Set up the connection string**
-
-    Refer to the [connection string section](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore#paste-the-connection-string-in-your-environment) for all options. For local testing in PowerShell:
-
-    ```powershell
-    $env:APPLICATIONINSIGHTS_CONNECTION_STRING="InstrumentationKey=5d..."
-    ```
-
-4. **Run & Verify**
-
-    ```sh
-    dotnet run
-    ```
-
-    Look for profiler startup log messages like:
-
-    ```
-    info: Azure.Monitor.OpenTelemetry.Profiler.ServiceProfilerAgentBootstrap[0]
-        Starting application insights profiler with connection string: InstrumentationKey=5d…
-    ```
-
-    After a few minutes, traces will appear in Application Insights — see [how to view profiler data](https://learn.microsoft.com/azure/azure-monitor/profiler/profiler-data).
-
-📖 **Full example:** [aspnetcore-aisdk3](./examples/aspnetcore-aisdk3)
-
----
-
 ### Let Copilot enable the Profiler for you
 
 As an alternative to the manual walkthrough above, you can use Copilot to enable the profiler automatically (works for both Option A and Option B):
@@ -228,8 +228,8 @@ If you're still experiencing issues, please [open an issue](https://github.com/A
 
 Learn more by following the examples:
 
-- [Azure Monitor OpenTelemetry Distro + Profiler (ASP.NET Core WebAPI)](./examples/aspnetcore-webapi) — for [Option A](#option-a-azure-monitor-opentelemetry-distro)
-- [Application Insights SDK for ASP.NET Core + Profiler](./examples/aspnetcore-aisdk3) — for [Option B](#option-b-application-insights-sdk-for-aspnet-core-experimental)
+- [Application Insights SDK for ASP.NET Core + Profiler](./examples/aspnetcore-aisdk3) — for [Option A](#option-a-application-insights-sdk-for-aspnet-core-experimental)
+- [Azure Monitor OpenTelemetry Distro + Profiler (ASP.NET Core WebAPI)](./examples/aspnetcore-webapi) — for [Option B](#option-b-azure-monitor-opentelemetry-distro)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,40 +8,29 @@ The Azure Monitor OpenTelemetry Profiler captures detailed performance traces of
 
 **Learn more:** [optix — Code Optimizations skills for Copilot](https://github.com/microsoft/code-optimizations-skills) · [Profiler Agent Selection Guide](./docs/ProfilerAgentSelectionGuide.md) · [CPU](./docs/CpuUsageMonitoring.md) & [Memory](./docs/MemoryUsageMonitoring.md) usage monitoring
 
-## Quick Start
+## Get Started
 
 **Prerequisites:** [.NET 8.0+](https://dotnet.microsoft.com/download/dotnet), an [Application Insights resource](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource), and its connection string set as `APPLICATIONINSIGHTS_CONNECTION_STRING`.
 
-Add the profiler package:
+**1. Add the profiler package:**
 
 ```sh
 dotnet add package Azure.Monitor.OpenTelemetry.Profiler --prerelease
 ```
 
-Then add **one line** where you configure telemetry, depending on which SDK you use:
+**2. Add one line where you configure telemetry** — pick the row that matches your SDK:
 
-| If you use… | Enable the profiler with |
-|---|---|
-| **Azure Monitor OpenTelemetry distro** | `AddOpenTelemetry().UseAzureMonitor().AddAzureMonitorProfiler();` |
-| **Application Insights SDK for ASP.NET Core** | `AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();` |
+| Your SDK | Enable the profiler with | Full walkthrough |
+|---|---|---|
+| **Application Insights SDK for ASP.NET Core** (`Microsoft.ApplicationInsights.AspNetCore`) | `AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();` | [Option A steps](#option-a-application-insights-sdk-for-aspnet-core-experimental) |
+| **Azure Monitor OpenTelemetry distro** (`Azure.Monitor.OpenTelemetry.AspNetCore`) | `AddOpenTelemetry().UseAzureMonitor().AddAzureMonitorProfiler();` | [Option B steps](#option-b-azure-monitor-opentelemetry-distro) |
+| **Application Insights SDK for ASP.NET Core — classic 2.x** (legacy) | Not supported by this profiler | Use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) |
 
-Run your app — profiler traces appear in Application Insights after a few minutes.
+**3. Run your app** — profiler traces appear in Application Insights after a few minutes.
 
 > 🤖 Not sure which you use, or want zero config? Let **optix** do it — install the [Code Optimizations skills for Copilot CLI](https://github.com/microsoft/code-optimizations-skills) and run `copilot "Help me enable the Application Insights Profiler"`. See [Enable the Profiler with optix](./docs/AddAzureMonitorProfilerWithCoPilot.md).
 
-Want the full step-by-step (packages, connection string, verification)? See the [detailed setup](#get-started) below.
-
-## Get Started
-
-### Which Application Insights SDK are you using?
-
-Choose the path that matches your project:
-
-| SDK | Path |
-|-----|------|
-| **Application Insights SDK for ASP.NET Core** (`Microsoft.ApplicationInsights.AspNetCore`, current OpenTelemetry-based release) | [Option A](#option-a-application-insights-sdk-for-aspnet-core-experimental) |
-| **Azure Monitor OpenTelemetry distro** (`Azure.Monitor.OpenTelemetry.AspNetCore`) | [Option B](#option-b-azure-monitor-opentelemetry-distro) |
-| **Application Insights SDK for ASP.NET Core — classic 2.x** (legacy, non-OpenTelemetry release) | Use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead |
+Need the full step-by-step (packages, connection string, verification)? Expand the walkthrough for your SDK below.
 
 ---
 
@@ -56,7 +45,7 @@ The current `Microsoft.ApplicationInsights.AspNetCore` SDK is an OpenTelemetry-b
 
 #### Prerequisites
 
-In addition to the [Quick Start prerequisites](#quick-start): your project must reference the current OpenTelemetry-based [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) SDK. The legacy classic 2.x release is not supported by this profiler — use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead.
+In addition to the [Get Started prerequisites](#get-started): your project must reference the current OpenTelemetry-based [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) SDK. The legacy classic 2.x release is not supported by this profiler — use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead.
 
 #### Walkthrough
 
@@ -127,7 +116,7 @@ In addition to the [Quick Start prerequisites](#quick-start): your project must 
 
 #### Prerequisites
 
-In addition to the [Quick Start prerequisites](#quick-start): this profiler works with the [Azure Monitor OpenTelemetry distro](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore).
+In addition to the [Get Started prerequisites](#get-started): this profiler works with the [Azure Monitor OpenTelemetry distro](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore).
 
 #### Walkthrough
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The Azure Monitor OpenTelemetry Profiler captures detailed performance traces of
 
 The profiler supports both **random sampling** (periodic snapshots) and **trigger-based profiling** (activated when CPU or memory usage exceeds a threshold). See [CPU Usage Monitoring](./docs/CpuUsageMonitoring.md) and [Memory Usage Monitoring](./docs/MemoryUsageMonitoring.md) for details on triggered profiling.
 
+> 💡 Want help acting on the results? Try [**optix** — Code Optimizations skills for GitHub Copilot](https://github.com/microsoft/code-optimizations-skills) to analyze profiler traces and get AI-assisted optimization suggestions right in your editor.
+
 > ⭐ Not sure which `Profiler Agent` is right for you? Check out our [Profiler Agent Selection Guide](./docs/ProfilerAgentSelectionGuide.md) to help you choose the best option for your needs.
 
 ## Get Started
@@ -148,9 +150,7 @@ Assuming you are building an **ASP.NET Core application**:
 
 2. **Enable the Profiler**
 
-    The code differs slightly depending on which version of `Azure.Monitor.OpenTelemetry.Profiler` you are using:
-
-    **`Azure.Monitor.OpenTelemetry.Profiler` 1.0.0-beta10 and later** — a single fluent chain:
+    Chain `AddAzureMonitorProfiler()` after `AddApplicationInsightsTelemetry()`:
 
     ```csharp
     using Azure.Monitor.OpenTelemetry.Profiler;
@@ -158,20 +158,6 @@ Assuming you are building an **ASP.NET Core application**:
     var builder = WebApplication.CreateBuilder(args);
 
     builder.Services.AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();
-
-    var app = builder.Build();
-    app.Run();
-    ```
-
-    **`Azure.Monitor.OpenTelemetry.Profiler` 1.0.0-beta9 and earlier** — separate calls:
-
-    ```csharp
-    using Azure.Monitor.OpenTelemetry.Profiler;
-
-    var builder = WebApplication.CreateBuilder(args);
-
-    builder.Services.AddApplicationInsightsTelemetry();
-    builder.Services.AddOpenTelemetry().AddAzureMonitorProfiler();
 
     var app = builder.Build();
     app.Run();

--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@
 
 ## Description
 
-The Azure Monitor OpenTelemetry Profiler captures detailed performance traces of your live .NET applications with minimal overhead. It helps you identify slow code paths, high-CPU methods, and performance bottlenecks — then surfaces actionable insights through [Code Optimizations](https://learn.microsoft.com/azure/azure-monitor/insights/code-optimizations-profiler-overview#code-optimizations) in your Application Insights resource.
+The Azure Monitor OpenTelemetry Profiler captures detailed performance traces of your live .NET applications with minimal overhead. It helps you identify slow code paths, high-CPU methods, and performance bottlenecks — then surfaces actionable insights through [Code Optimizations](https://learn.microsoft.com/azure/azure-monitor/insights/code-optimizations-profiler-overview#code-optimizations) in your Application Insights resource. To act on those insights directly in your editor, pair the profiler with [**optix** — Code Optimizations skills for GitHub Copilot](https://github.com/microsoft/code-optimizations-skills), which analyzes profiler traces and suggests AI-assisted optimizations.
 
 The profiler supports both **random sampling** (periodic snapshots) and **trigger-based profiling** (activated when CPU or memory usage exceeds a threshold). See [CPU Usage Monitoring](./docs/CpuUsageMonitoring.md) and [Memory Usage Monitoring](./docs/MemoryUsageMonitoring.md) for details on triggered profiling.
-
-> 💡 Want help acting on the results? Try [**optix** — Code Optimizations skills for GitHub Copilot](https://github.com/microsoft/code-optimizations-skills) to analyze profiler traces and get AI-assisted optimization suggestions right in your editor.
 
 > ⭐ Not sure which `Profiler Agent` is right for you? Check out our [Profiler Agent Selection Guide](./docs/ProfilerAgentSelectionGuide.md) to help you choose the best option for your needs.
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Choose the path that matches your project:
 | SDK | Path |
 |-----|------|
 | **Azure Monitor OpenTelemetry distro** (`Azure.Monitor.OpenTelemetry.AspNetCore`) | [Option A](#option-a-azure-monitor-opentelemetry-distro) |
-| **Application Insights ASP.NET Core 3.x** (`Microsoft.ApplicationInsights.AspNetCore` 3.x) | [Option B](#option-b-application-insights-aspnet-core-3x-experimental) |
-| **Application Insights ASP.NET Core 2.x** (classic SDK) | Use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead |
+| **Application Insights SDK for ASP.NET Core v3.x** (`Microsoft.ApplicationInsights.AspNetCore` package v3.x — an OpenTelemetry-based release) | [Option B](#option-b-application-insights-sdk-for-aspnet-core-v3x-experimental) |
+| **Application Insights SDK for ASP.NET Core v2.x** (classic, non-OpenTelemetry `Microsoft.ApplicationInsights.AspNetCore` package v2.x) | Use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead |
 
 ---
 
@@ -116,17 +116,17 @@ Assuming you are building an **ASP.NET Core application**:
 
 ---
 
-### Option B: Application Insights ASP.NET Core 3.x (Experimental)
+### Option B: Application Insights SDK for ASP.NET Core v3.x (Experimental)
 
 > ⚠️ **Experimental** — This integration is under active development. Please [report any issues](https://github.com/Azure/azuremonitor-opentelemetry-profiler-net/issues/new) you encounter.
 
-`Microsoft.ApplicationInsights.AspNetCore` 3.x is an OpenTelemetry-based wrapper. Since it already configures OpenTelemetry internally, you can enable the profiler **without** adding `Azure.Monitor.OpenTelemetry.AspNetCore` or calling `UseAzureMonitor()`.
+The `Microsoft.ApplicationInsights.AspNetCore` **package v3.x** (the SDK version — not the ASP.NET Core framework version) is an OpenTelemetry-based wrapper. Since it already configures OpenTelemetry internally, you can enable the profiler **without** adding `Azure.Monitor.OpenTelemetry.AspNetCore` or calling `UseAzureMonitor()`.
 
 #### Prerequisites
 
 - **.NET 8.0 or later**: Install the latest .NET SDK from [here](https://dotnet.microsoft.com/download/dotnet).
 - **Application Insights Resource**: Follow [this guide](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource) to create a new Application Insights resource.
-- **Application Insights ASP.NET Core 3.x**: Your project must reference [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) version **3.x or later**.
+- **Application Insights SDK for ASP.NET Core v3.x**: Your project must reference the [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) package version **3.x or later** (this is the NuGet package version, not the .NET framework version).
 
 #### Walkthrough
 
@@ -229,7 +229,7 @@ If you're still experiencing issues, please [open an issue](https://github.com/A
 Learn more by following the examples:
 
 - [Azure Monitor OpenTelemetry Distro + Profiler (ASP.NET Core WebAPI)](./examples/aspnetcore-webapi) — for [Option A](#option-a-azure-monitor-opentelemetry-distro)
-- [Application Insights ASP.NET Core 3.x + Profiler](./examples/aspnetcore-aisdk3) — for [Option B](#option-b-application-insights-aspnet-core-3x-experimental)
+- [Application Insights SDK for ASP.NET Core v3.x + Profiler](./examples/aspnetcore-aisdk3) — for [Option B](#option-b-application-insights-sdk-for-aspnet-core-v3x-experimental)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then add **one line** where you configure telemetry, depending on which SDK you 
 
 Run your app — profiler traces appear in Application Insights after a few minutes.
 
-> 🤖 Not sure which you use, or want zero config? [Let Copilot enable the Profiler for you](./docs/AddAzureMonitorProfilerWithCoPilot.md).
+> 🤖 Not sure which you use, or want zero config? Let **optix** do it — install the [Code Optimizations skills for Copilot CLI](https://github.com/microsoft/code-optimizations-skills) and run `copilot "Help me enable the Application Insights Profiler"`. See [Enable the Profiler with optix](./docs/AddAzureMonitorProfilerWithCoPilot.md).
 
 Want the full step-by-step (packages, connection string, verification)? See the [detailed setup](#get-started) below.
 
@@ -198,14 +198,9 @@ Assuming you are building an **ASP.NET Core application**:
 
 ---
 
-### Let Copilot enable the Profiler for you
-
-As an alternative to the manual walkthrough above, you can use Copilot to enable the profiler automatically (works for both Option A and Option B):
-
-- [Enable Profiler using Copilot](./docs/AddAzureMonitorProfilerWithCoPilot.md)
-
 ## Next
 
+- [Enable the Profiler with optix (Copilot CLI)](./docs/AddAzureMonitorProfilerWithCoPilot.md)
 - [Profiling Azure Service Bus Applications](./docs/ServiceBusSetup.md)
 - [Setup the Role name](./docs/SetupCloudRoleName.md)
 - [Configuration Guide](./docs/Configurations.md)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,35 @@
 # Azure Monitor OpenTelemetry Profiler for .NET
 
-| Continuous Integration | Status |
-| ----------- | ----------- |
-| Package | [![Nuget](https://img.shields.io/nuget/v/Azure.Monitor.OpenTelemetry.Profiler)](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.Profiler/) |
-| PR Build | [![Build Status](https://dev.azure.com/devdiv/OnlineServices/_apis/build/status%2FOneBranch%2FServiceProfiler%2FBuilds%2FEP-OTel-Profiler-PR?repoName=ServiceProfiler-EP-Profiler)](https://dev.azure.com/devdiv/OnlineServices/_build/latest?definitionId=25440&repoName=ServiceProfiler-EP-Profiler) |
-| Official Build | [![Build Status](https://dev.azure.com/devdiv/OnlineServices/_apis/build/status%2FOneBranch%2FServiceProfiler%2FBuilds%2FEP-OTel-Profiler-Official?repoName=ServiceProfiler-EP-Profiler&branchName=main)](https://dev.azure.com/devdiv/OnlineServices/_build/latest?definitionId=25454&repoName=ServiceProfiler-EP-Profiler&branchName=main) |
+[![NuGet](https://img.shields.io/nuget/v/Azure.Monitor.OpenTelemetry.Profiler)](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.Profiler/)
 
 ## Description
 
-The Azure Monitor OpenTelemetry Profiler captures detailed performance traces of your live .NET applications with minimal overhead. It helps you identify slow code paths, high-CPU methods, and performance bottlenecks — then surfaces actionable insights through [Code Optimizations](https://learn.microsoft.com/azure/azure-monitor/insights/code-optimizations-profiler-overview#code-optimizations) in your Application Insights resource. To act on those insights directly in your editor, pair the profiler with [**optix** — Code Optimizations skills for GitHub Copilot](https://github.com/microsoft/code-optimizations-skills), which analyzes profiler traces and suggests AI-assisted optimizations.
+The Azure Monitor OpenTelemetry Profiler captures detailed performance traces of your live .NET applications with minimal overhead — helping you find slow code paths, high-CPU methods, and bottlenecks, then surfacing fixes through [Code Optimizations](https://learn.microsoft.com/azure/azure-monitor/insights/code-optimizations-profiler-overview#code-optimizations) in Application Insights. It profiles on a schedule (random sampling) and can also trigger on high CPU or memory.
 
-The profiler supports both **random sampling** (periodic snapshots) and **trigger-based profiling** (activated when CPU or memory usage exceeds a threshold). See [CPU Usage Monitoring](./docs/CpuUsageMonitoring.md) and [Memory Usage Monitoring](./docs/MemoryUsageMonitoring.md) for details on triggered profiling.
+**Learn more:** [optix — Code Optimizations skills for Copilot](https://github.com/microsoft/code-optimizations-skills) · [Profiler Agent Selection Guide](./docs/ProfilerAgentSelectionGuide.md) · [CPU](./docs/CpuUsageMonitoring.md) & [Memory](./docs/MemoryUsageMonitoring.md) usage monitoring
 
-> ⭐ Not sure which `Profiler Agent` is right for you? Check out our [Profiler Agent Selection Guide](./docs/ProfilerAgentSelectionGuide.md) to help you choose the best option for your needs.
+## Quick Start
+
+**Prerequisites:** [.NET 8.0+](https://dotnet.microsoft.com/download/dotnet), an [Application Insights resource](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource), and its connection string set as `APPLICATIONINSIGHTS_CONNECTION_STRING`.
+
+Add the profiler package:
+
+```sh
+dotnet add package Azure.Monitor.OpenTelemetry.Profiler --prerelease
+```
+
+Then add **one line** where you configure telemetry, depending on which SDK you use:
+
+| If you use… | Enable the profiler with |
+|---|---|
+| **Azure Monitor OpenTelemetry distro** | `AddOpenTelemetry().UseAzureMonitor().AddAzureMonitorProfiler();` |
+| **Application Insights SDK for ASP.NET Core** | `AddApplicationInsightsTelemetry().AddAzureMonitorProfiler();` |
+
+Run your app — profiler traces appear in Application Insights after a few minutes.
+
+> 🤖 Not sure which you use, or want zero config? [Let Copilot enable the Profiler for you](./docs/AddAzureMonitorProfilerWithCoPilot.md).
+
+Want the full step-by-step (packages, connection string, verification)? See the [detailed setup](#get-started) below.
 
 ## Get Started
 
@@ -39,9 +56,7 @@ The current `Microsoft.ApplicationInsights.AspNetCore` SDK is an OpenTelemetry-b
 
 #### Prerequisites
 
-- **.NET 8.0 or later**: Install the latest .NET SDK from [here](https://dotnet.microsoft.com/download/dotnet).
-- **Application Insights Resource**: Follow [this guide](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource) to create a new Application Insights resource.
-- **Application Insights SDK for ASP.NET Core**: Your project must reference the current OpenTelemetry-based [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) SDK. The legacy classic 2.x release is not supported by this profiler — use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead.
+In addition to the [Quick Start prerequisites](#quick-start): your project must reference the current OpenTelemetry-based [`Microsoft.ApplicationInsights.AspNetCore`](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/) SDK. The legacy classic 2.x release is not supported by this profiler — use [Microsoft Application Insights Profiler for ASP.NET Core](https://github.com/microsoft/ApplicationInsights-Profiler-AspNetCore) instead.
 
 #### Walkthrough
 
@@ -112,9 +127,7 @@ The current `Microsoft.ApplicationInsights.AspNetCore` SDK is an OpenTelemetry-b
 
 #### Prerequisites
 
-- **.NET 8.0 or later**: Install the latest .NET SDK from [here](https://dotnet.microsoft.com/download/dotnet).
-- **Application Insights Resource**: Follow [this guide](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource#create-a-workspace-based-resource) to create a new Application Insights resource.
-- **Azure Monitor OpenTelemetry**: This profiler works with the [Azure Monitor OpenTelemetry distro](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore).
+In addition to the [Quick Start prerequisites](#quick-start): this profiler works with the [Azure Monitor OpenTelemetry distro](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore).
 
 #### Walkthrough
 
@@ -167,23 +180,10 @@ Assuming you are building an **ASP.NET Core application**:
     Run your application and verify the profiler starts. Look for this in the log output:
 
     ```sh
-    PS > dotnet run
-
-    Building...
-
-    info: Microsoft.Hosting.Lifetime[14]
-        Now listening on: http://localhost:5143
-    info: Microsoft.Hosting.Lifetime[0]
-        Application started. Press Ctrl+C to shut down.
-    info: Microsoft.Hosting.Lifetime[0]
-        Hosting environment: Development
-    info: Microsoft.Hosting.Lifetime[0]
-        Content root path: C:\
     info: Azure.Monitor.OpenTelemetry.Profiler.ServiceProfilerAgentBootstrap[0]
         Starting application insights profiler with connection string: InstrumentationKey=5d…
     info: Azure.Monitor.OpenTelemetry.Profiler.Core.DumbTraceControl[0]
         Start writing trace file C:\Users\aaa\AppData\Local\Temp\SPTraces\...
-    ...
     ```
 
 6. **View Profiler Data**
@@ -240,6 +240,14 @@ Learn more by following the examples:
 
 - [Application Insights SDK for ASP.NET Core + Profiler](./examples/aspnetcore-aisdk3) — for [Option A](#option-a-application-insights-sdk-for-aspnet-core-experimental)
 - [Azure Monitor OpenTelemetry Distro + Profiler (ASP.NET Core WebAPI)](./examples/aspnetcore-webapi) — for [Option B](#option-b-azure-monitor-opentelemetry-distro)
+
+## Build Status
+
+| Pipeline | Status |
+| ----------- | ----------- |
+| Package | [![Nuget](https://img.shields.io/nuget/v/Azure.Monitor.OpenTelemetry.Profiler)](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.Profiler/) |
+| PR Build | [![Build Status](https://dev.azure.com/devdiv/OnlineServices/_apis/build/status%2FOneBranch%2FServiceProfiler%2FBuilds%2FEP-OTel-Profiler-PR?repoName=ServiceProfiler-EP-Profiler)](https://dev.azure.com/devdiv/OnlineServices/_build/latest?definitionId=25440&repoName=ServiceProfiler-EP-Profiler) |
+| Official Build | [![Build Status](https://dev.azure.com/devdiv/OnlineServices/_apis/build/status%2FOneBranch%2FServiceProfiler%2FBuilds%2FEP-OTel-Profiler-Official?repoName=ServiceProfiler-EP-Profiler&branchName=main)](https://dev.azure.com/devdiv/OnlineServices/_build/latest?definitionId=25454&repoName=ServiceProfiler-EP-Profiler&branchName=main) |
 
 ## Contributing
 

--- a/docs/AddAzureMonitorProfilerWithCoPilot.md
+++ b/docs/AddAzureMonitorProfilerWithCoPilot.md
@@ -1,25 +1,44 @@
-# Add Azure Monitor Profiler using Copilot (Experiment)
+# Enable the Profiler with optix
+
+The easiest way to enable the Azure Monitor OpenTelemetry Profiler is to let **optix** —
+the [Code Optimizations skills for GitHub Copilot CLI](https://github.com/microsoft/code-optimizations-skills) —
+do it for you. optix ships a dedicated **enable-profiler** setup skill that detects your
+platform and walks you through the changes.
 
 ## Why?
 
 - Fast setup (≈2–3 minutes)
-- Consistent + low risk
-- Surfaces optional profiler features automatically
+- Consistent and low risk — the skill knows the current best practices
+- Works for both the Azure Monitor OpenTelemetry distro and the Application Insights SDK
+
+## Prerequisites
+
+- [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) installed and authenticated (`copilot auth login`)
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) installed and logged in (`az login`)
 
 ## Do it
 
-1. Download the prompt file: [enable-profiler.prompt.md](../prompts/enable-profiler.prompt.md). Save a copy into your solution (e.g. ./prompts/, ./eng/, or ./.copilot/) so it is under source control. If browsing in VS Code: open the link, then Save As into your repo.
-2. Open the saved file in VS Code.
-3. Review the prompts/instructions inside so you understand the changes it will generate.
-4. Run the prompt with Copilot.
-5. Commit the generated changes.
+1. Add the optix marketplace and install the skills:
 
-![Screenshots shows that Profiler added by Copilot](./images/enable-profiler-by-copilot.png)
+    ```sh
+    copilot plugin marketplace add microsoft/code-optimizations-skills
+    copilot plugin install optix@microsoft-optix
+    ```
+
+    _Tip: to install only the Setup skills, use `copilot plugin install optix-setup@microsoft-optix`._
+
+2. Ask Copilot to enable the profiler:
+
+    ```sh
+    copilot "Help me enable the Application Insights Profiler"
+    ```
+
+3. Review the changes optix proposes, apply them, and commit.
 
 ## Next
 
-Need more (triggers, schedules, upgrades)? Re‑open the same prompt and ask.
+Once the profiler is running, optix can also help you act on the data — explore errors,
+inspect profiler hot paths, and get code-level optimization recommendations. See the
+[optix skills catalog](https://github.com/microsoft/code-optimizations-skills#readme).
 
-That’s it—run the prompt now and get visibility sooner.
-
-Or [return to Readme](../README.md).
+Or [return to the Readme](../README.md).

--- a/docs/Configurations.md
+++ b/docs/Configurations.md
@@ -65,6 +65,71 @@ This document summarizes configuration options exposed via `UserConfigurationBas
 5. Use triggers (CPU/Memory thresholds) to supplement, not replace, random sampling.
 6. Set `StandaloneMode = true` only for offline/local investigations.
 
+## Applying Configuration
+
+The profiler binds its options from the **`ServiceProfiler`** configuration section. Every property above can therefore be set through any standard .NET configuration source — `appsettings.json`, environment variables, command-line arguments, or the programmatic callback. Values supplied through the `AddAzureMonitorProfiler(...)` callback are applied last and win over configuration sources.
+
+### Example (Environment Variables)
+
+.NET maps hierarchical configuration keys to environment variables by joining segments with a double underscore (`__`), prefixed with the section name `ServiceProfiler`:
+
+```sh
+# TimeSpan values use the "d.hh:mm:ss" / "hh:mm:ss" format
+export ServiceProfiler__Duration="00:00:45"
+export ServiceProfiler__InitialDelay="00:00:10"
+
+# Numeric and boolean values
+export ServiceProfiler__RandomProfilingOverhead="0.02"
+export ServiceProfiler__CPUTriggerThreshold="85"
+export ServiceProfiler__MemoryTriggerThreshold="85"
+export ServiceProfiler__PreserveTraceFile="true"
+export ServiceProfiler__IsDisabled="false"
+
+# String values
+export ServiceProfiler__LocalCacheFolder="/var/profiler-cache"
+
+# Array items are indexed with a numeric segment (0, 1, 2, ...)
+export ServiceProfiler__CustomEventPipeProviders__0__Name="MyCompany-Diagnostics"
+export ServiceProfiler__CustomEventPipeProviders__0__Level="4"
+export ServiceProfiler__CustomEventPipeProviders__0__Keywords="0xFFFFFFFFFFFFFFFF"
+```
+
+On Windows PowerShell, set the same variables with `$env:`:
+
+```powershell
+$env:ServiceProfiler__Duration = "00:00:45"
+$env:ServiceProfiler__RandomProfilingOverhead = "0.02"
+$env:ServiceProfiler__PreserveTraceFile = "true"
+```
+
+> Tip: In containers, pass these through your orchestrator (e.g., a Kubernetes `env:` list or a Docker `-e` flag) exactly as named above.
+
+### Example (appsettings.json)
+
+The same settings expressed as JSON:
+
+```json
+{
+  "ServiceProfiler": {
+    "Duration": "00:00:45",
+    "InitialDelay": "00:00:10",
+    "RandomProfilingOverhead": 0.02,
+    "CPUTriggerThreshold": 85,
+    "MemoryTriggerThreshold": 85,
+    "PreserveTraceFile": true,
+    "IsDisabled": false,
+    "LocalCacheFolder": "/var/profiler-cache",
+    "CustomEventPipeProviders": [
+      {
+        "Name": "MyCompany-Diagnostics",
+        "Level": 4,
+        "Keywords": "0xFFFFFFFFFFFFFFFF"
+      }
+    ]
+  }
+}
+```
+
 ## Example (Programmatic Setup)
 
 ```csharp

--- a/docs/Configurations.md
+++ b/docs/Configurations.md
@@ -36,7 +36,7 @@ This document summarizes configuration options exposed via `UserConfigurationBas
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| RandomProfilingOverhead | float | 0.01 (1%) | Target average time spent profiling per hour. Effective number of sessions per hour ≈ (60 * overhead) / DurationMinutes. |
+| SamplingRate | double | 0.05 (5%) | Probability, evaluated once per scheduling cycle, that a random profiling session starts. On each cycle the profiler flips a coin: if `random < SamplingRate` it profiles for `Duration`; otherwise it stands by (~120s by default) before the next flip. Valid range `[0, 1]`. |
 | CPUTriggerThreshold | float | 80 | Avg CPU (%) threshold to start a CPU-triggered session. See [CPU Usage Monitoring](CpuUsageMonitoring.md). |
 | CPUTriggerCooldown | TimeSpan | (default per CpuTriggerSettings) | Minimum wait after a CPU-triggered session. |
 | MemoryTriggerThreshold | float | 80 | Avg memory usage (%) threshold to start a memory-triggered session. See [Memory Usage Monitoring](MemoryUsageMonitoring.md). |
@@ -79,7 +79,7 @@ export ServiceProfiler__Duration="00:00:45"
 export ServiceProfiler__InitialDelay="00:00:10"
 
 # Numeric and boolean values
-export ServiceProfiler__RandomProfilingOverhead="0.02"
+export ServiceProfiler__SamplingRate="0.1"
 export ServiceProfiler__CPUTriggerThreshold="85"
 export ServiceProfiler__MemoryTriggerThreshold="85"
 export ServiceProfiler__PreserveTraceFile="true"
@@ -98,7 +98,7 @@ On Windows PowerShell, set the same variables with `$env:`:
 
 ```powershell
 $env:ServiceProfiler__Duration = "00:00:45"
-$env:ServiceProfiler__RandomProfilingOverhead = "0.02"
+$env:ServiceProfiler__SamplingRate = "0.1"
 $env:ServiceProfiler__PreserveTraceFile = "true"
 ```
 
@@ -113,7 +113,7 @@ The same settings expressed as JSON:
   "ServiceProfiler": {
     "Duration": "00:00:45",
     "InitialDelay": "00:00:10",
-    "RandomProfilingOverhead": 0.02,
+    "SamplingRate": 0.1,
     "CPUTriggerThreshold": 85,
     "MemoryTriggerThreshold": 85,
     "PreserveTraceFile": true,
@@ -136,7 +136,7 @@ The same settings expressed as JSON:
 var options = new ServiceProfilerOptions
 {
     Duration = TimeSpan.FromSeconds(45),
-    RandomProfilingOverhead = 0.02f, // target ~2% time
+    SamplingRate = 0.1, // ~10% chance to start a session each cycle
     CPUTriggerThreshold = 85f,
     MemoryTriggerThreshold = 85f,
     PreserveTraceFile = true,
@@ -153,12 +153,19 @@ var options = new ServiceProfilerOptions
 };
 ```
 
-## Overhead Estimation
+## Frequency Estimation
 
-Effective sessions per hour (random):
-sessions ≈ (60 * RandomProfilingOverhead) / (DurationMinutes)
+Random profiling is scheduled with a per-cycle coin flip, so `SamplingRate`, `Duration`, and the standby duration together determine how often sessions run. Modeling each cycle as either a session (`Duration` seconds, on success) or a standby wait (`StandbyDuration` seconds, on a miss), the expected time between two random sessions is:
 
-Example: overhead=0.01, duration=0.5 min (30s) → (60 * 0.01)/0.5 = 1.2 sessions/hour.
+```
+secondsBetweenSessions ≈ ((1 - SamplingRate) / SamplingRate) * StandbyDuration + Duration
+sessionsPerHour ≈ 3600 / secondsBetweenSessions
+```
+
+Example: `SamplingRate = 0.05`, `Duration = 30s`, `StandbyDuration = 120s` (default) →
+`((1 - 0.05) / 0.05) * 120 + 30 = 2310s` between sessions → ≈ **1.6 sessions/hour**.
+
+Raising `SamplingRate` increases frequency (e.g., `0.1` → ≈ 3.1 sessions/hour). `StandbyDuration` defaults to 120s and is tuned server-side, not through the `ServiceProfiler` config section.
 
 ## Safety Checklist
 
@@ -171,7 +178,7 @@ Example: overhead=0.01, duration=0.5 min (30s) → (60 * 0.01)/0.5 = 1.2 session
 
 | Symptom | Suggested Adjustment |
 |---------|----------------------|
-| Few or no profiles | Lower thresholds, slightly raise RandomProfilingOverhead |
+| Few or no profiles | Lower thresholds, slightly raise SamplingRate |
 | High overhead | Shorter Duration, reduce CustomEventPipeProviders |
 | Large disk usage | Disable PreserveTraceFile, tighten scavenger options |
 | Missing triggers | Verify thresholds below observed steady-state levels. See [CPU](CpuUsageMonitoring.md) and [Memory](MemoryUsageMonitoring.md) monitoring docs for diagnostic logging. |


### PR DESCRIPTION
Documentation-only changes addressing two upstream issues.

## #157 — Configuration doc lacks environment-variable examples

`docs/Configurations.md` previously only showed a programmatic setup example. Added an **"Applying Configuration"** section that explains options bind from the `ServiceProfiler` configuration section, plus:

- **Environment variable** examples (bash `export` and PowerShell `$env:`), showing the `__` hierarchy separator, TimeSpan / numeric / boolean formats, and indexed array items for `CustomEventPipeProviders`.
- An equivalent **appsettings.json** example.

## #156 — Make the README easier to follow

- Removed the version-conditional (beta9 vs. beta10) dual code example in Option B, keeping the single canonical fluent chain `AddApplicationInsightsTelemetry().AddAzureMonitorProfiler()`.
- Added a callout linking to [optix — Code Optimizations skills for GitHub Copilot](https://github.com/microsoft/code-optimizations-skills).

No code changes; no build or tests required.