### PR TITLE
Site extension: centralize low-baseline versions, dot-free version, NuGet compliance

### DIFF
--- a/SiteExtensionBaseline.props
+++ b/SiteExtensionBaseline.props
@@ -1,0 +1,43 @@
+<Project>
+
+  <!--
+    SINGLE SOURCE OF TRUTH for the codeless Site Extension's LOW-BASELINE package versions.
+
+    The codeless profiler is injected into a running app whose shared-framework Microsoft.Extensions.* (and,
+    for OTel apps, its own OpenTelemetry / Azure.Core) are already loaded BEFORE our HostingStartup runs. The
+    runtime can only roll an already-loaded assembly FORWARD, never backward. So the site-extension payload
+    must reference the LOWEST versions we support; those refs then roll forward to whatever the target app
+    loaded. See src/AppService.SiteExtension/SiteExtension/Build-SiteExtension.ps1 for the full rationale.
+
+    Both the local build script (Build-SiteExtension.ps1) and the DevOps pipeline
+    (.pipelines/.steps/Agent.EventPipe.Build.yml) PARSE the PropertyGroup below and pass each entry as an
+    explicit MSBuild global override, e.g.
+        dotnet publish ... -p:_OpenTelemetryVersion=1.8.1 -p:_AzureCoreVersion=1.46.1 ...
+    This is a data MANIFEST, not an imported build file. We pass explicit per-property globals (rather than a
+    single switch that flips these via an <Import>) because NuGet restore does not apply an imported-props
+    translation to project-to-project references, so a single boolean switch would only reach the entry
+    project and leave the referenced profiler projects on the repo defaults. Explicit global overrides
+    propagate to the whole restore graph. Keeping the versions here (and nowhere else) is what makes this the
+    single source of truth.
+
+    The *.Abstractions patches are pinned independently of _MicrosoftExtensionsVersion (transitive floors push
+    them above the 8.0.0 impls); Azure.Core is pinned to the documented minimum (>= 1.46.1). Values MUST be
+    literals (no $(...) references) so the script/pipeline parsers can read them.
+  -->
+  <PropertyGroup>
+    <_AzureMonitorOpenTelemetryExporterVersion>1.3.0</_AzureMonitorOpenTelemetryExporterVersion>
+    <_OpenTelemetryVersion>1.8.1</_OpenTelemetryVersion>
+    <_MicrosoftExtensionsVersion>8.0.0</_MicrosoftExtensionsVersion>
+    <_MicrosoftExtensionsOptionsVersion>8.0.2</_MicrosoftExtensionsOptionsVersion>
+    <_MicrosoftExtensionsLoggingAbstractionsVersion>8.0.3</_MicrosoftExtensionsLoggingAbstractionsVersion>
+    <_MicrosoftExtensionsDependencyInjectionAbstractionsVersion>8.0.2</_MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <_SystemTextJsonVersion>8.0.6</_SystemTextJsonVersion>
+    <_SystemDiagnosticsDiagnosticSourceVersion>8.0.1</_SystemDiagnosticsDiagnosticSourceVersion>
+    <_SystemMemoryDataVersion>8.0.1</_SystemMemoryDataVersion>
+    <_SystemSecurityCryptographyProtectedDataVersion>8.0.0</_SystemSecurityCryptographyProtectedDataVersion>
+    <_SystemTextEncodingsWebVersion>8.0.0</_SystemTextEncodingsWebVersion>
+    <_SystemIOHashingVersion>8.0.0</_SystemIOHashingVersion>
+    <_AzureCoreVersion>1.46.1</_AzureCoreVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/AppService.SiteExtension/SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.SiteExtension.nuspec
+++ b/src/AppService.SiteExtension/SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.SiteExtension.nuspec
@@ -6,7 +6,8 @@
     <title>Azure Monitor Profiler (Codeless)</title>
     <authors>Microsoft</authors>
     <owners>Microsoft,MicrosoftServiceProfiler</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectUrl>https://github.com/Azure/azuremonitor-opentelemetry-profiler-net</projectUrl>
     <description>
       Codeless Azure App Service (Windows) Site Extension that enables the Azure Monitor profiler without

--- a/src/AppService.SiteExtension/SiteExtension/Build-SiteExtension.ps1
+++ b/src/AppService.SiteExtension/SiteExtension/Build-SiteExtension.ps1
@@ -41,12 +41,12 @@
     Build configuration. Default: Release.
 
 .PARAMETER Version
-    Package version. Default: 1.0.0-beta.1.
+    Package version. Default: 1.0.0-beta01.
 #>
 [CmdletBinding()]
 param(
     [string]$Configuration = "Release",
-    [string]$Version = "1.0.0-beta.1"
+    [string]$Version = "1.0.0-beta01"
 )
 
 $ErrorActionPreference = "Stop"
@@ -88,31 +88,19 @@ $uploaderFramework = "net8.0"
 # Requirement this imposes on target apps: OpenTelemetry >= 1.8.1 and Azure.Core >= ~1.46 (documented).
 $baselineFramework = "net8.0"
 
-# Version-property overrides for the low baseline. Defaults are unchanged for the shipped profiler NuGet;
-# these only apply to this site-extension publish. The *.Abstractions packages need higher servicing patches
-# than their impls (capped at 8.0.1) due to transitive floors, so they are pinned independently (build-time
-# floors only; the app's 8.0.x framework satisfies them at runtime).
-$baselineOverrides = @{
-    "_AzureMonitorOpenTelemetryExporterVersion"                  = "1.3.0"
-    "_OpenTelemetryVersion"                                      = "1.8.1"
-    "_MicrosoftExtensionsVersion"                                = "8.0.0"
-    "_MicrosoftExtensionsOptionsVersion"                         = "8.0.2"
-    "_MicrosoftExtensionsLoggingAbstractionsVersion"             = "8.0.3"
-    "_MicrosoftExtensionsDependencyInjectionAbstractionsVersion" = "8.0.2"
-    "_SystemTextJsonVersion"                                     = "8.0.6"
-    "_SystemDiagnosticsDiagnosticSourceVersion"                  = "8.0.1"
-    "_SystemMemoryDataVersion"                                   = "8.0.1"
-    "_SystemSecurityCryptographyProtectedDataVersion"           = "8.0.0"
-    "_SystemTextEncodingsWebVersion"                             = "8.0.0"
-    "_SystemIOHashingVersion"                                    = "8.0.0"
-    # Azure.Core is a direct reference of the OpenTelemetry profiler; down-level it too so the payload's
-    # floor matches the documented minimum (>= 1.46.1). 1.46.1 is the lowest the graph allows - Azure.Identity
-    # 1.14.0 floors Azure.Core at 1.46.1. Without this the payload would ship the repo-default 1.50, silently
-    # raising the real floor above what the README documents and breaking apps on Azure.Core 1.46-1.49.
-    "_AzureCoreVersion"                                          = "1.46.1"
-}
+# Version-property overrides for the low baseline live in ONE place: the repo-root
+# SiteExtensionBaseline.props manifest. Parse it here and pass each entry as an explicit MSBuild global
+# override, so the version list is never duplicated between this script and the DevOps pipeline. Explicit
+# globals (rather than a single switch translated via an <Import>) are required because NuGet restore does
+# not apply an imported-props translation to project-to-project references. See SiteExtensionBaseline.props.
+$baselineManifest = Join-Path $repoRoot "SiteExtensionBaseline.props"
+if (-not (Test-Path $baselineManifest)) { throw "Baseline manifest not found at $baselineManifest." }
+[xml]$baselineXml = Get-Content -Raw -Path $baselineManifest
 $baselineArgs = @()
-foreach ($kvp in $baselineOverrides.GetEnumerator()) { $baselineArgs += "-p:$($kvp.Key)=$($kvp.Value)" }
+foreach ($node in $baselineXml.Project.PropertyGroup.ChildNodes) {
+    if ($node.NodeType -eq 'Element') { $baselineArgs += "-p:$($node.Name)=$($node.InnerText.Trim())" }
+}
+if ($baselineArgs.Count -eq 0) { throw "No baseline version properties parsed from $baselineManifest." }
 
 function Invoke-Checked([string]$description, [scriptblock]$action) {
     Write-Host "==> $description" -ForegroundColor Cyan

--- a/src/AppService.SiteExtension/SiteExtension/README.md
+++ b/src/AppService.SiteExtension/SiteExtension/README.md
@@ -136,7 +136,7 @@ versions its own StartupHook path (`…\ApplicationInsightsAgent\<version>\core\
 ## Building the package
 
 ```powershell
-pwsh ./Build-SiteExtension.ps1 -Configuration Release -Version 1.0.0-beta.1
+pwsh ./Build-SiteExtension.ps1 -Configuration Release -Version 1.0.0-beta01
 ```
 
 This publishes the stack-agnostic router + resolver hook into `staging/payload/<version>/`, each profiler
@@ -237,8 +237,8 @@ delivery differs.
 **Build the Linux payload zip** (produced by the same build):
 
 ```powershell
-pwsh ./Build-SiteExtension.ps1 -Configuration Release -Version 1.0.0-beta.1
-# -> <repo>/Out/Linux/AzureMonitorProfiler.1.0.0-beta.1.zip
+pwsh ./Build-SiteExtension.ps1 -Configuration Release -Version 1.0.0-beta01
+# -> <repo>/Out/Linux/AzureMonitorProfiler.1.0.0-beta01.zip
 ```
 
 **Enable** (pick either script — identical behavior; `pwsh` runs on Linux/macOS/Windows, so neither is


### PR DESCRIPTION
## Summary

Source-side improvements to the codeless Windows App Service **site extension** (from #167), developed and validated while wiring up its official build pipeline:

### 1. Single source of truth for the LOW-BASELINE versions
The 13 low-baseline package versions used to publish the site-extension payload were duplicated (script + build tooling). They now live in one repo-root manifest, **`SiteExtensionBaseline.props`**. `Build-SiteExtension.ps1` parses that manifest and passes each entry as an explicit `-p:_Xxx=value` MSBuild global.

> We pass explicit per-version globals rather than a single boolean switch translated via a `Directory.Packages.props` `<Import>`, because **NuGet restore does not apply an imported-props translation to project-to-project references** — a switch reaches only the entry project and leaves the referenced profiler projects on the repo defaults (NU1605/NU1109 downgrades). Explicit globals propagate across the whole restore graph. The repo `Directory.Packages.props` files are unchanged, so normal profiler builds are unaffected.

### 2. Dot-free default package version
Default changed from `1.0.0-beta.1` to **`1.0.0-beta01`** — site-extension version handling does not accept dots in the prerelease suffix.

### 3. NuGet.org metadata compliance for the site-extension package
- Add the required copyright: `© Microsoft Corporation. All rights reserved.`
- Set `requireLicenseAcceptance` to `true` (matching the shipping `Azure.Monitor.OpenTelemetry.Profiler` package).

## Files
- `SiteExtensionBaseline.props` (new)
- `src/AppService.SiteExtension/SiteExtension/Build-SiteExtension.ps1`
- `src/AppService.SiteExtension/SiteExtension/README.md`
- `src/AppService.SiteExtension/SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.SiteExtension.nuspec`

## Validation
- Parsed manifest → 13 explicit `-p:` args; clean-obj restores of both the OpenTelemetry and classic activators succeed (no NU1605/NU1109).
- The official site-extension build packs, Authenticode-signs (including the unsigned third-party `OpenTelemetry.PersistentStorage.*` DLLs), and passes Guardian CodeSign; the resulting package meets the NuGet.org metadata requirements above.

## Notes
The corresponding build-pipeline definitions are internal-only and are not part of this PR.
