### PR TITLE
Fix: PR-Assistant follow-ups — IK validation precision & Windows-only round-trip tests (#162)

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerContext.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerContext.cs
@@ -60,9 +60,10 @@ internal class ServiceProfilerContext : IServiceProfilerContext
         // Connection string is present but could not be parsed.
         if (ConnectionString is null)
         {
-            // Distinguish an explicitly empty instrumentation key (e.g. "InstrumentationKey=")
-            // from an otherwise malformed connection string.
-            return ContainsEmptyInstrumentationKey(_connectionStringValue)
+            // Distinguish an invalid instrumentation key (an "InstrumentationKey" token that is
+            // empty/whitespace or not a GUID, e.g. "InstrumentationKey=" or "InstrumentationKey=not-a-guid")
+            // from an otherwise malformed connection string. The former yields a more actionable error.
+            return ContainsInvalidInstrumentationKey(_connectionStringValue)
                 ? ConnectionStringValidationResult.InvalidInstrumentationKey
                 : ConnectionStringValidationResult.Malformed;
         }
@@ -77,10 +78,10 @@ internal class ServiceProfilerContext : IServiceProfilerContext
     }
 
     /// <summary>
-    /// Determines whether the raw connection string declares any
-    /// <c>InstrumentationKey</c> token whose value is empty or whitespace.
+    /// Determines whether the raw connection string declares any <c>InstrumentationKey</c> token
+    /// whose value is invalid - that is, empty/whitespace or not a valid <see cref="Guid"/>.
     /// </summary>
-    private static bool ContainsEmptyInstrumentationKey(string connectionStringValue)
+    private static bool ContainsInvalidInstrumentationKey(string connectionStringValue)
     {
         foreach (string token in connectionStringValue.Split(';'))
         {
@@ -91,8 +92,13 @@ internal class ServiceProfilerContext : IServiceProfilerContext
             }
 
             string key = token.Substring(0, separatorIndex).Trim();
-            if (key.Equals("InstrumentationKey", StringComparison.OrdinalIgnoreCase)
-                && string.IsNullOrWhiteSpace(token.Substring(separatorIndex + 1)))
+            if (!key.Equals("InstrumentationKey", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            string value = token.Substring(separatorIndex + 1);
+            if (string.IsNullOrWhiteSpace(value) || !Guid.TryParse(value.Trim(), out _))
             {
                 return true;
             }

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerContextValidationTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerContextValidationTests.cs
@@ -37,6 +37,13 @@ public class ServiceProfilerContextValidationTests
     public void Validation_EmptyInstrumentationKey_ReturnsInvalidInstrumentationKey(string connectionStringValue)
         => Assert.Equal(ConnectionStringValidationResult.InvalidInstrumentationKey, Validate(connectionStringValue));
 
+    [Theory]
+    [InlineData("InstrumentationKey=not-a-guid")]
+    [InlineData("InstrumentationKey=123")]
+    [InlineData("IngestionEndpoint=https://example.com/;InstrumentationKey=not-a-guid")]
+    public void Validation_NonGuidInstrumentationKey_ReturnsInvalidInstrumentationKey(string connectionStringValue)
+        => Assert.Equal(ConnectionStringValidationResult.InvalidInstrumentationKey, Validate(connectionStringValue));
+
     private static ConnectionStringValidationResult Validate(string? connectionStringValue)
     {
         Mock<IEndpointProvider> endpointProviderMock = new();

--- a/tests/ServiceProfiler.EventPipe.Upload.Tests/UploadContextRoundTripTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Upload.Tests/UploadContextRoundTripTests.cs
@@ -23,7 +23,7 @@ namespace ServiceProfiler.EventPipe.Upload.Tests
     /// </summary>
     public class UploadContextRoundTripTests
     {
-        [Fact]
+        [WindowsOnlyFact]
         public void ProducerOutput_RoundTripsToUploadContext_AllFields()
         {
             // Use a session id with sub-second precision so a lossy timestamp format would be caught.
@@ -68,7 +68,7 @@ namespace ServiceProfiler.EventPipe.Upload.Tests
             Assert.True(bound.UseNamedPipe);
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void ProducerOutput_WithOptionalFieldsOmitted_RoundTrips()
         {
             DateTimeOffset sessionId = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero).AddTicks(7654321);

--- a/tests/ServiceProfiler.EventPipe.Upload.Tests/WindowsOnlyFactAttribute.cs
+++ b/tests/ServiceProfiler.EventPipe.Upload.Tests/WindowsOnlyFactAttribute.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Upload.Tests
+{
+    /// <summary>
+    /// An xUnit <see cref="FactAttribute"/> that is skipped on non-Windows platforms. Use for tests
+    /// that exercise genuinely Windows-only behavior (e.g. Win32 P/Invokes such as
+    /// <c>CommandLineToArgvW</c>), so they run for real on Windows and are cleanly skipped elsewhere.
+    /// </summary>
+    public sealed class WindowsOnlyFactAttribute : FactAttribute
+    {
+        public WindowsOnlyFactAttribute()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Skip = "Windows-only: exercises Windows command-line tokenization (CommandLineToArgvW) semantics.";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #162. Two independent, Medium-severity PR-Assistant follow-ups.

## 1. Non-GUID instrumentation key classified `Malformed` instead of `InvalidInstrumentationKey`

**File:** `src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerContext.cs`

`ConnectionString.TryParse` rejects a non-GUID instrumentation key, so for
`InstrumentationKey=not-a-guid` the parsed `ConnectionString` is null and, because the value wasn't
*empty*, the result fell through to `Malformed`. A present-but-non-GUID key is more precisely an
invalid instrumentation key (and yields a more actionable bootstrap error).

- Generalized `ContainsEmptyInstrumentationKey` → `ContainsInvalidInstrumentationKey`: an
  `InstrumentationKey` token is invalid when its value is empty/whitespace **or** not
  `Guid.TryParse`-able.
- Scans **all** `InstrumentationKey` tokens (returns invalid if any is invalid), preserving the
  existing `InstrumentationKey=<valid-guid>;InstrumentationKey=` → `InvalidInstrumentationKey` case.
- Connection strings with no `InstrumentationKey` token remain `Malformed`. Only the
  `ConnectionString is null` branch is affected; the successfully-parsed path is untouched.

## 2. Windows-only P/Invokes in `UploadContextRoundTripTests` fail on non-Windows

**File:** `tests/ServiceProfiler.EventPipe.Upload.Tests/UploadContextRoundTripTests.cs` (+ new
`WindowsOnlyFactAttribute.cs`)

`Tokenize` P/Invokes `CommandLineToArgvW` (shell32) + `LocalFree` (kernel32) with no OS guard, so the
tests throw `DllNotFoundException` on Linux/macOS. The tests intentionally validate real Windows
`ProcessStartInfo.Arguments` / `CommandLineToArgvW` tokenization semantics, so a managed
reimplementation would defeat their purpose.

- Added `WindowsOnlyFactAttribute : FactAttribute` that sets `Skip` when not on Windows.
- Applied it to both round-trip facts — real Windows tokenization still runs on Windows; cleanly
  skipped elsewhere.

## Tests

- Added non-GUID IK cases to `ServiceProfilerContextValidationTests`
  (`InstrumentationKey=not-a-guid`, `InstrumentationKey=123`, and with `IngestionEndpoint`).
- Upload.Tests 27/27 and the App Insights profiler tests 51/51 pass on Windows.

## Notes

- No public API change (internal helper rename + test-only additions).
- The `ServiceProfiler/` submodule is untouched.

## Review

Reviewed with two independent models (Claude Opus 4.8 and GPT-5.5) to **two consecutive clean
rounds** — both verified the (a) non-GUID, (b) no-IK-token, and (c) multi-token classification cases,
the unaffected parsed path, and the `WindowsOnlyFact` skip logic.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>