### PR TITLE
Emit an early, actionable connection-string diagnostic at profiler startup (#178)

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ConnectionStringDiagnostics.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ConnectionStringDiagnostics.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+
+namespace Microsoft.ApplicationInsights.Profiler.Shared.Services;
+
+/// <summary>
+/// Maps a <see cref="ConnectionStringValidationResult"/> to an actionable diagnostic message.
+/// Shared by the early startup pre-check (<c>ProfilerBackgroundService</c>) and the profiler
+/// bootstrap so the wording stays consistent and defined in one place.
+/// </summary>
+internal static class ConnectionStringDiagnostics
+{
+    /// <summary>Suffix appended to an error to state the profiler will not start.</summary>
+    public const string ProfilerWontStartSuffix = " Application Insights Profiler won't start.";
+
+    /// <summary>
+    /// A hint that the Azure Monitor exporter itself requires a connection string. Without one the
+    /// exporter throws while building its telemetry providers and faults application startup - a
+    /// failure that originates in the exporter, not the profiler.
+    /// </summary>
+    public const string ExporterConnectionStringHint =
+        " Note: the Azure Monitor exporter also requires a valid connection string; if none is configured " +
+        "(via APPLICATIONINSIGHTS_CONNECTION_STRING or UseAzureMonitor(...)) it will fail application startup.";
+
+    private const string NoConnectionStringMessage = "No connection string is set.";
+    private const string InstrumentationKeyMessage = "Instrumentation key is not set or malformed in the connection string.";
+
+    /// <summary>
+    /// Returns an actionable error message describing why the connection string is unusable, or
+    /// <see langword="null"/> when it is valid.
+    /// </summary>
+    public static string? GetConfigurationError(ConnectionStringValidationResult validation) => validation switch
+    {
+        ConnectionStringValidationResult.Valid => null,
+        ConnectionStringValidationResult.NotConfigured => NoConnectionStringMessage,
+        ConnectionStringValidationResult.Empty => "The connection string is empty.",
+        ConnectionStringValidationResult.InvalidInstrumentationKey => InstrumentationKeyMessage,
+        ConnectionStringValidationResult.Malformed => "The connection string is malformed and could not be parsed. Verify the connection string and that it contains a valid instrumentation key.",
+        _ => "The connection string is invalid.",
+    };
+}

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerBackgroundService.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerBackgroundService.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,15 +19,18 @@ internal class ProfilerBackgroundService : BackgroundService
 {
     private readonly IServiceProfilerAgentBootstrap _bootstrap;
     private readonly IServiceProfilerContext _serviceProfilerContext;
+    private readonly UserConfigurationBase _userConfiguration;
     private readonly ILogger<ProfilerBackgroundService> _logger;
 
     public ProfilerBackgroundService(
         IServiceProfilerAgentBootstrap bootstrap,
         IServiceProfilerContext serviceProfilerContext,
+        IOptions<UserConfigurationBase> userConfiguration,
         ILogger<ProfilerBackgroundService> logger)
     {
         _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
         _serviceProfilerContext = serviceProfilerContext ?? throw new ArgumentNullException(nameof(serviceProfilerContext));
+        _userConfiguration = userConfiguration?.Value ?? throw new ArgumentNullException(nameof(userConfiguration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -55,6 +60,14 @@ internal class ProfilerBackgroundService : BackgroundService
     {
         try
         {
+            // Only warn about the connection string when the profiler would otherwise start. When it is
+            // disabled by configuration, a missing connection string is irrelevant to the profiler, and
+            // an error here would be misleading (the profiler is off, not misconfigured).
+            if (_userConfiguration.IsDisabled)
+            {
+                return;
+            }
+
             string? error = ConnectionStringDiagnostics.GetConfigurationError(_serviceProfilerContext.ConnectionStringValidation);
             if (error is not null)
             {

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerBackgroundService.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ProfilerBackgroundService.cs
@@ -16,13 +16,16 @@ namespace Microsoft.ApplicationInsights.Profiler.Shared.Services;
 internal class ProfilerBackgroundService : BackgroundService
 {
     private readonly IServiceProfilerAgentBootstrap _bootstrap;
+    private readonly IServiceProfilerContext _serviceProfilerContext;
     private readonly ILogger<ProfilerBackgroundService> _logger;
 
     public ProfilerBackgroundService(
         IServiceProfilerAgentBootstrap bootstrap,
+        IServiceProfilerContext serviceProfilerContext,
         ILogger<ProfilerBackgroundService> logger)
     {
         _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
+        _serviceProfilerContext = serviceProfilerContext ?? throw new ArgumentNullException(nameof(serviceProfilerContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -34,5 +37,38 @@ internal class ProfilerBackgroundService : BackgroundService
         await _bootstrap.ActivateAsync(stoppingToken).ConfigureAwait(false);
 
         _logger.LogDebug("Profiler bootstrap finished.");
+    }
+
+    public override Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Emit the connection-string diagnostic synchronously here (before ExecuteAsync), so a clear,
+        // actionable message is logged as early as possible - even if something else faults host
+        // startup shortly after, for example the Azure Monitor exporter, which throws while building its
+        // telemetry providers when no connection string is configured. This runs on the host-startup
+        // thread, and this profiler background service is not always wrapped in a fail-safe host-service
+        // wrapper (the classic profiler registers it directly), so it must never throw.
+        LogConnectionStringDiagnostic();
+        return base.StartAsync(cancellationToken);
+    }
+
+    private void LogConnectionStringDiagnostic()
+    {
+        try
+        {
+            string? error = ConnectionStringDiagnostics.GetConfigurationError(_serviceProfilerContext.ConnectionStringValidation);
+            if (error is not null)
+            {
+                _logger.LogError(
+                    "{error}{profilerWontStart}{exporterHint}",
+                    error,
+                    ConnectionStringDiagnostics.ProfilerWontStartSuffix,
+                    ConnectionStringDiagnostics.ExporterConnectionStringHint);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Diagnostics must never fault host startup.
+            _logger.LogDebug(ex, "Failed to evaluate the connection-string diagnostic at startup.");
+        }
     }
 }

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerAgentBootstrap.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/ServiceProfilerAgentBootstrap.cs
@@ -82,11 +82,13 @@ internal class ServiceProfilerAgentBootstrap : IServiceProfilerAgentBootstrap
 
         try
         {
-            // Diagnose the connection string state to provide an actionable error message.
-            string? connectionStringError = GetConnectionStringConfigurationError();
+            // Diagnose the connection string state. The early startup pre-check in
+            // ProfilerBackgroundService already logged an actionable error for this case, so keep this
+            // path at debug to avoid a duplicate error while still gating activation.
+            string? connectionStringError = ConnectionStringDiagnostics.GetConfigurationError(_serviceProfilerContext.ConnectionStringValidation);
             if (connectionStringError is not null)
             {
-                _logger.LogError(connectionStringError + ProfilerWontStartSuffix);
+                _logger.LogDebug(connectionStringError + ConnectionStringDiagnostics.ProfilerWontStartSuffix);
                 Activated(false);
                 return;
             }
@@ -106,7 +108,7 @@ internal class ServiceProfilerAgentBootstrap : IServiceProfilerAgentBootstrap
         catch (ArgumentNullException ex) when (string.Equals(ex.ParamName, "instrumentationKey", StringComparison.OrdinalIgnoreCase))
         {
             Debug.Fail("You hit the safety net! How could it escape the instrumentation key check?");
-            _logger.LogError(NoConnectionStringMessage + ProfilerWontStartSuffix);
+            _logger.LogError(ConnectionStringDiagnostics.GetConfigurationError(ConnectionStringValidationResult.NotConfigured) + ConnectionStringDiagnostics.ProfilerWontStartSuffix);
             Activated(false);
             return;
         }
@@ -126,22 +128,4 @@ internal class ServiceProfilerAgentBootstrap : IServiceProfilerAgentBootstrap
     {
         _bootstrapState.SetProfilerRunning(isRunning);
     }
-
-    private const string ProfilerWontStartSuffix = " Application Insights Profiler won't start.";
-    private const string NoConnectionStringMessage = "No connection string is set.";
-    private const string InstrumentationKeyMessage = "Instrumentation key is not set or malformed in the connection string.";
-
-    /// <summary>
-    /// Maps the connection string validation result to an actionable error message
-    /// describing why the profiler cannot start, or <see langword="null"/> when it is valid.
-    /// </summary>
-    private string? GetConnectionStringConfigurationError() => _serviceProfilerContext.ConnectionStringValidation switch
-    {
-        ConnectionStringValidationResult.Valid => null,
-        ConnectionStringValidationResult.NotConfigured => NoConnectionStringMessage,
-        ConnectionStringValidationResult.Empty => "The connection string is empty.",
-        ConnectionStringValidationResult.InvalidInstrumentationKey => InstrumentationKeyMessage,
-        ConnectionStringValidationResult.Malformed => "The connection string is malformed and could not be parsed. Verify the connection string and that it contains a valid instrumentation key.",
-        _ => "The connection string is invalid.",
-    };
 }

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerAgentBootstrapTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerAgentBootstrapTests.cs
@@ -96,7 +96,7 @@ public class ServiceProfilerAgentBootstrapTests
         orchestratorMock.Verify(o => o.StartAsync(It.IsAny<CancellationToken>()), Times.Never);
 
         bool running = bootstrapState.IsProfilerRunning(CancellationToken.None);
-        return (logger.LastError, running);
+        return (logger.LastMessage, running);
     }
 
     private sealed class TestUserConfiguration : UserConfigurationBase
@@ -105,7 +105,11 @@ public class ServiceProfilerAgentBootstrapTests
 
     private sealed class TestLogger : ILogger<ServiceProfilerAgentBootstrap>
     {
-        public string? LastError { get; private set; }
+        // Captures the last logged message regardless of level. The connection-string reason is logged
+        // by the bootstrap at Debug (the authoritative Error-level diagnostic is emitted earlier by
+        // ProfilerBackgroundService); these tests verify the bootstrap still surfaces the reason and
+        // disables profiling for each validation result.
+        public string? LastMessage { get; private set; }
 
         public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
 
@@ -113,10 +117,7 @@ public class ServiceProfilerAgentBootstrapTests
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
-            if (logLevel == LogLevel.Error)
-            {
-                LastError = formatter(state, exception);
-            }
+            LastMessage = formatter(state, exception);
         }
 
         private sealed class NullScope : IDisposable

--- a/tests/ServiceProfiler.EventPipe.Client.Tests/ConnectionStringDiagnosticsTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Client.Tests/ConnectionStringDiagnosticsTests.cs
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using Microsoft.ApplicationInsights.Profiler.Shared.Services;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Client.Tests;
+
+public class ConnectionStringDiagnosticsTests
+{
+    [Fact]
+    public void Valid_ReturnsNull()
+        => Assert.Null(ConnectionStringDiagnostics.GetConfigurationError(ConnectionStringValidationResult.Valid));
+
+    [Fact]
+    public void Invalid_ReturnsNonEmptyMessage()
+    {
+        ConnectionStringValidationResult[] invalid =
+        {
+            ConnectionStringValidationResult.NotConfigured,
+            ConnectionStringValidationResult.Empty,
+            ConnectionStringValidationResult.InvalidInstrumentationKey,
+            ConnectionStringValidationResult.Malformed,
+        };
+
+        foreach (ConnectionStringValidationResult validation in invalid)
+        {
+            Assert.False(string.IsNullOrEmpty(ConnectionStringDiagnostics.GetConfigurationError(validation)));
+        }
+    }
+}

--- a/tests/ServiceProfiler.EventPipe.Client.Tests/ProfilerBackgroundServiceTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Client.Tests/ProfilerBackgroundServiceTests.cs
@@ -7,9 +7,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.Profiler.Shared.Contracts;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services;
 using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -17,6 +19,31 @@ namespace ServiceProfiler.EventPipe.Client.Tests;
 
 public class ProfilerBackgroundServiceTests
 {
+    private sealed class TestUserConfiguration : UserConfigurationBase
+    {
+    }
+
+    private static ProfilerBackgroundService CreateService(
+        CapturingLogger logger,
+        ConnectionStringValidationResult validation,
+        bool isDisabled = false,
+        bool throwOnValidation = false)
+    {
+        var bootstrap = new Mock<IServiceProfilerAgentBootstrap>();
+        var context = new Mock<IServiceProfilerContext>();
+        if (throwOnValidation)
+        {
+            context.SetupGet(c => c.ConnectionStringValidation).Throws(new InvalidOperationException("boom"));
+        }
+        else
+        {
+            context.SetupGet(c => c.ConnectionStringValidation).Returns(validation);
+        }
+
+        IOptions<UserConfigurationBase> options = Options.Create<UserConfigurationBase>(new TestUserConfiguration { IsDisabled = isDisabled });
+        return new ProfilerBackgroundService(bootstrap.Object, context.Object, options, logger);
+    }
+
     [Fact]
     public async Task InvalidConnectionString_LogsActionableErrorEarly()
     {
@@ -31,11 +58,7 @@ public class ProfilerBackgroundServiceTests
         foreach ((ConnectionStringValidationResult validation, string expectedFragment) in cases)
         {
             var logger = new CapturingLogger();
-            var bootstrap = new Mock<IServiceProfilerAgentBootstrap>();
-            var context = new Mock<IServiceProfilerContext>();
-            context.SetupGet(c => c.ConnectionStringValidation).Returns(validation);
-
-            var service = new ProfilerBackgroundService(bootstrap.Object, context.Object, logger);
+            ProfilerBackgroundService service = CreateService(logger, validation);
             await service.StartAsync(CancellationToken.None);
             await service.StopAsync(CancellationToken.None);
 
@@ -50,11 +73,20 @@ public class ProfilerBackgroundServiceTests
     public async Task ValidConnectionString_LogsNoError()
     {
         var logger = new CapturingLogger();
-        var bootstrap = new Mock<IServiceProfilerAgentBootstrap>();
-        var context = new Mock<IServiceProfilerContext>();
-        context.SetupGet(c => c.ConnectionStringValidation).Returns(ConnectionStringValidationResult.Valid);
+        ProfilerBackgroundService service = CreateService(logger, ConnectionStringValidationResult.Valid);
+        await service.StartAsync(CancellationToken.None);
+        await service.StopAsync(CancellationToken.None);
 
-        var service = new ProfilerBackgroundService(bootstrap.Object, context.Object, logger);
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    [Fact]
+    public async Task DisabledProfiler_LogsNoConnectionStringError()
+    {
+        // When the profiler is disabled by configuration, a missing connection string is irrelevant to
+        // the profiler and must not produce an error (which would be misleading and could trip alerts).
+        var logger = new CapturingLogger();
+        ProfilerBackgroundService service = CreateService(logger, ConnectionStringValidationResult.NotConfigured, isDisabled: true);
         await service.StartAsync(CancellationToken.None);
         await service.StopAsync(CancellationToken.None);
 
@@ -65,11 +97,7 @@ public class ProfilerBackgroundServiceTests
     public async Task ContextValidationThrows_DoesNotFaultStartup()
     {
         var logger = new CapturingLogger();
-        var bootstrap = new Mock<IServiceProfilerAgentBootstrap>();
-        var context = new Mock<IServiceProfilerContext>();
-        context.SetupGet(c => c.ConnectionStringValidation).Throws(new InvalidOperationException("boom"));
-
-        var service = new ProfilerBackgroundService(bootstrap.Object, context.Object, logger);
+        ProfilerBackgroundService service = CreateService(logger, ConnectionStringValidationResult.NotConfigured, throwOnValidation: true);
 
         // The early diagnostic must never fault host startup (the classic profiler has no
         // SafeProfilerHostedService wrapper).

--- a/tests/ServiceProfiler.EventPipe.Client.Tests/ProfilerBackgroundServiceTests.cs
+++ b/tests/ServiceProfiler.EventPipe.Client.Tests/ProfilerBackgroundServiceTests.cs
@@ -1,0 +1,96 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services;
+using Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace ServiceProfiler.EventPipe.Client.Tests;
+
+public class ProfilerBackgroundServiceTests
+{
+    [Fact]
+    public async Task InvalidConnectionString_LogsActionableErrorEarly()
+    {
+        (ConnectionStringValidationResult Validation, string Fragment)[] cases =
+        {
+            (ConnectionStringValidationResult.NotConfigured, "No connection string is set"),
+            (ConnectionStringValidationResult.Empty, "connection string is empty"),
+            (ConnectionStringValidationResult.InvalidInstrumentationKey, "Instrumentation key"),
+            (ConnectionStringValidationResult.Malformed, "malformed"),
+        };
+
+        foreach ((ConnectionStringValidationResult validation, string expectedFragment) in cases)
+        {
+            var logger = new CapturingLogger();
+            var bootstrap = new Mock<IServiceProfilerAgentBootstrap>();
+            var context = new Mock<IServiceProfilerContext>();
+            context.SetupGet(c => c.ConnectionStringValidation).Returns(validation);
+
+            var service = new ProfilerBackgroundService(bootstrap.Object, context.Object, logger);
+            await service.StartAsync(CancellationToken.None);
+            await service.StopAsync(CancellationToken.None);
+
+            (LogLevel Level, string Message) error = Assert.Single(logger.Entries.Where(e => e.Level == LogLevel.Error));
+            Assert.Contains(expectedFragment, error.Message);
+            // Includes the actionable hint that the Azure Monitor exporter also needs a connection string.
+            Assert.Contains("Azure Monitor exporter", error.Message);
+        }
+    }
+
+    [Fact]
+    public async Task ValidConnectionString_LogsNoError()
+    {
+        var logger = new CapturingLogger();
+        var bootstrap = new Mock<IServiceProfilerAgentBootstrap>();
+        var context = new Mock<IServiceProfilerContext>();
+        context.SetupGet(c => c.ConnectionStringValidation).Returns(ConnectionStringValidationResult.Valid);
+
+        var service = new ProfilerBackgroundService(bootstrap.Object, context.Object, logger);
+        await service.StartAsync(CancellationToken.None);
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    [Fact]
+    public async Task ContextValidationThrows_DoesNotFaultStartup()
+    {
+        var logger = new CapturingLogger();
+        var bootstrap = new Mock<IServiceProfilerAgentBootstrap>();
+        var context = new Mock<IServiceProfilerContext>();
+        context.SetupGet(c => c.ConnectionStringValidation).Throws(new InvalidOperationException("boom"));
+
+        var service = new ProfilerBackgroundService(bootstrap.Object, context.Object, logger);
+
+        // The early diagnostic must never fault host startup (the classic profiler has no
+        // SafeProfilerHostedService wrapper).
+        Exception ex = await Record.ExceptionAsync(() => service.StartAsync(CancellationToken.None));
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Null(ex);
+    }
+
+    private sealed class CapturingLogger : ILogger<ProfilerBackgroundService>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+        public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
Addresses #178 ("[Regression] Connection string check shouldn't fail the app").

## Investigation finding (important)

I reproduced the reported crash with a control test. The exception in the issue
(`AzureMonitorMetricExporter..ctor` → `AzureMonitorTransmitter.InitializeConnectionVars` → "A
connection string was not found", thrown while building the MeterProvider) reproduces **identically
with and without the profiler**. It is the **Azure Monitor exporter/distro** refusing to initialize
when no connection string is configured — **not** caused by the profiler, and the profiler cannot
prevent it. (Resolving the profiler's own options and role-name/`TracerProvider` path did **not**
throw.)

So this is **not** a crash fix — the exporter still requires a connection string. It is a
**diagnostics improvement**: the profiler already disables itself gracefully on a bad connection
string, but that ran in the deferred background bootstrap (after `await Task.Yield()`), so the
exporter's crash could preempt the profiler's clear message and the user only saw the raw exception.

## Change

- **Shared `ConnectionStringDiagnostics`** — maps `ConnectionStringValidationResult` to an actionable
  message, and adds a hint that the Azure Monitor **exporter** also requires a connection string and
  will otherwise fail application startup.
- **`ProfilerBackgroundService`** — overrides `StartAsync` to log the connection-string diagnostic
  **synchronously and early** (before `ExecuteAsync`), **wrapped in try/catch so it can never throw**.
  It is suppressed when the profiler is disabled (`IsDisabled`), matching the bootstrap's own gate.
- **`ServiceProfilerAgentBootstrap`** — reuses the shared helper; its connection-string reason is now
  logged at Debug (the early path owns the Error-level message) to avoid duplicate errors. It still
  gates activation.

## Classic profiler

The **classic** profiler uses the AI SDK 2.x (not the Azure Monitor exporter), so it does **not** hit
this crash (the SDK tolerates a missing connection string). But it registers
`ProfilerBackgroundService` **directly** (not wrapped in `SafeProfilerHostedService` like OTel), so
the early diagnostic is deliberately **fail-safe** (try/catch) to ensure it can never crash the
classic host either. This change is shared, so both profilers get the clearer diagnostic.

## Tests

- `ProfilerBackgroundServiceTests`: early actionable error (incl. exporter hint) per invalid
  validation result; **no error when disabled**; **fail-safe when `ConnectionStringValidation`
  throws**; no error when valid.
- `ConnectionStringDiagnosticsTests`: mapping (valid → null; invalid → non-empty).
- Updated `ServiceProfilerAgentBootstrapTests` for the Debug-level reason.

Classic Client 78/78, App Insights profiler 59/59, OTel 91/91 pass.

## Notes

- No public API change (internal wiring). Submodule untouched. The diagnostic never throws.
- Ordering vs. the exporter's hosted service isn't guaranteed; this maximizes the chance (and
  guarantees, whenever the profiler's hosted service starts) that a clear, actionable message is
  emitted to explain the failure.

## Review

Reviewed with two independent models (Claude Opus 4.8 and GPT-5.5) to **two consecutive clean
rounds**; a round-1 finding (a *disabled* profiler would have emitted a misleading error) was fixed
by gating the diagnostic on `!IsDisabled`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>