### PR TITLE
Attach application version to ServiceProfilerIndex & ServiceProfilerSample custom events (#86)

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/CustomEvents/ServiceProfilerIndex.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/CustomEvents/ServiceProfilerIndex.cs
@@ -21,4 +21,6 @@ internal record ServiceProfilerIndex
     public double AverageMemoryUsage { get; init; }
 
     public string CloudRoleName { get; init; } = null!;
+
+    public string? AppVersion { get; init; }
 }

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/CustomEvents/ServiceProfilerSample.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/CustomEvents/ServiceProfilerSample.cs
@@ -16,4 +16,6 @@ internal record ServiceProfilerSample
 
     public string? RoleName { get; init; }
     public string? RoleInstance { get; init; }
+
+    public string? AppVersion { get; init; }
 }

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IAppVersionDetector.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IAppVersionDetector.cs
@@ -1,0 +1,18 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+
+/// <summary>
+/// Detects the application version by a single method. A collection of detectors can be registered
+/// in the ServiceCollection and the first one that returns a non-empty value is used.
+/// See <see cref="AggregatedAppVersionSource"/> for the usage.
+/// </summary>
+internal interface IAppVersionDetector
+{
+    /// <summary>
+    /// Gets the application version, or <see langword="null"/>/empty if it cannot be determined.
+    /// </summary>
+    string? GetAppVersion();
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IAppVersionSource.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/IAppVersionSource.cs
@@ -1,0 +1,16 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+
+/// <summary>
+/// Provides the effective application version to associate with profiler telemetry.
+/// </summary>
+internal interface IAppVersionSource
+{
+    /// <summary>
+    /// Gets the application version, or <see cref="string.Empty"/> when it cannot be determined.
+    /// </summary>
+    string AppVersion { get; }
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/AggregatedAppVersionSource.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/AggregatedAppVersionSource.cs
@@ -1,0 +1,47 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services;
+
+/// <summary>
+/// Aggregates the registered <see cref="IAppVersionDetector"/>s and exposes the first non-empty
+/// application version as the effective one (mirrors <see cref="AggregatedRoleNameSource"/>).
+/// </summary>
+internal class AggregatedAppVersionSource : IAppVersionSource
+{
+    private readonly ILogger<AggregatedAppVersionSource> _logger;
+
+    public AggregatedAppVersionSource(
+        IEnumerable<IAppVersionDetector> appVersionDetectors,
+        ILogger<AggregatedAppVersionSource> logger)
+    {
+        _logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
+
+        foreach (IAppVersionDetector detector in appVersionDetectors)
+        {
+            string appVersion = detector.GetAppVersion() ?? string.Empty;
+            _logger.LogDebug("App version detector {detector} returned version: {appVersion}", detector.GetType().Name, appVersion);
+
+            if (string.IsNullOrEmpty(appVersion))
+            {
+                // Try the next detector.
+                continue;
+            }
+
+            // We have a non-empty version. This is the effective application version.
+            AppVersion = appVersion;
+            return;
+        }
+
+        _logger.LogDebug("Application version is effectively empty. No app version detector returned a non-empty value.");
+        AppVersion = string.Empty;
+    }
+
+    public string AppVersion { get; }
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/AssemblyAppVersionDetector.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/AssemblyAppVersionDetector.cs
@@ -1,0 +1,45 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+using System.Reflection;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services;
+
+/// <summary>
+/// Detects the application version from the entry assembly, preferring the
+/// <see cref="AssemblyInformationalVersionAttribute"/> (the same source the Application Insights SDK
+/// uses for <c>application_Version</c>) and falling back to the assembly <see cref="AssemblyName.Version"/>.
+/// </summary>
+internal sealed class AssemblyAppVersionDetector : IAppVersionDetector
+{
+    private readonly Assembly? _assembly;
+
+    public AssemblyAppVersionDetector()
+        : this(Assembly.GetEntryAssembly())
+    {
+    }
+
+    // Exposed for testing with an explicit assembly.
+    internal AssemblyAppVersionDetector(Assembly? assembly)
+    {
+        _assembly = assembly;
+    }
+
+    public string? GetAppVersion()
+    {
+        if (_assembly is null)
+        {
+            return null;
+        }
+
+        string? informationalVersion = _assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (!string.IsNullOrWhiteSpace(informationalVersion))
+        {
+            return informationalVersion;
+        }
+
+        return _assembly.GetName().Version?.ToString();
+    }
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/CustomEventsBuilder.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/CustomEventsBuilder.cs
@@ -20,20 +20,24 @@ internal class CustomEventsBuilder : ICustomEventsBuilder
     private readonly IServiceProfilerContext _serviceProfilerContext;
     private readonly IRoleNameSource _roleNameSource;
     private readonly IRoleInstanceSource _roleInstanceSource;
+    private readonly IAppVersionSource _appVersionSource;
     private readonly ILogger _logger;
     private string? _roleNameCache;
     private string? _roleInstanceCache;
+    private string? _appVersionCache;
 
     public CustomEventsBuilder(
         IServiceProfilerContext serviceProfilerContext,
         IRoleNameSource roleNameSource,
         IRoleInstanceSource roleInstanceSource,
+        IAppVersionSource appVersionSource,
         ILogger<CustomEventsBuilder> logger)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serviceProfilerContext = serviceProfilerContext ?? throw new ArgumentNullException(nameof(serviceProfilerContext));
         _roleNameSource = roleNameSource ?? throw new ArgumentNullException(nameof(roleNameSource));
         _roleInstanceSource = roleInstanceSource ?? throw new ArgumentNullException(nameof(roleInstanceSource));
+        _appVersionSource = appVersionSource ?? throw new ArgumentNullException(nameof(appVersionSource));
     }
 
     public ServiceProfilerIndex CreateServiceProfilerIndex(string stampId, DateTimeOffset sessionId, Guid appId, Guid artifactId, IProfilerSource profilerSource, float averageCPUUsage, float averageMemoryUsage)
@@ -52,7 +56,8 @@ internal class CustomEventsBuilder : ICustomEventsBuilder
             OperatingSystem = Environment.OSVersion.VersionString,
             AverageCPUUsage = averageCPUUsage,
             AverageMemoryUsage = averageMemoryUsage,
-            CloudRoleName = _roleNameCache ??= _roleNameSource.CloudRoleName
+            CloudRoleName = _roleNameCache ??= _roleNameSource.CloudRoleName,
+            AppVersion = _appVersionCache ??= _appVersionSource.AppVersion
         };
 
         _logger.LogDebug("Service Profiler Index content: {content}", result);
@@ -90,6 +95,7 @@ internal class CustomEventsBuilder : ICustomEventsBuilder
             RoleName = _roleNameCache ??= _roleNameSource.CloudRoleName,
             OperationId = sample.OperationId,
             OperationName = sample.OperationName,
+            AppVersion = _appVersionCache ??= _appVersionSource.AppVersion,
         };
     }
 }

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/ServiceCollectionExtensions.cs
@@ -67,6 +67,12 @@ internal static class ServiceCollectionExtensions
         services.AddSingleton<IRoleInstanceDetector, OtelResourceRoleInstanceDetector>();
         services.AddSingleton<IRoleInstanceSource, AggregatedRoleInstanceSource>();
 
+        // Application version detectors and source: prefer the OTel Resource service.version, then
+        // fall back to the entry assembly version.
+        services.AddSingleton<IAppVersionDetector, OtelResourceAppVersionDetector>();
+        services.AddSingleton<IAppVersionDetector, AssemblyAppVersionDetector>();
+        services.AddSingleton<IAppVersionSource, AggregatedAppVersionSource>();
+
         services.AddSingleton<IFile, SystemFile>();
         services.AddSingleton<IEnvironment, SystemEnvironment>();
         services.AddSingleton<IZipFile, SystemZipFile>();

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/Services/OtelResourceAppVersionDetector.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/Services/OtelResourceAppVersionDetector.cs
@@ -1,0 +1,24 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+using System;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+
+namespace Azure.Monitor.OpenTelemetry.Profiler.Core.Services;
+
+/// <summary>
+/// Detects the application version from the OpenTelemetry Resource <c>service.version</c> attribute.
+/// </summary>
+internal sealed class OtelResourceAppVersionDetector : IAppVersionDetector
+{
+    private readonly OtelResourceDetector _otelResourceDetector;
+
+    public OtelResourceAppVersionDetector(OtelResourceDetector otelResourceDetector)
+    {
+        _otelResourceDetector = otelResourceDetector ?? throw new ArgumentNullException(nameof(otelResourceDetector));
+    }
+
+    public string? GetAppVersion()
+        => _otelResourceDetector.GetResource(OtelResourceSemanticConventions.AttributeServiceVersion);
+}

--- a/src/ServiceProfiler.EventPipe.Upload/CustomEventsSender.cs
+++ b/src/ServiceProfiler.EventPipe.Upload/CustomEventsSender.cs
@@ -126,6 +126,11 @@ internal class CustomEventsSender : ICustomEventsSender
             eventTelemetry.Context.Cloud.RoleName = sample.RoleName;
         }
 
+        if (!string.IsNullOrEmpty(sample.AppVersion))
+        {
+            eventTelemetry.Context.Component.Version = sample.AppVersion;
+        }
+
         if (!string.IsNullOrEmpty(sample.OperationName))
         {
             eventTelemetry.Context.Operation.Name = sample.OperationName;
@@ -160,6 +165,11 @@ internal class CustomEventsSender : ICustomEventsSender
         eventTelemetry.Metrics["AverageCPUUsage"] = index.AverageCPUUsage;
         eventTelemetry.Metrics["AverageMemoryUsage"] = index.AverageMemoryUsage;
         eventTelemetry.Context.Cloud.RoleName ??= index.CloudRoleName;
+
+        if (!string.IsNullOrEmpty(index.AppVersion))
+        {
+            eventTelemetry.Context.Component.Version = index.AppVersion;
+        }
 
         telemetryClient.TrackEvent(eventTelemetry);
     }

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
@@ -137,6 +137,10 @@ internal static class ServiceCollectionExtensions
         services.AddSingleton<IRoleInstanceDetector, ServiceProfilerContextRoleInstanceDetector>();
         services.AddSingleton<IRoleInstanceSource, AggregatedRoleInstanceSource>();
 
+        // Application version detectors and source
+        services.AddSingleton<IAppVersionDetector, AssemblyAppVersionDetector>();
+        services.AddSingleton<IAppVersionSource, AggregatedAppVersionSource>();
+
         // Profiler
         services.AddSingleton<SampleActivityContainerFactory>();
         services.AddSingleton<ITraceSessionListenerFactory, TraceSessionListenerFactory>();

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/TestsBase.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/TestsBase.cs
@@ -97,6 +97,11 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             roleInstanceSourceMock.Setup(role => role.CloudRoleInstance).Returns("testCloudRoleInstance");
             serviceCollection.AddSingleton<IRoleInstanceSource>(_ => roleInstanceSourceMock.Object);
 
+            // Application version source
+            Mock<IAppVersionSource> appVersionSourceMock = new();
+            appVersionSourceMock.Setup(v => v.AppVersion).Returns("1.2.3");
+            serviceCollection.AddSingleton<IAppVersionSource>(_ => appVersionSourceMock.Object);
+
             var delaySourceMock = new Mock<IDelaySource>();
             delaySourceMock.Setup(delay => delay.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
             serviceCollection.AddTransient<IDelaySource>(p => delaySourceMock.Object);

--- a/tests/ServiceProfiler.EventPipe.Client.Tests/AppVersionSourceTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Client.Tests/AppVersionSourceTests.cs
@@ -1,0 +1,78 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Client.Tests;
+
+public class AppVersionSourceTests
+{
+    [Fact]
+    public void AggregatedAppVersionSource_UsesFirstNonEmptyDetector()
+    {
+        var source = new AggregatedAppVersionSource(
+            new IAppVersionDetector[]
+            {
+                new FakeDetector(null),
+                new FakeDetector(""),
+                new FakeDetector("2.5.0"),
+                new FakeDetector("9.9.9"),
+            },
+            NullLogger<AggregatedAppVersionSource>.Instance);
+
+        Assert.Equal("2.5.0", source.AppVersion);
+    }
+
+    [Fact]
+    public void AggregatedAppVersionSource_WhenNoDetectorProvidesValue_ReturnsEmpty()
+    {
+        var source = new AggregatedAppVersionSource(
+            new IAppVersionDetector[] { new FakeDetector(null), new FakeDetector("   ") },
+            NullLogger<AggregatedAppVersionSource>.Instance);
+
+        // "   " is non-empty per IsNullOrEmpty, so it is returned as-is; verify the all-empty case:
+        var emptySource = new AggregatedAppVersionSource(
+            new IAppVersionDetector[] { new FakeDetector(null), new FakeDetector("") },
+            NullLogger<AggregatedAppVersionSource>.Instance);
+
+        Assert.Equal("   ", source.AppVersion);
+        Assert.Equal(string.Empty, emptySource.AppVersion);
+    }
+
+    [Fact]
+    public void AggregatedAppVersionSource_WhenNoDetectors_ReturnsEmpty()
+    {
+        var source = new AggregatedAppVersionSource(
+            new List<IAppVersionDetector>(),
+            NullLogger<AggregatedAppVersionSource>.Instance);
+
+        Assert.Equal(string.Empty, source.AppVersion);
+    }
+
+    [Fact]
+    public void AssemblyAppVersionDetector_WithNullAssembly_ReturnsNull()
+    {
+        var detector = new AssemblyAppVersionDetector((Assembly?)null);
+        Assert.Null(detector.GetAppVersion());
+    }
+
+    [Fact]
+    public void AssemblyAppVersionDetector_WithRealAssembly_ReturnsNonEmptyVersion()
+    {
+        var detector = new AssemblyAppVersionDetector(typeof(AggregatedAppVersionSource).Assembly);
+        Assert.False(string.IsNullOrEmpty(detector.GetAppVersion()));
+    }
+
+    private sealed class FakeDetector : IAppVersionDetector
+    {
+        private readonly string? _version;
+        public FakeDetector(string? version) => _version = version;
+        public string? GetAppVersion() => _version;
+    }
+}

--- a/tests/ServiceProfiler.EventPipe.Client.Tests/CustomEventsBuilderAppVersionTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Client.Tests/CustomEventsBuilderAppVersionTests.cs
@@ -1,0 +1,72 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
+using Microsoft.ApplicationInsights.Profiler.Shared.Contracts.CustomEvents;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.ServiceProfiler.Orchestration;
+using Moq;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Client.Tests;
+
+public class CustomEventsBuilderAppVersionTests
+{
+    [Fact]
+    public void CreateServiceProfilerIndex_SetsAppVersion()
+    {
+        CustomEventsBuilder builder = CreateBuilder("4.5.6");
+
+        ServiceProfilerIndex index = builder.CreateServiceProfilerIndex(
+            stampId: "stamp",
+            sessionId: DateTimeOffset.UtcNow,
+            appId: Guid.NewGuid(),
+            artifactId: Guid.NewGuid(),
+            profilerSource: Mock.Of<IProfilerSource>(s => s.Source == "TestSource"),
+            averageCPUUsage: 1,
+            averageMemoryUsage: 2);
+
+        Assert.Equal("4.5.6", index.AppVersion);
+    }
+
+    [Fact]
+    public void CreateServiceProfilerSamples_SetsAppVersion()
+    {
+        CustomEventsBuilder builder = CreateBuilder("4.5.6");
+
+        SampleActivity sample = new()
+        {
+            StartActivityIdPath = "/1/",
+            StopActivityIdPath = "/1/",
+            StartTimeUtc = DateTimeOffset.UtcNow,
+            StopTimeUtc = DateTimeOffset.UtcNow.AddSeconds(1),
+            RequestId = "req-1",
+            OperationId = "op-1",
+            OperationName = "GET /",
+        };
+
+        ServiceProfilerSample result = builder.CreateServiceProfilerSamples(
+            new[] { sample }, "stamp", DateTimeOffset.UtcNow, Guid.NewGuid(), Guid.NewGuid()).Single();
+
+        Assert.Equal("4.5.6", result.AppVersion);
+    }
+
+    private static CustomEventsBuilder CreateBuilder(string appVersion)
+    {
+        Mock<IAppVersionSource> appVersionSource = new();
+        appVersionSource.Setup(v => v.AppVersion).Returns(appVersion);
+
+        return new CustomEventsBuilder(
+            Mock.Of<IServiceProfilerContext>(),
+            Mock.Of<IRoleNameSource>(s => s.CloudRoleName == "role"),
+            Mock.Of<IRoleInstanceSource>(s => s.CloudRoleInstance == "instance"),
+            appVersionSource.Object,
+            NullLogger<CustomEventsBuilder>.Instance);
+    }
+}

--- a/tests/ServiceProfiler.EventPipe.Client.Tests/TestsBase.cs
+++ b/tests/ServiceProfiler.EventPipe.Client.Tests/TestsBase.cs
@@ -79,6 +79,11 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             roleInstanceSourceMock.Setup(role => role.CloudRoleInstance).Returns("testCloudRoleInstance");
             serviceCollection.AddSingleton<IRoleInstanceSource>(_ => roleInstanceSourceMock.Object);
 
+            // Application version source
+            Mock<IAppVersionSource> appVersionSourceMock = new();
+            appVersionSourceMock.Setup(v => v.AppVersion).Returns("1.2.3");
+            serviceCollection.AddSingleton<IAppVersionSource>(_ => appVersionSourceMock.Object);
+
             var delaySourceMock = new Mock<IDelaySource>();
             delaySourceMock.Setup(delay => delay.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
             serviceCollection.AddTransient<IDelaySource>(p => delaySourceMock.Object);


### PR DESCRIPTION
Implements #86. Associates the **application version** with profiler trace sessions so it flows onto
the `ServiceProfilerIndex` and `ServiceProfilerSample` custom events — enabling version-based
analysis and Code Optimizations breakdown. (Related: #76, role name.)

## Design

Mirrors the existing role-name detector/source pattern (`IRoleNameDetector` →
`AggregatedRoleNameSource` → `IRoleNameSource`).

- **Shared abstractions/impl:** `IAppVersionDetector`, `IAppVersionSource`,
  `AggregatedAppVersionSource` (iterates detectors, first non-empty wins, else empty),
  `AssemblyAppVersionDetector` (entry-assembly `AssemblyInformationalVersion`, falling back to the
  assembly `Version`).
- **OTel:** `OtelResourceAppVersionDetector` reads the OpenTelemetry Resource `service.version`.
- **DI:** OTel registers `OtelResourceAppVersionDetector` (primary) + `AssemblyAppVersionDetector`
  (fallback) + `AggregatedAppVersionSource`; classic registers `AssemblyAppVersionDetector` +
  `AggregatedAppVersionSource`.
- **Contracts:** `AppVersion` added to `ServiceProfilerIndex` and `ServiceProfilerSample` (a plain
  `init` property, so it round-trips over the agent→uploader IPC like the sibling role fields).
- **Agent (`CustomEventsBuilder`):** injects `IAppVersionSource` and sets `AppVersion` (cached) on the
  index and each sample.
- **Uploader (`CustomEventsSender`):** sets `EventTelemetry.Context.Component.Version` from
  `AppVersion` (when non-empty) on both events → surfaces as the standard `application_Version` field
  that Code Optimizations breaks down by.

## Why `Context.Component.Version`

`Component.Version` maps to `ai.application.ver` / the `application_Version` column and is the
AI-native "application version" field (the SDK's default `ComponentVersionTelemetryInitializer`
populates it from the entry assembly). It's a semantic match — not a repurposed dimension — and is
recognized by downstream experiences.

## Tests

- `AppVersionSourceTests`: aggregator precedence (first non-empty wins) + empty fallback; assembly
  detector null-assembly and real-assembly cases.
- `CustomEventsBuilderAppVersionTests`: `AppVersion` flows onto the index and the sample.
- Registered `IAppVersionSource` in both client-side test `TestsBase`.

All four affected test projects pass (Client 71, App Insights profiler 48, Upload 27, OTel 83).

## Notes

- No public API surface change — all new types are internal (OTel/Core Public API analyzers pass).
- Missing/empty version → simply not set on the event.
- The `ServiceProfiler/` submodule is untouched.

## Review

Reviewed with two independent models (Claude Opus 4.8 and GPT-5.5) to **two consecutive clean
rounds** — both verified detector precedence, IPC serialization round-trip, DI resolution/lifetime,
the `CustomEventsBuilder` constructor propagation, and null/empty guarding.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>