### PR TITLE
Suppress profiler activation in the Azure Functions platform host

### DIFF
--- a/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/BootstrapLog.cs
+++ b/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/BootstrapLog.cs
@@ -140,7 +140,7 @@ internal static class BootstrapLog
         return true;
     }
 
-    private static int GetProcessId()
+    internal static int GetProcessId()
     {
         try { return Environment.ProcessId; } catch { return 0; }
     }

--- a/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/DepsFileTelemetryStackDetector.cs
+++ b/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/DepsFileTelemetryStackDetector.cs
@@ -21,7 +21,7 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
 {
     private const string AzureFunctionsHostAssembly = "Microsoft.Azure.WebJobs.Script.WebHost";
     private const string FunctionsWorkerRuntimeEnvVar = "FUNCTIONS_WORKER_RUNTIME";
-    private const string DotNetIsolatedWorkerRuntime = "dotnet-isolated";
+    private const string DotNetInProcessWorkerRuntime = "dotnet";
 
     // Set by the App Service pre-installed Application Insights codeless agent (DiagnosticServices). Its
     // presence means telemetry is being instrumented at RUNTIME by the agent - which our build-time
@@ -81,22 +81,20 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
         string? entryAssemblyName = _entryAssemblyNameProvider();
         string? path = _depsFilePathProvider();
         string? functionsWorkerRuntime = _environmentVariableProvider(FunctionsWorkerRuntimeEnvVar);
-        bool isDotNetIsolatedFunctionsApp = string.Equals(
-            functionsWorkerRuntime,
-            DotNetIsolatedWorkerRuntime,
-            StringComparison.OrdinalIgnoreCase);
+        bool isOutOfProcessFunctionsApp =
+            !string.IsNullOrEmpty(functionsWorkerRuntime)
+            && !string.Equals(functionsWorkerRuntime, DotNetInProcessWorkerRuntime, StringComparison.OrdinalIgnoreCase);
         BootstrapLog.Info(
             $"Telemetry detection context: PID={_processIdProvider()}, " +
             $"entry assembly='{entryAssemblyName ?? "<unknown>"}', " +
             $".deps.json='{path ?? "<not found>"}', " +
             $"Functions worker runtime='{functionsWorkerRuntime ?? "<not set>"}'.");
 
-        // The site extension is injected at site scope, so an isolated Functions app runs this code in both
-        // the platform host and the customer's worker. Suppress the host before inspecting its telemetry
-        // dependencies. The worker inherits FUNCTIONS_WORKER_RUNTIME, so the exact host identity remains
-        // required; the runtime value distinguishes isolated apps from in-process apps where customer code
-        // runs inside this host process.
-        if (isDotNetIsolatedFunctionsApp && IsAzureFunctionsPlatformHost(entryAssemblyName))
+        // The site extension is injected at site scope, so an out-of-process Functions app runs this code in
+        // both the platform host and any managed customer worker. Suppress the host before inspecting its
+        // telemetry dependencies. Workers inherit FUNCTIONS_WORKER_RUNTIME, so exact host identity remains
+        // required; only the "dotnet" in-process model runs customer code inside this host process.
+        if (isOutOfProcessFunctionsApp && IsAzureFunctionsPlatformHost(entryAssemblyName))
         {
             BootstrapLog.Info("Detected the Azure Functions platform host process; profiler activation is intentionally suppressed in this process.");
             return TelemetryStack.AzureFunctionsPlatformHost;
@@ -115,7 +113,7 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
             return TelemetryStack.None;
         }
 
-        if (isDotNetIsolatedFunctionsApp && ContainsExactPackage(content!, AzureFunctionsHostAssembly))
+        if (isOutOfProcessFunctionsApp && ContainsExactPackage(content!, AzureFunctionsHostAssembly))
         {
             BootstrapLog.Info("The selected .deps.json belongs to the Azure Functions platform host; profiler activation is intentionally suppressed in this process.");
             return TelemetryStack.AzureFunctionsPlatformHost;

--- a/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/DepsFileTelemetryStackDetector.cs
+++ b/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/DepsFileTelemetryStackDetector.cs
@@ -20,6 +20,8 @@ namespace Azure.Monitor.OpenTelemetry.Profiler.HostingStartup;
 internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
 {
     private const string AzureFunctionsHostAssembly = "Microsoft.Azure.WebJobs.Script.WebHost";
+    private const string FunctionsWorkerRuntimeEnvVar = "FUNCTIONS_WORKER_RUNTIME";
+    private const string DotNetIsolatedWorkerRuntime = "dotnet-isolated";
 
     // Set by the App Service pre-installed Application Insights codeless agent (DiagnosticServices). Its
     // presence means telemetry is being instrumented at RUNTIME by the agent - which our build-time
@@ -78,15 +80,23 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
     {
         string? entryAssemblyName = _entryAssemblyNameProvider();
         string? path = _depsFilePathProvider();
+        string? functionsWorkerRuntime = _environmentVariableProvider(FunctionsWorkerRuntimeEnvVar);
+        bool isDotNetIsolatedFunctionsApp = string.Equals(
+            functionsWorkerRuntime,
+            DotNetIsolatedWorkerRuntime,
+            StringComparison.OrdinalIgnoreCase);
         BootstrapLog.Info(
             $"Telemetry detection context: PID={_processIdProvider()}, " +
             $"entry assembly='{entryAssemblyName ?? "<unknown>"}', " +
-            $".deps.json='{path ?? "<not found>"}'.");
+            $".deps.json='{path ?? "<not found>"}', " +
+            $"Functions worker runtime='{functionsWorkerRuntime ?? "<not set>"}'.");
 
         // The site extension is injected at site scope, so an isolated Functions app runs this code in both
         // the platform host and the customer's worker. Suppress the host before inspecting its telemetry
-        // dependencies; FUNCTIONS_* settings cannot be used because the customer worker inherits them too.
-        if (IsAzureFunctionsPlatformHost(entryAssemblyName))
+        // dependencies. The worker inherits FUNCTIONS_WORKER_RUNTIME, so the exact host identity remains
+        // required; the runtime value distinguishes isolated apps from in-process apps where customer code
+        // runs inside this host process.
+        if (isDotNetIsolatedFunctionsApp && IsAzureFunctionsPlatformHost(entryAssemblyName))
         {
             BootstrapLog.Info("Detected the Azure Functions platform host process; profiler activation is intentionally suppressed in this process.");
             return TelemetryStack.AzureFunctionsPlatformHost;
@@ -105,13 +115,13 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
             return TelemetryStack.None;
         }
 
-        TelemetryStack stack = DetectFromDepsJson(content!);
-        if (stack == TelemetryStack.AzureFunctionsPlatformHost)
+        if (isDotNetIsolatedFunctionsApp && ContainsExactPackage(content!, AzureFunctionsHostAssembly))
         {
             BootstrapLog.Info("The selected .deps.json belongs to the Azure Functions platform host; profiler activation is intentionally suppressed in this process.");
+            return TelemetryStack.AzureFunctionsPlatformHost;
         }
 
-        return stack;
+        return DetectFromDepsJson(content!);
     }
 
     /// <summary>
@@ -127,16 +137,7 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
     /// </remarks>
     internal static TelemetryStack DetectFromDepsJson(string depsJson)
     {
-        // 0. Back off in the Azure Functions platform host. Site-global injection also reaches the customer's
-        //    isolated worker, whose own dependency graph is classified normally in that separate process.
-        //    The exact host library key avoids suppressing customer workers that reference
-        //    Microsoft.Azure.Functions.Worker or inherit FUNCTIONS_* environment variables.
-        if (ContainsExactPackage(depsJson, AzureFunctionsHostAssembly))
-        {
-            return TelemetryStack.AzureFunctionsPlatformHost;
-        }
-
-        // 1. Back off if the app already references an EventPipe profiler NuGet - it activates the profiler in
+        // 0. Back off if the app already references an EventPipe profiler NuGet - it activates the profiler in
         //    its own code, so codeless enablement must not activate a second time (double EventPipe session).
         //    Uses the exact "<pkg>/" library-key marker so "Azure.Monitor.OpenTelemetry.Profiler" does not
         //    match its dependency "Azure.Monitor.OpenTelemetry.Profiler.Core".
@@ -146,13 +147,13 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
             return TelemetryStack.AlreadyInstrumented;
         }
 
-        // 2. Azure Monitor OpenTelemetry distro - unambiguous, supported OpenTelemetry signal.
+        // 1. Azure Monitor OpenTelemetry distro - unambiguous, supported OpenTelemetry signal.
         if (ContainsPackageToken(depsJson, "Azure.Monitor.OpenTelemetry.AspNetCore"))
         {
             return TelemetryStack.OpenTelemetry;
         }
 
-        // 3. Application Insights ASP.NET Core / Worker Service SDK. 3.x is an OpenTelemetry-based wrapper
+        // 2. Application Insights ASP.NET Core / Worker Service SDK. 3.x is an OpenTelemetry-based wrapper
         //    (supported via the OpenTelemetry profiler); 2.x is the legacy classic SDK (not supported).
         //    Checked before the generic OpenTelemetry test below, which 3.x pulls in transitively.
         if (ContainsPackageToken(depsJson, "Microsoft.ApplicationInsights.AspNetCore")
@@ -175,7 +176,7 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
             return major >= 3 ? TelemetryStack.OpenTelemetry : TelemetryStack.LegacyApplicationInsights;
         }
 
-        // 4. Manual OpenTelemetry setup (SDK / hosting) without either the distro or the AI SDK.
+        // 3. Manual OpenTelemetry setup (SDK / hosting) without either the distro or the AI SDK.
         if (ContainsPackageToken(depsJson, "OpenTelemetry"))
         {
             return TelemetryStack.OpenTelemetry;

--- a/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/DepsFileTelemetryStackDetector.cs
+++ b/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/DepsFileTelemetryStackDetector.cs
@@ -19,6 +19,8 @@ namespace Azure.Monitor.OpenTelemetry.Profiler.HostingStartup;
 /// </remarks>
 internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
 {
+    private const string AzureFunctionsHostAssembly = "Microsoft.Azure.WebJobs.Script.WebHost";
+
     // Set by the App Service pre-installed Application Insights codeless agent (DiagnosticServices). Its
     // presence means telemetry is being instrumented at RUNTIME by the agent - which our build-time
     // *.deps.json scan cannot see - so an otherwise-undetected app is still emitting telemetry.
@@ -27,20 +29,30 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
     private readonly Func<string?> _depsFilePathProvider;
     private readonly Func<string, string?> _readAllText;
     private readonly Func<string, string?> _environmentVariableProvider;
+    private readonly Func<string?> _entryAssemblyNameProvider;
+    private readonly Func<int> _processIdProvider;
 
     public DepsFileTelemetryStackDetector()
-        : this(GetEntryAssemblyDepsPath, TryReadAllText)
+        : this(
+            GetEntryAssemblyDepsPath,
+            TryReadAllText,
+            entryAssemblyNameProvider: GetEntryAssemblyName,
+            processIdProvider: BootstrapLog.GetProcessId)
     {
     }
 
     internal DepsFileTelemetryStackDetector(
         Func<string?> depsFilePathProvider,
         Func<string, string?> readAllText,
-        Func<string, string?>? environmentVariableProvider = null)
+        Func<string, string?>? environmentVariableProvider = null,
+        Func<string?>? entryAssemblyNameProvider = null,
+        Func<int>? processIdProvider = null)
     {
         _depsFilePathProvider = depsFilePathProvider ?? throw new ArgumentNullException(nameof(depsFilePathProvider));
         _readAllText = readAllText ?? throw new ArgumentNullException(nameof(readAllText));
         _environmentVariableProvider = environmentVariableProvider ?? Environment.GetEnvironmentVariable;
+        _entryAssemblyNameProvider = entryAssemblyNameProvider ?? GetEntryAssemblyName;
+        _processIdProvider = processIdProvider ?? BootstrapLog.GetProcessId;
     }
 
     public TelemetryStack Detect()
@@ -64,7 +76,22 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
 
     private TelemetryStack DetectFromDeps()
     {
+        string? entryAssemblyName = _entryAssemblyNameProvider();
         string? path = _depsFilePathProvider();
+        BootstrapLog.Info(
+            $"Telemetry detection context: PID={_processIdProvider()}, " +
+            $"entry assembly='{entryAssemblyName ?? "<unknown>"}', " +
+            $".deps.json='{path ?? "<not found>"}'.");
+
+        // The site extension is injected at site scope, so an isolated Functions app runs this code in both
+        // the platform host and the customer's worker. Suppress the host before inspecting its telemetry
+        // dependencies; FUNCTIONS_* settings cannot be used because the customer worker inherits them too.
+        if (IsAzureFunctionsPlatformHost(entryAssemblyName))
+        {
+            BootstrapLog.Info("Detected the Azure Functions platform host process; profiler activation is intentionally suppressed in this process.");
+            return TelemetryStack.AzureFunctionsPlatformHost;
+        }
+
         if (string.IsNullOrEmpty(path))
         {
             BootstrapLog.Info("Could not locate the application's .deps.json; treating telemetry stack as undetected.");
@@ -78,7 +105,13 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
             return TelemetryStack.None;
         }
 
-        return DetectFromDepsJson(content!);
+        TelemetryStack stack = DetectFromDepsJson(content!);
+        if (stack == TelemetryStack.AzureFunctionsPlatformHost)
+        {
+            BootstrapLog.Info("The selected .deps.json belongs to the Azure Functions platform host; profiler activation is intentionally suppressed in this process.");
+        }
+
+        return stack;
     }
 
     /// <summary>
@@ -94,7 +127,16 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
     /// </remarks>
     internal static TelemetryStack DetectFromDepsJson(string depsJson)
     {
-        // 0. Back off if the app already references an EventPipe profiler NuGet - it activates the profiler in
+        // 0. Back off in the Azure Functions platform host. Site-global injection also reaches the customer's
+        //    isolated worker, whose own dependency graph is classified normally in that separate process.
+        //    The exact host library key avoids suppressing customer workers that reference
+        //    Microsoft.Azure.Functions.Worker or inherit FUNCTIONS_* environment variables.
+        if (ContainsExactPackage(depsJson, AzureFunctionsHostAssembly))
+        {
+            return TelemetryStack.AzureFunctionsPlatformHost;
+        }
+
+        // 1. Back off if the app already references an EventPipe profiler NuGet - it activates the profiler in
         //    its own code, so codeless enablement must not activate a second time (double EventPipe session).
         //    Uses the exact "<pkg>/" library-key marker so "Azure.Monitor.OpenTelemetry.Profiler" does not
         //    match its dependency "Azure.Monitor.OpenTelemetry.Profiler.Core".
@@ -104,13 +146,13 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
             return TelemetryStack.AlreadyInstrumented;
         }
 
-        // 1. Azure Monitor OpenTelemetry distro - unambiguous, supported OpenTelemetry signal.
+        // 2. Azure Monitor OpenTelemetry distro - unambiguous, supported OpenTelemetry signal.
         if (ContainsPackageToken(depsJson, "Azure.Monitor.OpenTelemetry.AspNetCore"))
         {
             return TelemetryStack.OpenTelemetry;
         }
 
-        // 2. Application Insights ASP.NET Core / Worker Service SDK. 3.x is an OpenTelemetry-based wrapper
+        // 3. Application Insights ASP.NET Core / Worker Service SDK. 3.x is an OpenTelemetry-based wrapper
         //    (supported via the OpenTelemetry profiler); 2.x is the legacy classic SDK (not supported).
         //    Checked before the generic OpenTelemetry test below, which 3.x pulls in transitively.
         if (ContainsPackageToken(depsJson, "Microsoft.ApplicationInsights.AspNetCore")
@@ -133,7 +175,7 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
             return major >= 3 ? TelemetryStack.OpenTelemetry : TelemetryStack.LegacyApplicationInsights;
         }
 
-        // 3. Manual OpenTelemetry setup (SDK / hosting) without either the distro or the AI SDK.
+        // 4. Manual OpenTelemetry setup (SDK / hosting) without either the distro or the AI SDK.
         if (ContainsPackageToken(depsJson, "OpenTelemetry"))
         {
             return TelemetryStack.OpenTelemetry;
@@ -158,6 +200,9 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
     /// </summary>
     private static bool ContainsExactPackage(string depsJson, string package) =>
         depsJson.IndexOf("\"" + package + "/", StringComparison.OrdinalIgnoreCase) >= 0;
+
+    private static bool IsAzureFunctionsPlatformHost(string? entryAssemblyName) =>
+        string.Equals(entryAssemblyName, AzureFunctionsHostAssembly, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Extracts the major version from a <c>.deps.json</c> library key of the exact form
@@ -214,6 +259,8 @@ internal sealed class DepsFileTelemetryStackDetector : ITelemetryStackDetector
         string candidate = Path.Combine(directory!, assemblyName + ".deps.json");
         return File.Exists(candidate) ? candidate : null;
     }
+
+    private static string? GetEntryAssemblyName() => Assembly.GetEntryAssembly()?.GetName().Name;
 
     private static string? TryReadAllText(string path)
     {

--- a/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/ProfilerBootstrapper.cs
+++ b/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/ProfilerBootstrapper.cs
@@ -117,6 +117,10 @@ public sealed class ProfilerBootstrapper : IHostingStartup
                 BootstrapLog.Info("The App Service Application Insights agent is instrumenting this application at runtime, but the application does not reference a supported telemetry SDK in its build (*.deps.json), so the codeless profiler cannot be enabled against it. To enable the profiler, add the latest 'Microsoft.ApplicationInsights.AspNetCore' NuGet package (version 3.0 or later, which is OpenTelemetry-based) to the application and redeploy. The profiler will then activate automatically.");
                 break;
 
+            case TelemetryStack.AzureFunctionsPlatformHost:
+                BootstrapLog.Info("This process is the Azure Functions platform host, not the customer's isolated worker. Codeless profiler activation is intentionally suppressed in this process; the customer worker is detected independently.");
+                break;
+
             default:
                 BootstrapLog.Error("No supported telemetry stack (OpenTelemetry, the Azure Monitor OpenTelemetry distro, the OpenTelemetry-based Application Insights SDK 3.x, or the classic Application Insights SDK 2.x) was detected. The profiler will NOT be activated.");
                 break;

--- a/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/ProfilerBootstrapper.cs
+++ b/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/ProfilerBootstrapper.cs
@@ -118,7 +118,7 @@ public sealed class ProfilerBootstrapper : IHostingStartup
                 break;
 
             case TelemetryStack.AzureFunctionsPlatformHost:
-                BootstrapLog.Info("This process is the Azure Functions platform host, not the customer's isolated worker. Codeless profiler activation is intentionally suppressed in this process; the customer worker is detected independently.");
+                BootstrapLog.Info("This process is the Azure Functions platform host for a .NET isolated app, not the customer's worker. Codeless profiler activation is intentionally suppressed in this process; an isolated worker using ASP.NET Core integration is detected independently.");
                 break;
 
             default:

--- a/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/ProfilerBootstrapper.cs
+++ b/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/ProfilerBootstrapper.cs
@@ -118,7 +118,7 @@ public sealed class ProfilerBootstrapper : IHostingStartup
                 break;
 
             case TelemetryStack.AzureFunctionsPlatformHost:
-                BootstrapLog.Info("This process is the Azure Functions platform host for a .NET isolated app, not the customer's worker. Codeless profiler activation is intentionally suppressed in this process; an isolated worker using ASP.NET Core integration is detected independently.");
+                BootstrapLog.Info("This process is the Azure Functions platform host for an out-of-process worker app, not the customer's worker. Codeless profiler activation is intentionally suppressed in this process; a supported .NET isolated worker using ASP.NET Core integration is detected independently.");
                 break;
 
             default:

--- a/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/TelemetryStack.cs
+++ b/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/TelemetryStack.cs
@@ -39,4 +39,11 @@ internal enum TelemetryStack
     /// not activate and instead logs a recommendation to add a supported SDK NuGet package.
     /// </summary>
     AgentInstrumentedNoSdk,
+
+    /// <summary>
+    /// The current process is the Azure Functions platform host, not the customer's isolated worker.
+    /// Site-global injection reaches both processes, so codeless enablement intentionally does nothing in
+    /// this process and lets the customer worker perform its own telemetry-stack detection.
+    /// </summary>
+    AzureFunctionsPlatformHost,
 }

--- a/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/TelemetryStack.cs
+++ b/src/AppService.SiteExtension/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup/TelemetryStack.cs
@@ -41,9 +41,9 @@ internal enum TelemetryStack
     AgentInstrumentedNoSdk,
 
     /// <summary>
-    /// The current process is the Azure Functions platform host, not the customer's isolated worker.
-    /// Site-global injection reaches both processes, so codeless enablement intentionally does nothing in
-    /// this process and lets the customer worker perform its own telemetry-stack detection.
+    /// The current process is the Azure Functions platform host for an out-of-process worker app, not the
+    /// customer's worker. Site-global injection reaches both processes, so codeless enablement intentionally
+    /// does nothing in this process and lets a supported .NET isolated worker perform its own detection.
     /// </summary>
     AzureFunctionsPlatformHost,
 }

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests/DepsFileTelemetryStackDetectorTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests/DepsFileTelemetryStackDetectorTests.cs
@@ -75,7 +75,7 @@ public class DepsFileTelemetryStackDetectorTests
     [InlineData(ClassicProfilerReferencedDeps, TelemetryStack.AlreadyInstrumented)]
     [InlineData(OtelProfilerCoreOnlyDeps, TelemetryStack.OpenTelemetry)]
     [InlineData(IsolatedFunctionsWorkerDeps, TelemetryStack.OpenTelemetry)]
-    [InlineData(AzureFunctionsPlatformHostDeps, TelemetryStack.AzureFunctionsPlatformHost)]
+    [InlineData(AzureFunctionsPlatformHostDeps, TelemetryStack.LegacyApplicationInsights)]
     internal void DetectFromDepsJson_ClassifiesStack(string depsJson, TelemetryStack expected)
     {
         Assert.Equal(expected, DepsFileTelemetryStackDetector.DetectFromDepsJson(depsJson));
@@ -125,6 +125,7 @@ public class DepsFileTelemetryStackDetectorTests
         DepsFileTelemetryStackDetector detector = new(
             depsFilePathProvider: () => null,
             readAllText: _ => null,
+            environmentVariableProvider: name => name == "FUNCTIONS_WORKER_RUNTIME" ? "dotnet-isolated" : null,
             entryAssemblyNameProvider: () => "Microsoft.Azure.WebJobs.Script.WebHost",
             processIdProvider: () => 4242);
 
@@ -137,10 +138,37 @@ public class DepsFileTelemetryStackDetectorTests
         DepsFileTelemetryStackDetector detector = new(
             depsFilePathProvider: () => @"C:\home\site\wwwroot\EventHubProfiler_Function.deps.json",
             readAllText: _ => IsolatedFunctionsWorkerDeps,
+            environmentVariableProvider: name => name == "FUNCTIONS_WORKER_RUNTIME" ? "dotnet-isolated" : null,
             entryAssemblyNameProvider: () => "EventHubProfiler_Function",
             processIdProvider: () => 4243);
 
         Assert.Equal(TelemetryStack.OpenTelemetry, detector.Detect());
+    }
+
+    [Fact]
+    internal void Detect_WhenInProcessFunctionsHost_ClassifiesTelemetryStack()
+    {
+        DepsFileTelemetryStackDetector detector = new(
+            depsFilePathProvider: () => @"C:\Program Files\SiteExtensions\Functions\Microsoft.Azure.WebJobs.Script.WebHost.deps.json",
+            readAllText: _ => AzureFunctionsPlatformHostDeps,
+            environmentVariableProvider: name => name == "FUNCTIONS_WORKER_RUNTIME" ? "dotnet" : null,
+            entryAssemblyNameProvider: () => "Microsoft.Azure.WebJobs.Script.WebHost",
+            processIdProvider: () => 4244);
+
+        Assert.Equal(TelemetryStack.LegacyApplicationInsights, detector.Detect());
+    }
+
+    [Fact]
+    internal void Detect_WhenIsolatedFunctionsHostIdentifiedFromDeps_SuppressesActivation()
+    {
+        DepsFileTelemetryStackDetector detector = new(
+            depsFilePathProvider: () => @"C:\Program Files\SiteExtensions\Functions\Microsoft.Azure.WebJobs.Script.WebHost.deps.json",
+            readAllText: _ => AzureFunctionsPlatformHostDeps,
+            environmentVariableProvider: name => name == "FUNCTIONS_WORKER_RUNTIME" ? "DOTNET-ISOLATED" : null,
+            entryAssemblyNameProvider: () => "dotnet",
+            processIdProvider: () => 4245);
+
+        Assert.Equal(TelemetryStack.AzureFunctionsPlatformHost, detector.Detect());
     }
 
     [Fact]

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests/DepsFileTelemetryStackDetectorTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests/DepsFileTelemetryStackDetectorTests.cs
@@ -37,6 +37,16 @@ public class DepsFileTelemetryStackDetectorTests
         { "libraries": { "SampleApp/1.0.0": {}, "Newtonsoft.Json/13.0.3": {} } }
         """;
 
+    private const string IsolatedFunctionsWorkerDeps = """
+        { "libraries": { "EventHubProfiler_Function/1.0.0": {}, "Microsoft.Azure.Functions.Worker.OpenTelemetry/1.2.0": {}, "Azure.Monitor.OpenTelemetry.Exporter/1.7.0": {}, "OpenTelemetry.Extensions.Hosting/1.15.3": {}, "OpenTelemetry/1.15.3": {} } }
+        """;
+
+    // The Functions platform host can carry classic Application Insights 2.x. Its host-only package marker
+    // must take precedence so site-global injection never activates the classic profiler in this process.
+    private const string AzureFunctionsPlatformHostDeps = """
+        { "libraries": { "Microsoft.Azure.WebJobs.Script.WebHost/4.1045.200": {}, "Microsoft.ApplicationInsights.AspNetCore/2.23.0": {}, "Microsoft.ApplicationInsights/2.23.0": {}, "OpenTelemetry/1.15.3": {} } }
+        """;
+
     // App already references the OpenTelemetry profiler NuGet (note its .Core dependency is also present).
     private const string OtelProfilerReferencedDeps = """
         { "libraries": { "SampleApp/1.0.0": {}, "Azure.Monitor.OpenTelemetry.Profiler/1.0.0-beta2": {}, "Azure.Monitor.OpenTelemetry.Profiler.Core/1.0.0-beta2": {}, "OpenTelemetry/1.9.0": {} } }
@@ -64,6 +74,8 @@ public class DepsFileTelemetryStackDetectorTests
     [InlineData(OtelProfilerReferencedDeps, TelemetryStack.AlreadyInstrumented)]
     [InlineData(ClassicProfilerReferencedDeps, TelemetryStack.AlreadyInstrumented)]
     [InlineData(OtelProfilerCoreOnlyDeps, TelemetryStack.OpenTelemetry)]
+    [InlineData(IsolatedFunctionsWorkerDeps, TelemetryStack.OpenTelemetry)]
+    [InlineData(AzureFunctionsPlatformHostDeps, TelemetryStack.AzureFunctionsPlatformHost)]
     internal void DetectFromDepsJson_ClassifiesStack(string depsJson, TelemetryStack expected)
     {
         Assert.Equal(expected, DepsFileTelemetryStackDetector.DetectFromDepsJson(depsJson));
@@ -103,6 +115,30 @@ public class DepsFileTelemetryStackDetectorTests
         DepsFileTelemetryStackDetector detector = new(
             depsFilePathProvider: () => @"C:\app\SampleApp.deps.json",
             readAllText: _ => OpenTelemetryDeps);
+
+        Assert.Equal(TelemetryStack.OpenTelemetry, detector.Detect());
+    }
+
+    [Fact]
+    internal void Detect_WhenEntryAssemblyIsAzureFunctionsPlatformHost_SuppressesWithoutDeps()
+    {
+        DepsFileTelemetryStackDetector detector = new(
+            depsFilePathProvider: () => null,
+            readAllText: _ => null,
+            entryAssemblyNameProvider: () => "Microsoft.Azure.WebJobs.Script.WebHost",
+            processIdProvider: () => 4242);
+
+        Assert.Equal(TelemetryStack.AzureFunctionsPlatformHost, detector.Detect());
+    }
+
+    [Fact]
+    internal void Detect_WhenIsolatedWorkerEntryAssembly_ClassifiesWorkerDeps()
+    {
+        DepsFileTelemetryStackDetector detector = new(
+            depsFilePathProvider: () => @"C:\home\site\wwwroot\EventHubProfiler_Function.deps.json",
+            readAllText: _ => IsolatedFunctionsWorkerDeps,
+            entryAssemblyNameProvider: () => "EventHubProfiler_Function",
+            processIdProvider: () => 4243);
 
         Assert.Equal(TelemetryStack.OpenTelemetry, detector.Detect());
     }

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests/DepsFileTelemetryStackDetectorTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests/DepsFileTelemetryStackDetectorTests.cs
@@ -159,6 +159,19 @@ public class DepsFileTelemetryStackDetectorTests
     }
 
     [Fact]
+    internal void Detect_WhenNonDotNetFunctionsHost_SuppressesActivation()
+    {
+        DepsFileTelemetryStackDetector detector = new(
+            depsFilePathProvider: () => @"C:\Program Files\SiteExtensions\Functions\Microsoft.Azure.WebJobs.Script.WebHost.deps.json",
+            readAllText: _ => AzureFunctionsPlatformHostDeps,
+            environmentVariableProvider: name => name == "FUNCTIONS_WORKER_RUNTIME" ? "node" : null,
+            entryAssemblyNameProvider: () => "Microsoft.Azure.WebJobs.Script.WebHost",
+            processIdProvider: () => 4245);
+
+        Assert.Equal(TelemetryStack.AzureFunctionsPlatformHost, detector.Detect());
+    }
+
+    [Fact]
     internal void Detect_WhenIsolatedFunctionsHostIdentifiedFromDeps_SuppressesActivation()
     {
         DepsFileTelemetryStackDetector detector = new(
@@ -166,7 +179,7 @@ public class DepsFileTelemetryStackDetectorTests
             readAllText: _ => AzureFunctionsPlatformHostDeps,
             environmentVariableProvider: name => name == "FUNCTIONS_WORKER_RUNTIME" ? "DOTNET-ISOLATED" : null,
             entryAssemblyNameProvider: () => "dotnet",
-            processIdProvider: () => 4245);
+            processIdProvider: () => 4246);
 
         Assert.Equal(TelemetryStack.AzureFunctionsPlatformHost, detector.Detect());
     }

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests/DetectedStackAppContextDataTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests/DetectedStackAppContextDataTests.cs
@@ -13,6 +13,7 @@ public class DetectedStackAppContextDataTests
     [InlineData(TelemetryStack.None, "")]
     [InlineData(TelemetryStack.AlreadyInstrumented, "")]
     [InlineData(TelemetryStack.AgentInstrumentedNoSdk, "")]
+    [InlineData(TelemetryStack.AzureFunctionsPlatformHost, "")]
     internal void ToPayloadSubfolder_MapsStackToFolder(TelemetryStack stack, string expected)
     {
         Assert.Equal(expected, DetectedStackAppContextData.ToPayloadSubfolder(stack));

--- a/tests/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests/ProfilerBootstrapperRoutingTests.cs
+++ b/tests/Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests/ProfilerBootstrapperRoutingTests.cs
@@ -163,6 +163,20 @@ public class ProfilerBootstrapperRoutingTests
     }
 
     [Fact]
+    internal void Apply_WhenAzureFunctionsPlatformHost_BacksOffAndRegistersNothing()
+    {
+        (Mock<IWebHostBuilder> builder, List<Action<IServiceCollection>> captured) = CreateBuilder();
+        Mock<IProfilerActivatorInvoker> invoker = new();
+        ProfilerBootstrapper bootstrapper = CreateBootstrapper(TelemetryStack.None, invoker.Object);
+
+        bootstrapper.Apply(builder.Object, TelemetryStack.AzureFunctionsPlatformHost);
+
+        Assert.Empty(captured);
+        builder.Verify(b => b.ConfigureServices(It.IsAny<Action<IServiceCollection>>()), Times.Never);
+        invoker.Verify(i => i.Invoke(It.IsAny<TelemetryStack>(), It.IsAny<IServiceCollection>()), Times.Never);
+    }
+
+    [Fact]
     internal void Apply_WhenDependencyFloorViolation_DoesNotInvokeActivator()
     {
         // A below-floor shared dependency loaded by the app: the deferred callback must back off (log) and


### PR DESCRIPTION
Fixes #187.

## Problem

The site extension injects its startup hook and HostingStartup at site scope. For Azure Functions apps, that configuration reaches both the Azure Functions platform host and the customer worker.

The platform host's dependency graph contains the classic Application Insights SDK 2.x, so the existing process-local detection could misclassify the host as the customer application and activate the classic profiler in the wrong process.

## Changes

- Detect the exact `Microsoft.Azure.WebJobs.Script.WebHost` process before telemetry-stack routing.
- Suppress profiler activation in the platform host for configured out-of-process worker runtimes, including `dotnet-isolated` and non-.NET workers.
- Preserve existing behavior for the `dotnet` in-process model, where customer code runs inside the Functions host.
- Continue normal OpenTelemetry detection and activation in a supported isolated worker using ASP.NET Core integration.
- Add PID, entry assembly, selected `.deps.json`, and Functions worker runtime to startup diagnostics.
- Carry the suppression decision through the shared StartupHook/HostingStartup `AppContext` contract so neither profiler payload is selected in the host process.

## Tests

- Added representative dependency graphs for a .NET 8 isolated worker and the Azure Functions platform host.
- Added regressions for isolated, in-process, and non-.NET worker models.
- Added routing coverage proving the platform host registers and invokes no profiler activator.
- `dotnet test tests\Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests\Azure.Monitor.OpenTelemetry.Profiler.HostingStartup.Tests.csproj --no-restore` (64 passed)
- Built the site-extension package with `Build-SiteExtension.ps1`.