### PR TITLE
Fix: forward classic-profiler uploader logs to the customer's Application Insights (#165)

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IUploaderLogForwarderSink.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IUploaderLogForwarderSink.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+
+/// <summary>
+/// Forwards uploader (sub-process) log lines to the customer's Application Insights resource.
+/// </summary>
+/// <remarks>
+/// The uploader runs out-of-process; its logs are captured and re-emitted through
+/// <see cref="ILogger"/>. In hosts where the <see cref="ILogger"/> pipeline is already wired to
+/// the customer's Application Insights (e.g. the OpenTelemetry profiler), no extra forwarding is
+/// needed and a no-op implementation is used. In the classic profiler the <see cref="ILogger"/>
+/// pipeline is not connected to the customer resource, so an implementation backed by the
+/// profiler's dedicated telemetry channel forwards the lines instead.
+/// </remarks>
+internal interface IUploaderLogForwarderSink
+{
+    /// <summary>
+    /// Tracks a single uploader log line at the given <paramref name="level"/> to the customer's
+    /// Application Insights resource.
+    /// </summary>
+    void Track(LogLevel level, string message);
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/NullUploaderLogForwarderSink.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/NullUploaderLogForwarderSink.cs
@@ -1,0 +1,22 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.UploaderProxy;
+
+/// <summary>
+/// No-op <see cref="IUploaderLogForwarderSink"/> for hosts whose <see cref="ILogger"/> pipeline
+/// already forwards uploader logs to the customer's Application Insights (e.g. the OpenTelemetry
+/// profiler). Forwarding again would duplicate the telemetry, so this sink does nothing.
+/// </summary>
+internal sealed class NullUploaderLogForwarderSink : IUploaderLogForwarderSink
+{
+    public void Track(LogLevel level, string message)
+    {
+        // Intentionally no-op: the host's ILogger pipeline already routes these logs to
+        // Application Insights.
+    }
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/SubprocessLogForwarder.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/UploaderProxy/SubprocessLogForwarder.cs
@@ -3,6 +3,7 @@
 // -----------------------------------------------------------------------------
 
 using System;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.UploaderProxy;
@@ -20,14 +21,21 @@ namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.UploaderProxy;
 /// This class recognizes the standard prefixes (trce, dbug, info, warn, fail, crit)
 /// and maps them to <see cref="LogLevel"/> values. Continuation lines (no recognized prefix)
 /// inherit the level of the preceding line.
+///
+/// In addition to the local <see cref="ILogger"/>, lines at <see cref="LogLevel.Information"/>
+/// and above are forwarded to the customer's Application Insights via
+/// <see cref="IUploaderLogForwarderSink"/> (a no-op in hosts whose logging pipeline is already
+/// wired to Application Insights).
 /// </remarks>
 internal sealed class SubprocessLogForwarder
 {
     private readonly ILogger _logger;
+    private readonly IUploaderLogForwarderSink _customerSink;
 
-    public SubprocessLogForwarder(ILogger<SubprocessLogForwarder> logger)
+    public SubprocessLogForwarder(ILogger<SubprocessLogForwarder> logger, IUploaderLogForwarderSink customerSink)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _customerSink = customerSink ?? throw new ArgumentNullException(nameof(customerSink));
     }
 
     /// <summary>
@@ -57,7 +65,15 @@ internal sealed class SubprocessLogForwarder
                 currentLevel = parsed;
             }
 
-            _logger.Log(currentLevel, "[Uploader] {line}", trimmed.ToString());
+            string message = "[Uploader] " + trimmed.ToString();
+            _logger.Log(currentLevel, "{line}", message);
+
+            // Forward Information and above to the customer's Application Insights. Debug/Trace
+            // lines are local diagnostics only and are not sent to the customer's resource.
+            if (currentLevel >= LogLevel.Information && currentLevel < LogLevel.None)
+            {
+                _customerSink.Track(currentLevel, message);
+            }
         }
     }
 

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/ServiceCollectionExtensions.cs
@@ -227,6 +227,9 @@ internal static class ServiceCollectionExtensions
 
         services.AddSingleton<IOutOfProcCallerFactory, OutOfProcCallerFactory>();
         services.AddSingleton<SubprocessLogForwarder>();
+        // The OpenTelemetry logging pipeline already forwards ILogger output (including the
+        // forwarded uploader logs) to Application Insights, so no additional forwarding is needed.
+        services.AddSingleton<IUploaderLogForwarderSink, NullUploaderLogForwarderSink>();
 
         services.AddTransient<ITraceUploader, TraceUploaderProxy>();
     }

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/CustomerAppInsightsLogger.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/CustomerAppInsightsLogger.cs
@@ -1,0 +1,23 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+using System;
+using Microsoft.ApplicationInsights.Profiler.Core.Logging;
+
+namespace Microsoft.ApplicationInsights.Profiler.Core.Orchestration;
+
+/// <summary>
+/// Holds the <see cref="IAppInsightsLogger"/> that targets the <b>customer's</b> Application
+/// Insights resource (as opposed to Microsoft's anonymous-telemetry resource). Used to forward
+/// telemetry that must reach the customer only, e.g. uploader sub-process logs.
+/// </summary>
+internal sealed class CustomerAppInsightsLogger
+{
+    public CustomerAppInsightsLogger(IAppInsightsLogger logger)
+    {
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public IAppInsightsLogger Logger { get; }
+}

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
@@ -314,6 +314,9 @@ internal static class ServiceCollectionExtensions
 
         services.AddSingleton<IOutOfProcCallerFactory, OutOfProcCallerFactory>();
         services.AddSingleton<SubprocessLogForwarder>();
+        // Classic profiler: the ILogger pipeline is not wired to the customer's Application
+        // Insights, so forward uploader logs through the profiler's dedicated telemetry channel.
+        services.AddSingleton<IUploaderLogForwarderSink, UploaderLogForwarderSink>();
 
         services.AddTransient<ITraceUploader, TraceUploaderProxy>();
 

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
@@ -114,7 +114,12 @@ internal static class ServiceCollectionExtensions
         // Build the customer telemetry client from the full connection string (so the regional
         // IngestionEndpoint is honored) and the configured AAD token credential (so it works when
         // local auth is disabled). This is the same mechanism used by AgentStatusSender.
-        services.AddSingleton<IAppInsightsLogger>(CreateCustomerAppInsightsLogger);
+        // Register it once as a dedicated holder so the *same* instance can be (a) part of the
+        // IAppInsightsLogger fan-out used for notable Start/Stop traces, and (b) targeted directly
+        // (customer-only) when forwarding uploader logs - which must never go to Microsoft's
+        // anonymous-telemetry resource.
+        services.AddSingleton(sp => new CustomerAppInsightsLogger(CreateCustomerAppInsightsLogger(sp)));
+        services.AddSingleton<IAppInsightsLogger>(sp => sp.GetRequiredService<CustomerAppInsightsLogger>().Logger);
 
         // Heartbeats
         services.TryAddSingleton<IEventPipeTelemetryTracker, TelemetryTracker>();

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/UploaderLogForwarderSink.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/UploaderLogForwarderSink.cs
@@ -3,7 +3,6 @@
 //-----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Profiler.Core.Logging;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
@@ -17,22 +16,23 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Orchestration;
 /// profiler's <see cref="ILogger"/> pipeline is not connected to the customer's resource, so this
 /// sink is required for uploader logs to appear there.
 /// </summary>
+/// <remarks>
+/// Only the customer's logger is targeted (never Microsoft's anonymous-telemetry logger): uploader
+/// stdout can contain customer-specific details (paths, machine/role names, blob URIs, errors) and
+/// must not be sent to Microsoft's resource.
+/// </remarks>
 internal sealed class UploaderLogForwarderSink : IUploaderLogForwarderSink
 {
-    private readonly IEnumerable<IAppInsightsLogger> _loggers;
+    private readonly IAppInsightsLogger _customerLogger;
 
-    public UploaderLogForwarderSink(IEnumerable<IAppInsightsLogger> loggers)
+    public UploaderLogForwarderSink(CustomerAppInsightsLogger customerLogger)
     {
-        _loggers = loggers ?? throw new ArgumentNullException(nameof(loggers));
+        _customerLogger = customerLogger?.Logger ?? throw new ArgumentNullException(nameof(customerLogger));
     }
 
     public void Track(LogLevel level, string message)
     {
-        SeverityLevel severityLevel = ToSeverityLevel(level);
-        foreach (IAppInsightsLogger logger in _loggers)
-        {
-            logger.TrackTrace(message, severityLevel);
-        }
+        _customerLogger.TrackTrace(message, ToSeverityLevel(level));
     }
 
     private static SeverityLevel ToSeverityLevel(LogLevel level) => level switch

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/UploaderLogForwarderSink.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/UploaderLogForwarderSink.cs
@@ -1,0 +1,46 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Profiler.Core.Logging;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.ApplicationInsights.Profiler.Core.Orchestration;
+
+/// <summary>
+/// Forwards uploader sub-process log lines to the customer's Application Insights using the
+/// profiler's dedicated telemetry channel (<see cref="IAppInsightsLogger"/>). The classic
+/// profiler's <see cref="ILogger"/> pipeline is not connected to the customer's resource, so this
+/// sink is required for uploader logs to appear there.
+/// </summary>
+internal sealed class UploaderLogForwarderSink : IUploaderLogForwarderSink
+{
+    private readonly IEnumerable<IAppInsightsLogger> _loggers;
+
+    public UploaderLogForwarderSink(IEnumerable<IAppInsightsLogger> loggers)
+    {
+        _loggers = loggers ?? throw new ArgumentNullException(nameof(loggers));
+    }
+
+    public void Track(LogLevel level, string message)
+    {
+        SeverityLevel severityLevel = ToSeverityLevel(level);
+        foreach (IAppInsightsLogger logger in _loggers)
+        {
+            logger.TrackTrace(message, severityLevel);
+        }
+    }
+
+    private static SeverityLevel ToSeverityLevel(LogLevel level) => level switch
+    {
+        LogLevel.Critical => SeverityLevel.Critical,
+        LogLevel.Error => SeverityLevel.Error,
+        LogLevel.Warning => SeverityLevel.Warning,
+        LogLevel.Information => SeverityLevel.Information,
+        _ => SeverityLevel.Verbose,
+    };
+}

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/SubprocessLogForwarderTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.Tests/SubprocessLogForwarderTests.cs
@@ -2,6 +2,7 @@
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 // -----------------------------------------------------------------------------
 
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.UploaderProxy;
 using Microsoft.Extensions.Logging;
 
@@ -39,20 +40,23 @@ public class SubprocessLogForwarderTests
     public void Forward_EmptyOrWhitespace_DoesNotLog()
     {
         var logger = new FakeLogger();
-        var forwarder = new SubprocessLogForwarder(logger);
+        var sink = new FakeSink();
+        var forwarder = new SubprocessLogForwarder(logger, sink);
 
         forwarder.Forward("");
         forwarder.Forward("   ");
         forwarder.Forward(null!);
 
         Assert.Empty(logger.Entries);
+        Assert.Empty(sink.Entries);
     }
 
     [Fact]
     public void Forward_SingleLine_LogsAtCorrectLevel()
     {
         var logger = new FakeLogger();
-        var forwarder = new SubprocessLogForwarder(logger);
+        var sink = new FakeSink();
+        var forwarder = new SubprocessLogForwarder(logger, sink);
 
         forwarder.Forward("warn: MyApp.Service[0] Something is wrong");
 
@@ -65,7 +69,8 @@ public class SubprocessLogForwarderTests
     public void Forward_MultipleLines_EachAtCorrectLevel()
     {
         var logger = new FakeLogger();
-        var forwarder = new SubprocessLogForwarder(logger);
+        var sink = new FakeSink();
+        var forwarder = new SubprocessLogForwarder(logger, sink);
 
         string output = string.Join(Environment.NewLine, new[]
         {
@@ -86,7 +91,8 @@ public class SubprocessLogForwarderTests
     public void Forward_ContinuationLines_InheritPreviousLevel()
     {
         var logger = new FakeLogger();
-        var forwarder = new SubprocessLogForwarder(logger);
+        var sink = new FakeSink();
+        var forwarder = new SubprocessLogForwarder(logger, sink);
 
         string output = string.Join(Environment.NewLine, new[]
         {
@@ -106,13 +112,79 @@ public class SubprocessLogForwarderTests
     public void Forward_SkipsBlankLines()
     {
         var logger = new FakeLogger();
-        var forwarder = new SubprocessLogForwarder(logger);
+        var sink = new FakeSink();
+        var forwarder = new SubprocessLogForwarder(logger, sink);
 
         string output = "info: MyApp[0] First\n\n\nwarn: MyApp[0] Second";
 
         forwarder.Forward(output);
 
         Assert.Equal(2, logger.Entries.Count);
+    }
+
+    [Fact]
+    public void Forward_InformationAndAbove_AreForwardedToCustomerSink()
+    {
+        var logger = new FakeLogger();
+        var sink = new FakeSink();
+        var forwarder = new SubprocessLogForwarder(logger, sink);
+
+        string output = string.Join(Environment.NewLine, new[]
+        {
+            "trce: MyApp.Upload[0] Trace line",
+            "dbug: MyApp.Upload[0] Debug line",
+            "info: MyApp.Upload[0] Upload started",
+            "warn: MyApp.Upload[0] Retrying upload",
+            "fail: MyApp.Upload[0] Upload failed",
+            "crit: MyApp.Upload[0] Fatal",
+        });
+
+        forwarder.Forward(output);
+
+        // All lines still go to the local logger.
+        Assert.Equal(6, logger.Entries.Count);
+
+        // Only Information and above are forwarded to the customer's Application Insights.
+        Assert.Equal(4, sink.Entries.Count);
+        Assert.Equal(LogLevel.Information, sink.Entries[0].Level);
+        Assert.Equal(LogLevel.Warning, sink.Entries[1].Level);
+        Assert.Equal(LogLevel.Error, sink.Entries[2].Level);
+        Assert.Equal(LogLevel.Critical, sink.Entries[3].Level);
+        Assert.All(sink.Entries, e => Assert.Contains("[Uploader]", e.Message));
+    }
+
+    [Fact]
+    public void Forward_DebugAndTrace_AreNotForwardedToCustomerSink()
+    {
+        var logger = new FakeLogger();
+        var sink = new FakeSink();
+        var forwarder = new SubprocessLogForwarder(logger, sink);
+
+        string output = string.Join(Environment.NewLine, new[]
+        {
+            "trce: MyApp.Upload[0] Trace line",
+            "dbug: MyApp.Upload[0] Debug line",
+        });
+
+        forwarder.Forward(output);
+
+        Assert.Equal(2, logger.Entries.Count);
+        Assert.Empty(sink.Entries);
+    }
+
+    [Fact]
+    public void Forward_UnprefixedLines_DefaultToDebug_AreNotForwardedToCustomerSink()
+    {
+        var logger = new FakeLogger();
+        var sink = new FakeSink();
+        var forwarder = new SubprocessLogForwarder(logger, sink);
+
+        // No recognized prefix: default level is Debug, so nothing is forwarded to the sink.
+        forwarder.Forward("some plain uploader output without a level prefix");
+
+        Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Debug, logger.Entries[0].Level);
+        Assert.Empty(sink.Entries);
     }
 
     /// <summary>
@@ -129,6 +201,19 @@ public class SubprocessLogForwarderTests
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+
+    /// <summary>
+    /// Simple in-memory customer-AI sink for testing.
+    /// </summary>
+    private sealed class FakeSink : IUploaderLogForwarderSink
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public void Track(LogLevel level, string message)
+        {
+            Entries.Add((level, message));
         }
     }
 }

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/UploaderLogForwarderSinkTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/UploaderLogForwarderSinkTests.cs
@@ -21,16 +21,14 @@ namespace ServiceProfiler.EventPipe.Client.Tests
         [InlineData(LogLevel.Warning, SeverityLevel.Warning)]
         [InlineData(LogLevel.Error, SeverityLevel.Error)]
         [InlineData(LogLevel.Critical, SeverityLevel.Critical)]
-        public void Track_MapsLogLevelToSeverityAndForwardsToAllLoggers(LogLevel level, SeverityLevel expected)
+        public void Track_MapsLogLevelToSeverityAndForwardsToCustomerLogger(LogLevel level, SeverityLevel expected)
         {
-            Mock<IAppInsightsLogger> logger1 = new();
-            Mock<IAppInsightsLogger> logger2 = new();
-            var sink = new UploaderLogForwarderSink(new[] { logger1.Object, logger2.Object });
+            Mock<IAppInsightsLogger> customerLogger = new();
+            var sink = new UploaderLogForwarderSink(new CustomerAppInsightsLogger(customerLogger.Object));
 
             sink.Track(level, "[Uploader] hello");
 
-            logger1.Verify(l => l.TrackTrace("[Uploader] hello", expected, It.IsAny<IDictionary<string, string>>(), It.IsAny<bool>()), Times.Once);
-            logger2.Verify(l => l.TrackTrace("[Uploader] hello", expected, It.IsAny<IDictionary<string, string>>(), It.IsAny<bool>()), Times.Once);
+            customerLogger.Verify(l => l.TrackTrace("[Uploader] hello", expected, It.IsAny<IDictionary<string, string>>(), It.IsAny<bool>()), Times.Once);
         }
     }
 }

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/UploaderLogForwarderSinkTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/UploaderLogForwarderSinkTests.cs
@@ -1,0 +1,36 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Profiler.Core.Logging;
+using Microsoft.ApplicationInsights.Profiler.Core.Orchestration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Client.Tests
+{
+    public class UploaderLogForwarderSinkTests
+    {
+        [Theory]
+        [InlineData(LogLevel.Trace, SeverityLevel.Verbose)]
+        [InlineData(LogLevel.Debug, SeverityLevel.Verbose)]
+        [InlineData(LogLevel.Information, SeverityLevel.Information)]
+        [InlineData(LogLevel.Warning, SeverityLevel.Warning)]
+        [InlineData(LogLevel.Error, SeverityLevel.Error)]
+        [InlineData(LogLevel.Critical, SeverityLevel.Critical)]
+        public void Track_MapsLogLevelToSeverityAndForwardsToAllLoggers(LogLevel level, SeverityLevel expected)
+        {
+            Mock<IAppInsightsLogger> logger1 = new();
+            Mock<IAppInsightsLogger> logger2 = new();
+            var sink = new UploaderLogForwarderSink(new[] { logger1.Object, logger2.Object });
+
+            sink.Track(level, "[Uploader] hello");
+
+            logger1.Verify(l => l.TrackTrace("[Uploader] hello", expected, It.IsAny<IDictionary<string, string>>(), It.IsAny<bool>()), Times.Once);
+            logger2.Verify(l => l.TrackTrace("[Uploader] hello", expected, It.IsAny<IDictionary<string, string>>(), It.IsAny<bool>()), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #165. Uploader logs never appear in the customer's Application Insights when using the
**classic** profiler.

## Root cause

The uploader runs out-of-process. `OutOfProcCaller` captures its stdout and re-emits each line via
`SubprocessLogForwarder`, which logs through a plain `ILogger`.

- **OTel profiler:** the app's OpenTelemetry logging pipeline is wired to Azure Monitor, so
  `ILogger` output reaches customer AI automatically. ✅
- **Classic profiler:** it reaches customer AI only through a dedicated channel
  (`IAppInsightsSinks` → `IAppInsightsLogger`/`EventPipeAppInsightsLogger`, a private
  `TelemetryClient`), used only for notable Start/Stop traces. The classic profiler registers no
  `ILogger → AI` bridge, so `SubprocessLogForwarder`'s output never reaches the customer's AI. ❌

## Changes

- **Shared:** new `IUploaderLogForwarderSink` (`Track(LogLevel, string)`) + no-op
  `NullUploaderLogForwarderSink`.
- **Shared `SubprocessLogForwarder`:** injects the sink; still logs every line to `ILogger`, and
  additionally forwards **Information and above** to the sink (prefixed `[Uploader]`). Debug/Trace
  remain local-only; continuation lines inherit the current level.
- **Classic:** `UploaderLogForwarderSink` forwards via the profiler's dedicated `IAppInsightsLogger`
  channel, mapping `LogLevel` → `SeverityLevel`. It targets **only the customer's** logger (never
  Microsoft's anonymous-telemetry resource) — a new `CustomerAppInsightsLogger` holder exposes the
  single customer logger instance, which is also still part of the notable-trace fan-out.
- **OTel:** registers `NullUploaderLogForwarderSink` to avoid duplicate telemetry (its `ILogger`
  already flows to AI).

## Notes

- All new types are internal; no public API change.
- The `ServiceProfiler/` submodule is untouched.

## Tests

- Extended `SubprocessLogForwarderTests`: Information+ reaches the sink; Debug/Trace and unprefixed
  (default-Debug) lines do not; the local `ILogger` still receives every line.
- Added `UploaderLogForwarderSinkTests`: `LogLevel` → `SeverityLevel` mapping and customer-only
  forwarding.

Classic Client + OTel Core build clean; OTel 19/19 and classic 54/54 tests pass.

## Review

Reviewed with two independent models (Claude Opus 4.8 and GPT-5.5) to **two consecutive clean
rounds**. Round 1 surfaced a privacy issue (uploader stdout could reach Microsoft's anonymous
resource when anonymous telemetry was enabled); fixed by targeting only the customer's logger.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>