### PR TITLE
Fix PowerShell 5.1 and cross-platform path issues in site-extension scripts (#176)

### DIFF
--- a/src/AppService.SiteExtension/SiteExtension/Build-SiteExtension.ps1
+++ b/src/AppService.SiteExtension/SiteExtension/Build-SiteExtension.ps1
@@ -170,7 +170,8 @@ $xdtGenerated = $xdtTemplate -replace '\{\{PAYLOAD_SUBDIR\}\}', $Version
 Set-Content -Path (Join-Path $staging "applicationHost.xdt") -Value $xdtGenerated -Encoding UTF8
 
 # 7. Pack the site extension.
-$nuget = (Get-Command nuget -ErrorAction SilentlyContinue)?.Source
+$nugetCmd = Get-Command nuget -ErrorAction SilentlyContinue
+$nuget = if ($nugetCmd) { $nugetCmd.Source } else { $null }
 if (-not $nuget) { $nuget = "C:\Program Files\NuGet\nuget.exe" }
 if (-not (Test-Path $nuget)) { throw "nuget.exe not found. Install NuGet CLI or add it to PATH." }
 

--- a/src/AppService.SiteExtension/SiteExtension/Enable-LinuxAppService.ps1
+++ b/src/AppService.SiteExtension/SiteExtension/Enable-LinuxAppService.ps1
@@ -92,7 +92,7 @@ if ($Disable) {
 
 # Resolve the payload zip and version.
 if (-not $PayloadZip) {
-    $candidate = Join-Path $PSScriptRoot "..\..\..\Out\Linux"
+    $candidate = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..', '..', '..', 'Out', 'Linux'))
     $PayloadZip = (Get-ChildItem -Path $candidate -Filter "AzureMonitorProfiler.*.zip" -ErrorAction SilentlyContinue |
         Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName)
 }


### PR DESCRIPTION
Fixes #176. Two portability defects in the codeless site-extension PowerShell scripts (flagged by the AI PR Assistant). Neither blocks the current build; this addresses the tracked follow-up. Two-line change across two files — no code, package, or public API impact.

## 1. `Build-SiteExtension.ps1` — PowerShell 5.1 parse failure

The nuget resolution used the PowerShell 7 null-conditional operator, which **fails to parse** under Windows PowerShell 5.1 (`Unexpected token '?.Source'`):

```powershell
$nuget = (Get-Command nuget -ErrorAction SilentlyContinue)?.Source
```

Replaced with a 5.1-compatible two-step assignment (the existing fallback path and `Test-Path` guard are unchanged):

```powershell
$nugetCmd = Get-Command nuget -ErrorAction SilentlyContinue
$nuget = if ($nugetCmd) { $nugetCmd.Source } else { $null }
```

## 2. `Enable-LinuxAppService.ps1` — Windows backslashes in a cross-platform default path

The default payload lookup path used Windows backslashes, which are literal filename characters (not directory separators) on Linux/macOS pwsh, so the default lookup pointed at a non-existent path:

```powershell
$candidate = Join-Path $PSScriptRoot "..\..\..\Out\Linux"
```

Replaced with a separator-agnostic construction:

```powershell
$candidate = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..', '..', '..', 'Out', 'Linux'))
```

## Validation

- Both scripts parse with **zero errors under Windows PowerShell 5.1** (5.1.26100) and **PowerShell 7** (7.6.3) via `[System.Management.Automation.Language.Parser]::ParseFile`. Confirmed the old `?.Source` syntax fails under 5.1 while the new form parses.
- The new `Path.Combine` expression resolves to `<repo>/Out/Linux` (correct separator per platform by construction).

## Acceptance (from issue)

- [x] `Build-SiteExtension.ps1` parses/runs under Windows PowerShell 5.1 and PowerShell 7.
- [x] `Enable-LinuxAppService.ps1`'s default payload path resolves correctly on Linux/macOS pwsh.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>