### PR TITLE
Use connection string instead of iKey for agent telemetry (#36)

### DIFF
--- a/src/ServiceProfiler.EventPipe.Upload/Program.cs
+++ b/src/ServiceProfiler.EventPipe.Upload/Program.cs
@@ -112,7 +112,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Uploader
             services.TryAddSingleton<IAppInsightsLogger>(provider =>
             {
                 IAppInsightsLogger logger = new EventPipeAppInsightsLogger(
-                    TelemetryConstants.ServiceProfilerAgentIKey);
+                    TelemetryConstants.ServiceProfilerAgentConnectionString);
                 UploadContext uploaderContext = provider.GetRequiredService<UploadContext>();
 
                 logger.SetCommonProperty(Constants.SessionId, uploaderContext.SessionId.ToString("o", CultureInfo.InvariantCulture));

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceCollectionExtensions.cs
@@ -101,7 +101,7 @@ internal static class ServiceCollectionExtensions
             {
                 logger.LogDebug("Sending anonymous telemetry data to Microsoft to make this product better.");
                 return new EventPipeAppInsightsLogger(
-                    TelemetryConstants.ServiceProfilerAgentIKey);
+                    TelemetryConstants.ServiceProfilerAgentConnectionString);
             }
             else
             {

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/Utilities/TelemetryConfigurationBuilder.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/Utilities/TelemetryConfigurationBuilder.cs
@@ -58,9 +58,8 @@ internal sealed class TelemetryConfigurationBuilder
         }
 
         _logger.LogDebug(
-            "TelemetryConfiguration created. Connection string: {connectionString}, iKey: {iKey}, Channel Endpoint Address: {channelEndpoint}",
+            "TelemetryConfiguration created. Connection string: {connectionString}, Channel Endpoint Address: {channelEndpoint}",
             telemetryConfiguration.ConnectionString,
-            telemetryConfiguration.InstrumentationKey,
             telemetryConfiguration.TelemetryChannel.EndpointAddress);
 
         return telemetryConfiguration;

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Logging/EventPipeAppInsightsLogger.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Logging/EventPipeAppInsightsLogger.cs
@@ -21,12 +21,12 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Logging
         private bool _isDisposed = false;
 
         /// <summary>
-        /// Creates a logger that sends telemetry using an instrumentation-key-only connection string.
-        /// This routes telemetry to the global ingestion endpoint without AAD authentication and is
-        /// intended only for Microsoft's anonymous-usage telemetry, not customer telemetry.
+        /// Creates a logger that sends telemetry using the given connection string.
+        /// This is intended for Microsoft's anonymous agent-usage telemetry (see
+        /// TelemetryConstants.ServiceProfilerAgentConnectionString), not customer telemetry.
         /// </summary>
-        public EventPipeAppInsightsLogger(Guid instrumentationKey)
-            : this(CreateInstrumentationKeyOnlyConfiguration(instrumentationKey))
+        public EventPipeAppInsightsLogger(string connectionString)
+            : this(CreateConnectionStringConfiguration(connectionString))
         {
         }
 
@@ -45,10 +45,10 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Logging
             SetCommonProperty(Constants.SdkVersion, sdkVersion);
         }
 
-        private static TelemetryConfiguration CreateInstrumentationKeyOnlyConfiguration(Guid instrumentationKey)
+        private static TelemetryConfiguration CreateConnectionStringConfiguration(string connectionString)
             => new TelemetryConfiguration
             {
-                ConnectionString = $"InstrumentationKey={instrumentationKey}",
+                ConnectionString = connectionString,
             };
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Logging
         {
             get
             {
-                return _connectionString ?? (ConnectionString.TryParse(_telemetryConfiguration.InstrumentationKey, out _connectionString) ? _connectionString : default(ConnectionString));
+                return _connectionString ?? (ConnectionString.TryParse(_telemetryConfiguration.ConnectionString, out _connectionString) ? _connectionString : default(ConnectionString));
             }
             set
             {

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Logging/TelemetryConstants.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Logging/TelemetryConstants.cs
@@ -1,8 +1,6 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //-----------------------------------------------------------------------------
-
-using System;
 
 namespace Microsoft.ApplicationInsights.Profiler.Core.Logging
 {
@@ -11,12 +9,14 @@ namespace Microsoft.ApplicationInsights.Profiler.Core.Logging
 #if DESKTOPBUILD
         // Test App Insight account.
         // Correspond to App Insight Account: sp-dev-telemetry-profiler-agent
-        public static Guid ServiceProfilerAgentIKey = new Guid("55fc42f8-b1cc-4343-9e1d-363994950358");
+        // TODO(#36): replace with the full connection string (incl. IngestionEndpoint) provided by the team.
+        public const string ServiceProfilerAgentConnectionString = "InstrumentationKey=55fc42f8-b1cc-4343-9e1d-363994950358";
 
 #else
         // Production App Insight account.
         // Correspond to App Insight Account: sp-telemetry-profiler-agent
-        public static Guid ServiceProfilerAgentIKey = new Guid("ad4481a6-e86a-4f34-bf37-35484e63016c");
+        // TODO(#36): replace with the full connection string (incl. IngestionEndpoint) provided by the team.
+        public const string ServiceProfilerAgentConnectionString = "InstrumentationKey=ad4481a6-e86a-4f34-bf37-35484e63016c";
 #endif
 
         public const string SessionStarted = "Service Profiler session started.";

--- a/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/EventPipeAppInsightsLoggerTests.cs
+++ b/tests/ServiceProfiler.EventPipe.ApplicationInsights.Profiler.Tests/EventPipeAppInsightsLoggerTests.cs
@@ -34,9 +34,9 @@ namespace ServiceProfiler.EventPipe.Client.Tests
         }
 
         [Fact]
-        public void ShouldBuildInstrumentationKeyOnlyConfigurationFromGuid()
+        public void ShouldBuildConfigurationFromConnectionString()
         {
-            using EventPipeAppInsightsLogger logger = new(TestIKey);
+            using EventPipeAppInsightsLogger logger = new($"InstrumentationKey={TestIKey}");
 
             Assert.NotNull(logger.ConnectionString);
             Assert.Equal(TestIKey, logger.ConnectionString!.InstrumentationKeyGuid);


### PR DESCRIPTION
Addresses #36 (assoc. #78) — pay down the "part of the system is still using iKey" tech debt.

> **Draft:** the code refactor is complete and validated, but the two agent-telemetry connection-string constants currently hold an interim `InstrumentationKey=<guid>` value (behavior-preserving) and **must be replaced with the real endpoint-bearing connection strings before merge** (see below).

## Finding

A full rebuild shows **no remaining iKey `CS0618`** warnings — `TelemetryConfiguration.InstrumentationKey` is not obsolete in the pinned SDK, and the iKey→connection-string migration is already largely done. The only `CS0618` left are unrelated obsolete config members (`SkipEndpointCertificateValidation`, `UploaderEnvironment`), tracked separately. So this PR is the remaining **modernization** per the issue intent.

## What changed

Per the design rule: the **FE backend API is iKey-based** (routes `api/apps/{iKey}/...`), so FE clients keep sending an **iKey parsed from the connection string** — unchanged and verified. Only **telemetry emission** is migrated to the connection string:

- **`EventPipeAppInsightsLogger`**
  - `ConnectionString` getter now reads the actual `TelemetryConfiguration.ConnectionString` instead of reconstructing one from `.InstrumentationKey`.
  - The anonymous-agent-telemetry constructor now takes a **connection string** (`EventPipeAppInsightsLogger(string)`) instead of a `Guid` iKey that was expanded into `"InstrumentationKey={iKey}"`.
- **`TelemetryConstants`**: `ServiceProfilerAgentIKey` (`Guid`) → `ServiceProfilerAgentConnectionString` (`string`).
  - ⚠️ **Interim value** is the behavior-preserving `InstrumentationKey=<guid>` form, marked `TODO(#36)`. Replace both (DESKTOPBUILD/test = `sp-dev-telemetry-profiler-agent`, prod = `sp-telemetry-profiler-agent`) with the real connection strings (incl. `IngestionEndpoint`) before merge.
- **`TelemetryConfigurationBuilder`**: debug log no longer reads the deprecated `.InstrumentationKey` (logs the connection string + channel endpoint).
- Updated call sites (`Upload/Program.cs`, classic `Client/ServiceCollectionExtensions.cs`) and the `EventPipeAppInsightsLogger` unit test.

## Validation

- `EventPipe.Profilers.All.sln` builds with **0 errors**.
- Tests pass: classic Application Insights profiler **59**, Upload **27**, Client **72**.

## Out of scope

- The non-iKey `CS0618` (`SkipEndpointCertificateValidation`, `UploaderEnvironment`).
- FE client iKey usage (correct by design — FE requires an iKey, taken from the connection string).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>