### PR TITLE
Fix: classic profiler no longer reports a stop failure when there's no traffic (#166)

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/PostStopProcessor.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/PostStopProcessor.cs
@@ -101,7 +101,7 @@ internal class PostStopProcessor : IPostStopProcessor
         _logger.LogDebug("There are {sampleNumber} samples before validation.", sampleCount);
         if (sampleCount == 0 && uploadMode != UploadMode.Always)
         {
-            _logger.LogWarning("Skip uploading. No samples collected and upload mode is {mode}.", uploadMode);
+            _logger.LogInformation("No trace was uploaded because no samples were collected during this profiling session (no traffic). This is expected when the application received no requests while profiling; the profiler stopped normally. Upload mode: {mode}.", uploadMode);
             return false;
         }
 
@@ -194,9 +194,14 @@ internal class PostStopProcessor : IPostStopProcessor
             // Trace is uploaded.
             int validSampleCount = e.Samples.Count();
             _logger.LogDebug("Sent {validSampleCount} valid custom events to AI. Valid sample count equals total sample count: {result}", validSampleCount, validSampleCount == sampleCount);
+            return true;
         }
 
-        return true;
+        // The upload was attempted (there were samples and a valid uploader) but produced no
+        // upload context. This is an unexpected failure - not a by-design skip - so surface it
+        // at error level so it can be investigated. Stopping the profiler itself still succeeded.
+        _logger.LogError("Trace upload did not complete successfully: the uploader returned no upload context.");
+        return false;
     }
 
     private IPCAdditionalData CreateAdditionalData(

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfilerProvider.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfilerProvider.cs
@@ -208,11 +208,28 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
 
             try
             {
-                await _traceControl.DisableAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await _traceControl.DisableAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Fail to disable EventPipe profiling.");
+                    _appInsightsSinks.LogInformation(StopProfilerFailed);
+                    throw;
+                }
+
+                // The profiler has stopped successfully once the trace is disabled. This is
+                // independent of whether the trace is subsequently uploaded: uploading can be
+                // skipped by design (e.g. no samples collected / upload disabled), which must not
+                // be treated as a stop failure. Any unexpected upload failure is logged by the
+                // post-stop processor so it can be investigated.
+                profilerStopped = true;
+                _appInsightsSinks.LogInformation(StopProfilerSucceeded);
 
                 string currentTraceFilePath = _currentTraceFilePath ?? throw new InvalidOperationException("Current trace file path is not set. This should not happen. Please contact the project owner.");
 
-                profilerStopped = await _postStopProcessorFactory.Create().PostStopProcessAsync(new PostStopOptions(
+                await _postStopProcessorFactory.Create().PostStopProcessAsync(new PostStopOptions(
                     currentTraceFilePath,
                     currentSessionId.Value,
                     stampFrontendHostUrl: _serviceProfilerContext.StampFrontendEndpointUrl,
@@ -221,14 +238,6 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
                     averageCPUUsage: cpuUsage,
                     averageMemoryUsage: memoryUsage
                     ), cancellationToken).ConfigureAwait(false);
-
-                _appInsightsSinks.LogInformation(profilerStopped ? StopProfilerSucceeded : StopProfilerFailed);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Fail to disable EventPipe profiling.");
-                _appInsightsSinks.LogInformation(StopProfilerFailed);
-                throw;
             }
             finally
             {

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfilerProvider.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfilerProvider.cs
@@ -229,18 +229,32 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
 
                 string currentTraceFilePath = _currentTraceFilePath ?? throw new InvalidOperationException("Current trace file path is not set. This should not happen. Please contact the project owner.");
 
-                await _postStopProcessorFactory.Create().PostStopProcessAsync(new PostStopOptions(
-                    currentTraceFilePath,
-                    currentSessionId.Value,
-                    stampFrontendHostUrl: _serviceProfilerContext.StampFrontendEndpointUrl,
-                    sampleActivities ?? Enumerable.Empty<SampleActivity>(),
-                    source,
-                    averageCPUUsage: cpuUsage,
-                    averageMemoryUsage: memoryUsage
-                    ), cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await _postStopProcessorFactory.Create().PostStopProcessAsync(new PostStopOptions(
+                        currentTraceFilePath,
+                        currentSessionId.Value,
+                        stampFrontendHostUrl: _serviceProfilerContext.StampFrontendEndpointUrl,
+                        sampleActivities ?? Enumerable.Empty<SampleActivity>(),
+                        source,
+                        averageCPUUsage: cpuUsage,
+                        averageMemoryUsage: memoryUsage
+                        ), cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // The profiler already stopped successfully (the trace was disabled above);
+                    // only the post-stop processing / trace upload failed. Surface the unexpected
+                    // failure so it can be investigated, but do not fault the stop itself.
+                    _logger.LogError(ex, "Post-stop processing (trace upload) failed after the profiler was stopped.");
+                }
             }
             finally
             {
+                // The inner try guarantees this runs on every path that started post-stop
+                // processing, releasing the profiling semaphore exactly once. No additional
+                // release is performed elsewhere, so a concurrent StartServiceProfilerAsync
+                // cannot have its freshly acquired semaphore released by this stop.
                 ReleaseSemaphoreForProfiling();
             }
 
@@ -252,20 +266,6 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
         {
             _logger.LogDebug(ex, "Unexpected error happens on stopping service profiler tracing.");
             throw;
-        }
-        finally
-        {
-            try
-            {
-                if (profilerStopped)
-                {
-                    ReleaseSemaphoreForProfiling();
-                }
-            }
-            catch (SemaphoreFullException ex)
-            {
-                _logger.LogWarning(ex, "Additional releasing of semaphore upon stopping profiler. This should not happen very often. Please contact the project owner otherwise.");
-            }
         }
     }
 

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfilerProvider.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfilerProvider.cs
@@ -241,11 +241,14 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
                         averageMemoryUsage: memoryUsage
                         ), cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     // The profiler already stopped successfully (the trace was disabled above);
                     // only the post-stop processing / trace upload failed. Surface the unexpected
                     // failure so it can be investigated, but do not fault the stop itself.
+                    // Cancellation (OperationCanceledException) is excluded: it is a benign,
+                    // caller-requested outcome (e.g. host shutdown) and is allowed to propagate
+                    // rather than being logged as an error.
                     _logger.LogError(ex, "Post-stop processing (trace upload) failed after the profiler was stopped.");
                 }
             }

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerProviderTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerProviderTests.cs
@@ -88,6 +88,36 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             }
         }
 
+        [Fact]
+        public async Task ShouldReportStopSucceededWhenUploadFails()
+        {
+            // Even when the trace upload fails unexpectedly, stopping the profiler itself
+            // succeeded (the trace was disabled), so StopServiceProfilerAsync must still return
+            // true. The upload failure is surfaced via logging, not by faulting the stop.
+            ServiceProvider testServiceProvider = CreateServiceProvider(TimeSpan.FromSeconds(5), TimeSpan.Zero,
+                uploaderExecuteCallback: () => throw new InvalidOperationException("Simulated upload failure."));
+
+            try
+            {
+                using (ServiceProfilerProvider target = testServiceProvider.GetRequiredService<ServiceProfilerProvider>())
+                {
+                    SchedulingPolicy schedulingPolicy = testServiceProvider.GetRequiredService<SchedulingPolicy>();
+
+                    await target.StartServiceProfilerAsync(schedulingPolicy, default);
+                    while (target.SessionListener == null) await Task.Delay(50);
+                    ((TraceSessionListenerStub)target.SessionListener).AddSampleActivity();
+
+                    bool stopResult = await target.StopServiceProfilerAsync(schedulingPolicy, default);
+
+                    Assert.True(stopResult);
+                }
+            }
+            finally
+            {
+                await testServiceProvider.DisposeAsync();
+            }
+        }
+
         #region Private
         private ServiceProvider CreateServiceProvider(
             TimeSpan duration,

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerProviderTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerProviderTests.cs
@@ -57,6 +57,37 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             }
         }
 
+        [Fact]
+        public async Task ShouldReportStopSucceededWhenNoSamplesCollected()
+        {
+            // Regression test for issue #166: when there is no traffic (no samples collected),
+            // the upload is skipped by design. That must NOT be reported as a stop failure -
+            // StopServiceProfilerAsync should still return true.
+            bool isUploaderCalled = false;
+            ServiceProvider testServiceProvider = CreateServiceProvider(TimeSpan.FromSeconds(5), TimeSpan.Zero,
+                uploaderExecuteCallback: () => { isUploaderCalled = true; });
+
+            try
+            {
+                using (ServiceProfilerProvider target = testServiceProvider.GetRequiredService<ServiceProfilerProvider>())
+                {
+                    SchedulingPolicy schedulingPolicy = testServiceProvider.GetRequiredService<SchedulingPolicy>();
+
+                    await target.StartServiceProfilerAsync(schedulingPolicy, default);
+
+                    // Intentionally do not add any sample activity: upload is skipped by design.
+                    bool stopResult = await target.StopServiceProfilerAsync(schedulingPolicy, default);
+
+                    Assert.True(stopResult);
+                    Assert.False(isUploaderCalled);
+                }
+            }
+            finally
+            {
+                await testServiceProvider.DisposeAsync();
+            }
+        }
+
         #region Private
         private ServiceProvider CreateServiceProvider(
             TimeSpan duration,


### PR DESCRIPTION
## Problem

Fixes #166. When the classic Application Insights profiler stopped a session in which no traffic was captured (no samples), the log showed:

```
StopProfiler reported failure for RandomSchedulingPolicy
StopProfiler failed
Skip uploading. No samples collected and upload mode is OnSuccess
StopProfiler triggered
```

Skipping the upload because there were no samples is **by design**, but it was being surfaced as a *stop failure*.

## Root cause

`ServiceProfilerProvider.StopServiceProfilerAsync` derived its return value from `PostStopProcessAsync`, which returns `false` when the upload is skipped by design (no samples / upload disabled). That `false` was logged as `StopProfilerFailed` and bubbled up to `OrchestratorEventPipe`, which logged `StopProfiler reported failure`.

## Changes

- **`ServiceProfilerProvider.StopServiceProfilerAsync`** — the profiler is now considered stopped successfully once the EventPipe trace is disabled: it logs `StopProfilerSucceeded` and returns `true` regardless of the upload outcome. `StopProfilerFailed` is now reserved for a genuine *disable* failure.
- **Stop vs. upload fully decoupled** — the post-stop/upload call is wrapped so an *unexpected* upload failure is logged (`LogError`) for investigation but does not fault the stop. `OperationCanceledException` is excluded so a caller-requested cancellation (e.g. host shutdown) propagates normally instead of being logged as an error.
- **Removed a redundant semaphore release** — the outer `finally` release was always redundant (the inner `finally` already releases exactly once on every path that set `profilerStopped = true`) and opened a narrow TOCTOU window where a concurrent `StartServiceProfilerAsync` could have its freshly acquired semaphore released by this stop.
- **`PostStopProcessor` (shared with the OTel provider)** — surfaces the previously-swallowed unexpected upload failure (`uploadContext == null`) via `LogError`, and logs a clear, expected-reason **Information** message when no samples were collected (no traffic).

## Notes

- The OTel provider already returned `true` once the trace was disabled, so it never had the mislabeling bug; it shares `PostStopProcessor`, so it benefits from the clearer upload-outcome logging.
- The `ServiceProfiler/` submodule is untouched.

## Tests

Added regression tests in `ServiceProfilerProviderTests`:

- `ShouldReportStopSucceededWhenNoSamplesCollected` — stop returns `true` and no upload occurs when there is no traffic.
- `ShouldReportStopSucceededWhenUploadFails` — stop returns `true` even when the trace upload throws.

All 50 tests in `ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests` pass.

## Review

Reviewed with two independent models (Claude Opus 4.8 and GPT-5.5) to **two consecutive clean rounds**; findings addressed along the way (removed a redundant/racy semaphore release; decoupled upload failures from stop success; excluded cancellation from the error path).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>