### PR TITLE
Fix ObjectDisposedException on profiler stop during shutdown (#177)

### DIFF
--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/OpenTelemetryProfilerProvider.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/OpenTelemetryProfilerProvider.cs
@@ -32,6 +32,10 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
 
     private TraceSessionListener? _listener;
 
+    // Set once Dispose() has run (e.g. during host shutdown). Used to short-circuit the
+    // semaphore release so a stop racing with disposal does not touch a disposed semaphore.
+    private volatile bool _disposed;
+
     /// <inheritdoc />
     public bool IsProfilerRunning => _singleProfilingSemaphore.CurrentCount == 0;
     public string Source => nameof(OpenTelemetryProfilerProvider);
@@ -179,6 +183,17 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
                 semaphoreReleased = true;
             }
 
+            // If the caller cancels the stop (e.g. the scheduling policy's token is cancelled during
+            // agent deactivation / shutdown), the EventPipe session is already disabled and the
+            // semaphore released - the profiler has stopped successfully. There is no value in
+            // uploading the trace at that point, so skip the post-stop processing and report success
+            // (the stop itself succeeded; only the upload was intentionally skipped).
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug("Stop requested cancellation (likely agent deactivation / host shutdown). EventPipe disabled; skipping post-stop trace upload.");
+                return true;
+            }
+
             // Only the post-stop processing resolves services from the (possibly disposed during
             // shutdown) root IServiceProvider, so scope the ObjectDisposedException handling to just
             // this call. An ObjectDisposedException from anywhere else (e.g. DisableAsync) must still
@@ -208,6 +223,15 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
 
             return true;
         }
+        catch (OperationCanceledException ex)
+        {
+            // Cancellation is expected when the caller cancels the stop (e.g. agent deactivation or
+            // host shutdown cancels the scheduling policy's token). Log gracefully instead of as an
+            // unexpected error, but still rethrow so the caller can finish its own teardown (e.g.
+            // release the concurrency lease).
+            _logger.LogDebug(ex, "Stop profiler cancelled ({phase}).", profilerStopped ? "after EventPipe disabled" : "while disabling EventPipe");
+            throw;
+        }
         catch (Exception ex)
         {
             if (!profilerStopped)
@@ -231,15 +255,32 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
 
     public void Dispose()
     {
+        _disposed = true;
         _singleProfilingSemaphore.Dispose();
         _listener?.Dispose();
     }
 
     private void ReleaseSemaphoreForProfiling()
     {
-        if (IsProfilerRunning)
+        // The provider is a singleton IDisposable. During host shutdown its Dispose() can run
+        // concurrently with an in-flight (best-effort) stop, disposing the semaphore before this
+        // release. Treat a disposed semaphore as a graceful no-op instead of surfacing a noisy
+        // "Unexpected error after EventPipe profiler disabled" ObjectDisposedException.
+        if (_disposed)
         {
-            _singleProfilingSemaphore.Release();
+            return;
+        }
+
+        try
+        {
+            if (IsProfilerRunning)
+            {
+                _singleProfilingSemaphore.Release();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            _logger.LogDebug("Profiling semaphore already disposed (likely during host shutdown); skipping release.");
         }
     }
 }

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfilerProvider.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfilerProvider.cs
@@ -54,6 +54,10 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
     private SemaphoreSlim _singleProfilingSemaphore = new SemaphoreSlim(1, 1);
     public bool IsProfilerRunning => _singleProfilingSemaphore.CurrentCount == 0;
 
+    // Set once Dispose() has run (e.g. during host shutdown). Used to short-circuit the semaphore
+    // release so a stop racing with disposal does not touch a disposed semaphore.
+    private volatile bool _disposed;
+
     public ServiceProfilerProvider(
         IServiceProfilerContext serviceProfilerContext,
         ITraceControl traceControl,
@@ -274,9 +278,25 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
 
     private void ReleaseSemaphoreForProfiling()
     {
-        if (IsProfilerRunning)
+        // The provider is a singleton IDisposable. During host shutdown its Dispose() can run
+        // concurrently with an in-flight (best-effort) stop, disposing the semaphore before this
+        // release. Treat a disposed semaphore as a graceful no-op instead of surfacing a noisy
+        // "Unexpected error happens on stopping service profiler tracing." ObjectDisposedException.
+        if (_disposed)
         {
-            _singleProfilingSemaphore.Release();
+            return;
+        }
+
+        try
+        {
+            if (IsProfilerRunning)
+            {
+                _singleProfilingSemaphore.Release();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            _logger.LogDebug("Profiling semaphore already disposed (likely during host shutdown); skipping release.");
         }
     }
 
@@ -333,6 +353,7 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
 
     public void Dispose()
     {
+        _disposed = true;
         _singleProfilingSemaphore?.Dispose();
 
         _sessionListeners?.Dispose();

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerProviderTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/ServiceProfilerProviderTests.cs
@@ -118,6 +118,36 @@ namespace ServiceProfiler.EventPipe.Client.Tests
             }
         }
 
+        [Fact]
+        public async Task ShouldNotThrowWhenSemaphoreDisposedDuringStop()
+        {
+            // Regression test for issue #177: the provider is a singleton IDisposable. During host
+            // shutdown its Dispose() (which disposes the profiling semaphore) can run concurrently with
+            // an in-flight best-effort stop. Releasing the semaphore must then be a graceful no-op
+            // instead of surfacing an ObjectDisposedException as an unexpected stop failure.
+            ServiceProvider testServiceProvider = CreateServiceProvider(TimeSpan.FromSeconds(5), TimeSpan.Zero);
+
+            try
+            {
+                ServiceProfilerProvider target = testServiceProvider.GetRequiredService<ServiceProfilerProvider>();
+                SchedulingPolicy schedulingPolicy = testServiceProvider.GetRequiredService<SchedulingPolicy>();
+
+                await target.StartServiceProfilerAsync(schedulingPolicy, default);
+
+                // Simulate the shutdown race by disposing the provider (disposing the semaphore) before
+                // the stop releases it.
+                target.Dispose();
+
+                bool stopResult = await target.StopServiceProfilerAsync(schedulingPolicy, default);
+
+                Assert.True(stopResult);
+            }
+            finally
+            {
+                await testServiceProvider.DisposeAsync();
+            }
+        }
+
         #region Private
         private ServiceProvider CreateServiceProvider(
             TimeSpan duration,


### PR DESCRIPTION
Fixes #177. When a .NET app using the profiler is terminated (e.g. Ctrl+C), an error was logged during shutdown:

```
fail: Azure.Monitor.OpenTelemetry.Profiler.Core.OpenTelemetryProfilerProvider[0]
  Unexpected error after EventPipe profiler disabled.
  System.ObjectDisposedException: Cannot access a disposed object. Object name: 'System.Threading.SemaphoreSlim'.
    at System.Threading.SemaphoreSlim.Release(Int32 releaseCount)
    at ...OpenTelemetryProfilerProvider.ReleaseSemaphoreForProfiling()
    at ...OpenTelemetryProfilerProvider.StopServiceProfilerAsync(...)
```

## Root cause

Both profiler providers (`OpenTelemetryProfilerProvider` [OTel] and `ServiceProfilerProvider` [classic]) are singleton `IDisposable`s. During host shutdown, DI disposes the provider — disposing its `_singleProfilingSemaphore` — while a fire-and-forget best-effort stop (`OrchestratorEventPipe` teardown → `StopServiceProfilerAsync`) is still running and calls `ReleaseSemaphoreForProfiling()` → `Release()` on the now-disposed semaphore. `ReleaseSemaphoreForProfiling` was unguarded, so the `ObjectDisposedException` propagated to the outer catch and was logged as an "Unexpected error". The earlier fix in #152 only guarded the post-stop processor (disposed root `IServiceProvider`), not the semaphore release itself.

## Fix

- **Both providers:** added a `volatile bool _disposed` set first in `Dispose()` (before disposing the semaphore), and guarded `ReleaseSemaphoreForProfiling()` with a `_disposed` early-return plus a `try/catch (ObjectDisposedException)` that logs at Debug. A stop racing with disposal is now a graceful no-op rather than a noisy error. (`SemaphoreSlim.CurrentCount`, used by `IsProfilerRunning`, does not throw on a disposed instance; only `Release()` does, and it is fully covered.)
- **OTel provider — cancellation parity with the classic provider:** when the caller cancels the stop (e.g. the scheduling policy's token is cancelled on agent deactivation / shutdown), the EventPipe session is already disabled and the semaphore released, so the post-stop trace upload is skipped and the stop reports success; `OperationCanceledException` is logged at Debug instead of as an unexpected error.

## Tests

- New regression test `ServiceProfilerProviderTests.ShouldNotThrowWhenSemaphoreDisposedDuringStop` reproduces the disposal race and asserts the stop no longer surfaces the exception. It covers the identical semaphore-guard logic shared by both providers.
- Verified locally: OTel tests **91 passed**, classic AI profiler tests **60 passed**, orchestrator concurrency tests **7 passed**.

## On "why doesn't it fail faster?"

The issue also asked why the process is slow to quit. A bounded-timeout teardown was prototyped and **intentionally not included**: it gave no benefit on the disposal path (the teardown cleanup is fire-and-forget and does not block process exit), was ineffective for the classic profiler (whose `DiagnosticsClientTraceControl` ignores the cancellation token and uses a fixed 1-hour EventPipe stop timeout), and could strand the session semaphore on the agent-deactivation→reactivation path. A proper "fail faster" is a larger, separate change (proactive cooperative shutdown wired into the host stop + making the classic trace control honor cancellation) and is left as follow-up.

This change was reviewed with two independent models (GPT-5.5 and Opus 4.8) to two consecutive clean rounds.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>