### PR TITLE
Fix: report the in-flight operation in scheduler-conflict warnings instead of "(null)" (#164)

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Orchestrations/OrchestratorEventPipe.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Orchestrations/OrchestratorEventPipe.cs
@@ -43,6 +43,14 @@ internal abstract class OrchestratorEventPipe : Orchestrator
     // Guarded by _policyChangeHandler alongside _currentProfilingPolicy.
     private IAsyncDisposable? _currentLease = null;
 
+    // Describes the policy-change operation that currently holds _policyChangeHandler, for
+    // diagnostics when another operation cannot acquire the gate within its timeout. It is written
+    // by the gate holder (right after acquiring, cleared before releasing) and read WITHOUT the gate
+    // by a timed-out waiter, so it is volatile for cross-thread visibility. Reporting this is far
+    // more useful than _currentProfilingPolicy, which is null while a start is mid-flight (assigned
+    // only after the provider starts) or while a stop is tearing down (cleared before release).
+    private volatile PolicyChangeActivity? _policyChangeInProgress;
+
     // Set during disposal so an in-flight StartProfilingAsync releases its lease instead of
     // retaining it (the normal stop path won't run during shutdown). Volatile for visibility.
     private volatile bool _disposed = false;
@@ -219,6 +227,7 @@ internal abstract class OrchestratorEventPipe : Orchestrator
             _semaphoreTasks.TryAdd(waitSemaphoreTask, 0);
             if (await waitSemaphoreTask.ConfigureAwait(false))
             {
+                _policyChangeInProgress = new PolicyChangeActivity("start", policy.Source);
                 try
                 {
                     if (_currentProfilingPolicy == null)
@@ -301,12 +310,13 @@ internal abstract class OrchestratorEventPipe : Orchestrator
                 }
                 finally
                 {
+                    _policyChangeInProgress = null;
                     _policyChangeHandler.Release();
                 }
             }
             else
             {
-                _logger.LogWarning("Can't get the handler to start a profiling. Requested by {newSource}. Current Profiling by: {currentSource}", policy.Source, _currentProfilingPolicy?.Source);
+                _logger.LogWarning("Can't acquire the profiler policy-change gate within {timeoutMs}ms to start profiling requested by {newSource}. A policy change is already in progress: {inProgress}.", 500, policy.Source, DescribeInProgressPolicyChange());
             }
 
             _logger.LogTrace("Profiling is running by policy: {source}", _currentProfilingPolicy?.Source);
@@ -341,6 +351,7 @@ internal abstract class OrchestratorEventPipe : Orchestrator
                 _semaphoreTasks.TryAdd(waitSemaphoreTask, 0);
                 if (await waitSemaphoreTask.ConfigureAwait(false))
                 {
+                    _policyChangeInProgress = new PolicyChangeActivity("stop", policy.Source);
                     try
                     {
                         if (_currentProfilingPolicy == policy)
@@ -407,12 +418,13 @@ internal abstract class OrchestratorEventPipe : Orchestrator
                     }
                     finally
                     {
+                        _policyChangeInProgress = null;
                         _policyChangeHandler.Release();
                     }
                 }
                 else
                 {
-                    _logger.LogWarning("Can't get the handler to stop a profiling. Requested by {newSource}. Current Profiling by: {currentSource}", policy.Source, _currentProfilingPolicy?.Source);
+                    _logger.LogWarning("Can't acquire the profiler policy-change gate within {timeoutSeconds}s to stop profiling requested by {newSource}. A policy change is already in progress: {inProgress}.", 30, policy.Source, DescribeInProgressPolicyChange());
                     result = false;
                 }
             }
@@ -460,6 +472,7 @@ internal abstract class OrchestratorEventPipe : Orchestrator
 
             if (acquired)
             {
+                _policyChangeInProgress = new PolicyChangeActivity("dispose", null);
                 leaseToRelease = _currentLease;
                 policyToStop = _currentProfilingPolicy;
                 _currentLease = null;
@@ -470,6 +483,7 @@ internal abstract class OrchestratorEventPipe : Orchestrator
                 // it is never used via AvailableWaitHandle (so Dispose would free nothing), and disposing it
                 // while in-flight/queued callers may still call Release() in their finally blocks would throw
                 // ObjectDisposedException.
+                _policyChangeInProgress = null;
                 _policyChangeHandler.Release();
             }
 
@@ -574,6 +588,7 @@ internal abstract class OrchestratorEventPipe : Orchestrator
 
         try
         {
+            _policyChangeInProgress = new PolicyChangeActivity("cleanup", reason);
             SchedulingPolicy? policy = _currentProfilingPolicy;
             IAsyncDisposable? lease = _currentLease;
             if (policy is null && lease is null)
@@ -594,6 +609,7 @@ internal abstract class OrchestratorEventPipe : Orchestrator
         }
         finally
         {
+            _policyChangeInProgress = null;
             _policyChangeHandler.Release();
         }
     }
@@ -609,5 +625,30 @@ internal abstract class OrchestratorEventPipe : Orchestrator
         }
 
         return activated;
+    }
+
+    /// <summary>
+    /// Describes the in-flight policy-change operation for a conflict log message. Falls back to a
+    /// clear phrase when no operation is recorded (the holder may have released between a failed
+    /// wait and this read).
+    /// </summary>
+    private string DescribeInProgressPolicyChange()
+        => _policyChangeInProgress?.ToString() ?? "unknown (a concurrent policy change just completed)";
+
+    /// <summary>
+    /// Identifies the policy-change operation currently holding <see cref="_policyChangeHandler"/>.
+    /// </summary>
+    private sealed class PolicyChangeActivity
+    {
+        private readonly string _kind;
+        private readonly string? _source;
+
+        public PolicyChangeActivity(string kind, string? source)
+        {
+            _kind = kind;
+            _source = source;
+        }
+
+        public override string ToString() => _source is null ? _kind : $"{_kind} by {_source}";
     }
 }

--- a/tests/ServiceProfiler.EventPipe.Client.Tests/OrchestratorEventPipeConcurrencyTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Client.Tests/OrchestratorEventPipeConcurrencyTests.cs
@@ -4,11 +4,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
 using Microsoft.ApplicationInsights.Profiler.Shared.Orchestrations;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.ServiceProfiler.Orchestration;
@@ -178,9 +180,58 @@ public class OrchestratorEventPipeConcurrencyTests
         leaseHandle.Verify(l => l.DisposeAsync(), Times.Once);
     }
 
+    [Fact]
+    public async Task StartProfilingAsync_WhenGateHeldByAnotherStart_WarningNamesInFlightOperationNotNull()
+    {
+        // Regression test for issue #164: while one start holds the policy-change gate (and has not
+        // yet assigned _currentProfilingPolicy), a second start that times out on the gate must
+        // report the in-flight operation - not "(null)".
+        TaskCompletionSource startEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource<bool> releaseStart = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Mock<IServiceProfilerProvider> provider = new();
+        provider.Setup(p => p.StartServiceProfilerAsync(It.IsAny<IProfilerSource>(), It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                // Signal that the gate is now held, then block so it stays held.
+                startEntered.TrySetResult();
+                return releaseStart.Task;
+            });
+
+        Mock<IAsyncDisposable> leaseHandle = new();
+        leaseHandle.Setup(l => l.DisposeAsync()).Returns(default(ValueTask));
+        Mock<IProfilerConcurrencyControlClient> concurrency = new();
+        concurrency.Setup(c => c.TryAcquireLeaseAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(leaseHandle.Object);
+
+        CapturingLogger logger = new();
+        TestOrchestrator orchestrator = CreateOrchestrator(provider, concurrency, logger);
+
+        TestPolicy holder = new("HoldingPolicy");
+        TestPolicy waiter = new("WaitingPolicy");
+
+        Task<bool> holderTask = orchestrator.StartProfilingAsync(holder, CancellationToken.None);
+        await startEntered.Task; // The gate is now held by the holder start.
+
+        // This call cannot acquire the gate within its 500ms timeout and logs the conflict warning.
+        bool waiterResult = await orchestrator.StartProfilingAsync(waiter, CancellationToken.None);
+
+        // Let the holder finish.
+        releaseStart.SetResult(true);
+        Assert.True(await holderTask);
+
+        Assert.False(waiterResult);
+
+        string warning = Assert.Single(logger.Entries.Where(e => e.Level == LogLevel.Warning)).Message;
+        Assert.Contains("WaitingPolicy", warning);           // who was denied
+        Assert.Contains("start by HoldingPolicy", warning);  // the in-flight operation
+        Assert.DoesNotContain("(null)", warning);
+    }
+
     private static TestOrchestrator CreateOrchestrator(
         Mock<IServiceProfilerProvider> provider,
-        Mock<IProfilerConcurrencyControlClient> concurrency)
+        Mock<IProfilerConcurrencyControlClient> concurrency,
+        ILogger<OrchestratorEventPipe> logger = null)
     {
         IOptions<UserConfigurationBase> options = Options.Create<UserConfigurationBase>(new TestUserConfiguration());
         return new TestOrchestrator(
@@ -189,7 +240,26 @@ public class OrchestratorEventPipeConcurrencyTests
             Mock.Of<IDelaySource>(),
             Mock.Of<IAgentStatusService>(),
             Mock.Of<IResourceUsageSource>(),
-            concurrency.Object);
+            concurrency.Object,
+            logger ?? NullLogger<OrchestratorEventPipe>.Instance);
+    }
+
+    private sealed class CapturingLogger : ILogger<OrchestratorEventPipe>
+    {
+        private readonly object _gate = new();
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            lock (_gate)
+            {
+                Entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
     }
 
     private sealed class TestUserConfiguration : UserConfigurationBase
@@ -204,7 +274,8 @@ public class OrchestratorEventPipeConcurrencyTests
             IDelaySource delaySource,
             IAgentStatusService agentStatusService,
             IResourceUsageSource resourceUsageSource,
-            IProfilerConcurrencyControlClient concurrencyControlClient)
+            IProfilerConcurrencyControlClient concurrencyControlClient,
+            ILogger<OrchestratorEventPipe> logger)
             : base(
                 profilerProvider,
                 config,
@@ -212,7 +283,7 @@ public class OrchestratorEventPipeConcurrencyTests
                 delaySource,
                 agentStatusService,
                 resourceUsageSource,
-                NullLogger<OrchestratorEventPipe>.Instance,
+                logger,
                 concurrencyControlClient)
         {
         }
@@ -220,12 +291,15 @@ public class OrchestratorEventPipeConcurrencyTests
 
     private sealed class TestPolicy : SchedulingPolicy
     {
-        public TestPolicy()
+        private readonly string _source;
+
+        public TestPolicy(string source = nameof(TestPolicy))
             : base(TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, Mock.Of<IDelaySource>(), Mock.Of<IExpirationPolicy>(), NullLogger<SchedulingPolicy>.Instance)
         {
+            _source = source;
         }
 
-        public override string Source => nameof(TestPolicy);
+        public override string Source => _source;
 
         public override IAsyncEnumerable<(TimeSpan duration, ProfilerAction action)> GetScheduleAsync(CancellationToken cancellationToken)
             => throw new NotSupportedException();


### PR DESCRIPTION
## Problem

Fixes #164. On a scheduler conflict the orchestrator logged an unhelpful `(null)`:

```
Can't get the handler to start a profiling. Requested by RandomSchedulingPolicy. Current Profiling by: (null)
Can't get the handler to start a profiling. Requested by CPUMonitoringSchedulingPolicy. Current Profiling by: (null)
```

## Root cause

`OrchestratorEventPipe` logs this warning (start path and the twin in the stop path) when it
**cannot acquire the `_policyChangeHandler` gate** within its timeout (500ms for start, 30s for
stop) — i.e. another policy-change operation is holding the gate. It printed
`_currentProfilingPolicy?.Source`, but that field is:
- set **only after** a start actually succeeds (mid-flight starts haven't assigned it yet), and
- **cleared** during stop teardown.

So under contention it is almost always `null`. The message also conflated "gate contention" with
"actively profiling."

## Changes

- Track the in-flight policy-change operation in a `volatile PolicyChangeActivity? _policyChangeInProgress`
  (a tiny immutable `{ Kind, Source }` with a readable `ToString()`, e.g. `"start by RandomSchedulingPolicy"`).
- Set it immediately **after** acquiring `_policyChangeHandler` and clear it **before** releasing, at
  all four acquire sites: `StartProfilingAsync`, `StopProfilingAsync`,
  `StopActiveSessionAndReleaseLeaseAsync`, and `Dispose`.
- Reword both conflict warnings to describe gate contention and report the in-flight operation via
  `DescribeInProgressPolicyChange()`, with a null-safe fallback
  (`"unknown (a concurrent policy change just completed)"`).

Example new message:

```
Can't acquire the profiler policy-change gate within 500ms to start profiling requested by
CPUMonitoringSchedulingPolicy. A policy change is already in progress: start by RandomSchedulingPolicy.
```

## Notes

- Diagnostics-only: no change to locking semantics or scheduling behavior. The field is written
  under the gate and read (best-effort) without it, hence `volatile`; the null race is handled by the
  fallback.
- `OrchestratorEventPipe` is Shared, so both the classic and OpenTelemetry profilers benefit.
- The `ServiceProfiler/` submodule is untouched.

## Tests

Added a contention regression test in `OrchestratorEventPipeConcurrencyTests` that holds the gate via
a blocking provider start and asserts the second start's warning names the in-flight operation (not
`(null)`).

Shared builds clean; classic client 65/65 and OTel 83/83 tests pass.

## Review

Reviewed with two independent models (Claude Opus 4.8 and GPT-5.5) to **two consecutive clean
rounds** — both verified set/clear coverage across all four gate paths (including early-return and
exception paths), volatile visibility, test determinism, and that no locking/behavioral semantics
changed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>